### PR TITLE
fix mobile layout in docs 

### DIFF
--- a/site/src/lib/components/DocsMobileNav.svelte
+++ b/site/src/lib/components/DocsMobileNav.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+import { page } from '$app/state';
+import type { DocSection } from '$lib/utils/docs';
+
+let { sections }: { sections: DocSection[] } = $props();
+
+const current = $derived.by(() => {
+	for (const section of sections) {
+		for (const doc of section.pages) {
+			if (page.url.pathname === `/docs/${doc.slug}`) {
+				return { section: section.name, doc: doc.title };
+			}
+		}
+	}
+	return null;
+});
+
+const label = $derived(current ? `${current.section} › ${current.doc}` : 'Documentation');
+</script>
+
+<details class="group border-b border-border lg:hidden">
+	<summary
+		class="cursor-pointer list-none flex items-baseline justify-between gap-4 px-5 md:px-10 py-4 text-xs font-mono tracking-tighter text-muted-foreground"
+	>
+		<span class="truncate">// {label}</span>
+		<span class="text-foreground/40 group-open:text-accent transition-colors" aria-hidden="true">
+			▾
+		</span>
+	</summary>
+	<nav
+		class="border-t border-border px-5 md:px-10 py-4 space-y-5"
+		aria-label="Documentation"
+	>
+		{#each sections as section}
+			<div>
+				<h3
+					class="mb-2 text-[10px] font-mono tracking-tighter text-muted-foreground uppercase"
+				>
+					// {section.name}
+				</h3>
+				<ul class="space-y-0 border-l border-border">
+					{#each section.pages as doc}
+						{@const active = page.url.pathname === `/docs/${doc.slug}`}
+						<li>
+							<a
+								href="/docs/{doc.slug}"
+								class="block -ml-px border-l pl-3 pr-2 py-1.5 text-xs font-mono transition-colors {active
+									? 'border-accent text-foreground'
+									: 'border-transparent text-muted-foreground hover:text-foreground hover:border-border'}"
+							>
+								{doc.title}
+							</a>
+						</li>
+					{/each}
+				</ul>
+			</div>
+		{/each}
+	</nav>
+</details>

--- a/site/src/routes/+page.svelte
+++ b/site/src/routes/+page.svelte
@@ -131,11 +131,11 @@ const softwareLd = {
 	</section>
 
 	<!-- Bottom strip -->
-	<div class="grid grid-cols-3 min-h-[4.5rem]">
-		<Cell pad="sm" class="border-r border-border">
+	<div class="grid grid-cols-1 sm:grid-cols-3 sm:min-h-[4.5rem]">
+		<Cell pad="sm" class="border-b sm:border-b-0 sm:border-r border-border">
 			<span class="text-sm font-bold text-foreground/40">seeleseek</span>
 		</Cell>
-		<Cell pad="sm" href="https://github.com/bretth18/seeleseek" external class="border-r border-border">
+		<Cell pad="sm" href="https://github.com/bretth18/seeleseek" external class="border-b sm:border-b-0 sm:border-r border-border">
 			<span class="text-sm font-bold group-hover:text-accent transition-colors">GitHub</span>
 		</Cell>
 		<Cell pad="sm">

--- a/site/src/routes/docs/+layout.svelte
+++ b/site/src/routes/docs/+layout.svelte
@@ -1,11 +1,16 @@
 <script lang="ts">
+import DocsMobileNav from '$lib/components/DocsMobileNav.svelte';
 import Sidebar from '$lib/components/Sidebar.svelte';
 
 let { data, children } = $props();
 </script>
 
+<DocsMobileNav sections={data.sections} />
+
 <div class="mx-auto flex max-w-6xl gap-10 px-5 md:px-10 py-8">
-	<Sidebar sections={data.sections} />
+	<div class="hidden lg:block">
+		<Sidebar sections={data.sections} />
+	</div>
 	<div class="min-w-0 flex-1">
 		{@render children()}
 	</div>

--- a/site/src/routes/docs/[...slug]/+page.svelte
+++ b/site/src/routes/docs/[...slug]/+page.svelte
@@ -9,21 +9,21 @@ let { data } = $props();
 </DocLayout>
 
 {#if data.prev || data.next}
-	<nav class="mt-12 flex items-center justify-between border-t border-border pt-6 text-xs font-mono">
+	<nav class="mt-12 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between border-t border-border pt-6 text-xs font-mono">
 		{#if data.prev}
-			<a href="/docs/{data.prev.slug}" class="group flex flex-col items-start no-underline">
+			<a href="/docs/{data.prev.slug}" class="group flex flex-col items-start no-underline min-w-0">
 				<span class="text-muted-foreground tracking-tighter">← prev</span>
-				<span class="text-foreground group-hover:text-accent transition-colors">
+				<span class="text-foreground group-hover:text-accent transition-colors truncate max-w-full">
 					{data.prev.title}
 				</span>
 			</a>
 		{:else}
-			<div></div>
+			<div class="hidden sm:block"></div>
 		{/if}
 		{#if data.next}
-			<a href="/docs/{data.next.slug}" class="group flex flex-col items-end no-underline">
+			<a href="/docs/{data.next.slug}" class="group flex flex-col sm:items-end no-underline min-w-0">
 				<span class="text-muted-foreground tracking-tighter">next →</span>
-				<span class="text-foreground group-hover:text-accent transition-colors">
+				<span class="text-foreground group-hover:text-accent transition-colors truncate max-w-full">
 					{data.next.title}
 				</span>
 			</a>


### PR DESCRIPTION
### Description

This PR fixes mobile layout styling for the `/docs` route + footer in the sveltekit app. No changes are made to swift code in this unit of work.

<!--
### Future work
A place to describe changes that can or will be done in follow-up PRs
-->

### How to test
- N/A
- (ensure swift tests pass)

### Author checklist

This PR:

- [x] Satisfies a goal that is specific & clearly motivated
- [x] Adds value in isolation (whether user-facing or sustainability-related)
- [x] Contains a concise & easy-to-understand title + description
- [x] Adheres to [SRP](https://en.wikipedia.org/wiki/Single-responsibility_principle) by default
- [x] Presents the best possible implementation to meet its goal, given constraints at hand
