### PR TITLE
v111

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,6 +104,24 @@ jobs:
           -exportOptionsPlist ExportOptions.plist \
           -exportPath $PWD/build
 
+    - name: Verify exported .app contains GeoLite2 database
+      # Single integrity check on the shipped artifact. Fails the release if
+      # GeoLite2-Country.mmdb didn't make it into the .app for any reason —
+      # sandbox denial, codesign strip, export drop, etc. Catches the class
+      # of silent-resource-drop bug that shipped broken in v1.1.0.
+      run: |
+        MMDB="$PWD/build/seeleseek.app/Contents/Resources/GeoLite2-Country.mmdb"
+        if [ ! -f "$MMDB" ]; then
+          echo "::error::GeoLite2-Country.mmdb missing from exported .app. Release aborted."
+          exit 1
+        fi
+        SIZE=$(stat -f%z "$MMDB")
+        if [ "$SIZE" -lt 1000000 ]; then
+          echo "::error::GeoLite2-Country.mmdb is suspiciously small ($SIZE bytes) — expected ~9MB."
+          exit 1
+        fi
+        echo "Verified: $MMDB ($SIZE bytes)"
+
     - name: Extract version from tag
       id: version
       run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"

--- a/seeleseek.xcodeproj/project.pbxproj
+++ b/seeleseek.xcodeproj/project.pbxproj
@@ -274,15 +274,17 @@
 			inputFileListPaths = (
 			);
 			inputPaths = (
+				"$(SRCROOT)/GeoLite2-Country.mmdb",
 			);
 			name = "Copy GeoLite2 MMDB (Optional)";
 			outputFileListPaths = (
 			);
 			outputPaths = (
+				"$(BUILT_PRODUCTS_DIR)/$(UNLOCALIZED_RESOURCES_FOLDER_PATH)/GeoLite2-Country.mmdb",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = " MMDB=\"${SRCROOT}/GeoLite2-Country.mmdb\"\n  if [ -f \"$MMDB\" ]; then\n      cp \"$MMDB\" \"${BUILT_PRODUCTS_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/\"\n      echo \"Copied GeoLite2-Country.mmdb ($(stat -f%z \"$MMDB\") bytes)\"\n  else\n      echo \"warning: GeoLite2-Country.mmdb not found at \\$SRCROOT — GeoIP lookups\n  will return nil\"\n  fi\n";
+			shellScript = "set -e\nMMDB=\"${SRCROOT}/GeoLite2-Country.mmdb\"\nif [ ! -f \"$MMDB\" ]; then\n    echo \"warning: GeoLite2-Country.mmdb not found at \\$SRCROOT — GeoIP lookups will return nil\"\n    exit 0\nfi\nmkdir -p \"${BUILT_PRODUCTS_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}\"\n# -X skips extended attributes; avoids 'Operation not permitted' under Xcode's\n# user-script sandbox on CI runners.\n/bin/cp -X -f \"$MMDB\" \"${BUILT_PRODUCTS_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/GeoLite2-Country.mmdb\"\necho \"Copied GeoLite2-Country.mmdb ($(stat -f%z \"$MMDB\") bytes)\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
### Description

This PR updates the build phase script responsible for copying the `GeoLite2-Country.mmdb` file in the Xcode project. 

Build script improvements:

* Updated the shell script in the Xcode project (`seeleseek.xcodeproj/project.pbxproj`) to:
  - Exit early and print a warning if `GeoLite2-Country.mmdb` is missing, instead of failing the build.
  - Ensure the destination directory exists before copying.
  - Use `/bin/cp -X -f` to skip extended attributes, preventing 'Operation not permitted' errors in CI environments.
  - Provide clearer output about the copy operation.

<!--
### Future work
A place to describe changes that can or will be done in follow-up PRs
-->

### How to test

- Ensure all checks pass


### Author checklist

This PR:

- [x] Satisfies a goal that is specific & clearly motivated
- [x] Adds value in isolation (whether user-facing or sustainability-related)
- [x] Contains a concise & easy-to-understand title + description
- [x] Adheres to [SRP](https://en.wikipedia.org/wiki/Single-responsibility_principle) by default
- [x] Presents the best possible implementation to meet its goal, given constraints at hand
