### PR TITLE
fix wishlist result accumulation

### DIFF
--- a/seeleseek/Features/Wishlist/WishlistState.swift
+++ b/seeleseek/Features/Wishlist/WishlistState.swift
@@ -127,7 +127,9 @@ final class WishlistState {
     func removeItem(id: UUID) {
         tokenToWishlistId = tokenToWishlistId.filter { $0.value != id }
         items.removeAll { $0.id == id }
+        let phantomCount = results[id]?.count ?? 0
         results.removeValue(forKey: id)
+        unviewedResultCount = max(0, unviewedResultCount - phantomCount)
 
         Task {
             do {
@@ -166,8 +168,14 @@ final class WishlistState {
         tokenToWishlistId[token] = item.id
         logger.info("searchNow: query='\(item.query)' token=\(String(format: "0x%08X", token)) itemId=\(item.id) activeTokens=\(self.tokenToWishlistId.count)")
 
-        // Clear stale results from previous search cycle
+        // Clear stale results from previous search cycle, subtracting their
+        // contribution from the sidebar badge so the count stays in sync
+        // with results actually visible in the wishlist view. max(0, …)
+        // guards against markResultsViewed() having already zeroed the
+        // badge between results arriving and this next scan.
+        let staleCount = results[item.id]?.count ?? 0
         results[item.id] = []
+        unviewedResultCount = max(0, unviewedResultCount - staleCount)
 
         Task {
             do {


### PR DESCRIPTION
### Description


This PR updates the `WishlistState` logic to ensure that the sidebar badge count (`unviewedResultCount`) accurately reflects the number of unviewed results when items are removed or when search results are cleared. The main focus is on keeping the badge count in sync with the actual state of the wishlist view.

Badge count synchronization improvements:

* When an item is removed via `removeItem`, the code now subtracts the number of associated results from `unviewedResultCount` to keep the badge accurate.
* When clearing stale results in a new search cycle, the code subtracts the count of those results from `unviewedResultCount`, ensuring the badge matches visible results. This also guards against double-counting if the badge was already zeroed.


### Future work
- fix self upload speed

### How to test

- Ensure all checks pass

### Author checklist

This PR:

- [x] Satisfies a goal that is specific & clearly motivated
- [x] Adds value in isolation (whether user-facing or sustainability-related)
- [x] Contains a concise & easy-to-understand title + description
- [x] Adheres to [SRP](https://en.wikipedia.org/wiki/Single-responsibility_principle) by default
- [x] Presents the best possible implementation to meet its goal, given constraints at hand
