### PR TITLE
fix self upload speed

### DIFF
--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Storage/UploadManager.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Storage/UploadManager.swift
@@ -26,6 +26,12 @@ public final class UploadManager {
     public var maxQueuedPerUser = 50  // Max files queued per user (nicotine+ default)
     public var uploadSpeedLimit: Int64? = nil  // bytes per second, nil = unlimited
 
+    /// Highest valid upload-speed sample observed this session, in B/s.
+    /// Used to avoid overwriting our server-side profile speed with noisy
+    /// samples (small files, throttled peers, TCP slow-start). Session-only
+    /// by design — next good upload after a restart re-establishes it.
+    private var peakReportedSpeed: UInt32 = 0
+
     /// Called to check if an upload should be allowed (checks blocklist + leech status)
     /// Set by AppState to delegate to SocialState
     public var uploadPermissionChecker: ((String) -> Bool)?
@@ -775,22 +781,24 @@ public final class UploadManager {
                 })
             }
 
-            // Give TCP stack time to flush any remaining buffered data
-            // This is important because cancel() might tear down the connection before TCP sends all data
+            // Measure transfer duration at the moment the last application
+            // byte has been handed to TCP — the 500 ms flush sleep below is
+            // transport teardown, not transfer time, so must not inflate the
+            // denominator.
+            let duration = Date().timeIntervalSince(startTime)
+
+            // Give TCP stack time to flush any remaining buffered data.
+            // This is important because cancel() might tear down the
+            // connection before TCP sends all data.
             try? await Task.sleep(for: .milliseconds(500))
 
-            // Complete
-            let duration = Date().timeIntervalSince(startTime)
             logger.info("Upload complete: \(bytesSent) bytes sent in \(String(format: "%.1f", duration))s")
 
             let filename = (filePath as NSString).lastPathComponent
             let uploadUsername = activeUploads[transferId]?.username ?? "unknown"
 
-            // Report upload speed to server
-            let avgSpeed = duration > 0 ? UInt32(Double(bytesSent - offset) / duration) : 0
-            if avgSpeed > 0 {
-                try? await networkClient?.reportUploadSpeed(avgSpeed)
-            }
+            // Report upload speed to server (filtered, peak-tracked)
+            await reportUploadSpeedIfValid(bytesTransferred: bytesSent - offset, elapsed: duration)
 
             await MainActor.run { [transferState, statisticsState] in
                 transferState?.updateTransfer(id: transferId) { t in
@@ -877,6 +885,53 @@ public final class UploadManager {
             group.cancelAll()
             return result
         }
+    }
+
+    // MARK: - Upload Speed Reporting
+
+    /// Report a completed upload's throughput to the Soulseek server, but only
+    /// if the sample is trustworthy AND exceeds the best sample we've seen
+    /// this session.
+    ///
+    /// Why: the server's `SendUploadSpeed` (code 121) simply overwrites the
+    /// profile's stored value. Reporting every completed file — including
+    /// small files dominated by TCP slow-start and uploads throttled by a
+    /// slow peer — silently ratchets the displayed speed downward. Peak
+    /// tracking + noise filtering ensures the profile reflects our actual
+    /// sustained throughput on representative transfers.
+    ///
+    /// Filters:
+    /// - `bytesTransferred < 1 MiB`: dominated by connection setup and TCP
+    ///   slow-start, not a measurement of sustained throughput.
+    /// - `elapsed < 2 s`: too short for the transport to reach steady state.
+    /// - `sample > 1 GiB/s`: implausible on any consumer uplink — almost
+    ///   certainly loopback or a measurement bug. Rejected to protect the
+    ///   peak from getting stuck at an unreachable value.
+    private func reportUploadSpeedIfValid(bytesTransferred: UInt64, elapsed: TimeInterval) async {
+        let minBytes: UInt64 = 1_048_576                    // 1 MiB
+        let minElapsed: TimeInterval = 2.0                  // seconds
+        let maxPlausibleSpeed: Double = 1_073_741_824       // 1 GiB/s
+
+        guard bytesTransferred >= minBytes, elapsed >= minElapsed else {
+            logger.debug("Upload speed sample rejected: bytes=\(bytesTransferred) elapsed=\(elapsed)")
+            return
+        }
+
+        let sample = Double(bytesTransferred) / elapsed
+        guard sample > 0, sample < maxPlausibleSpeed else {
+            logger.debug("Upload speed sample rejected: implausible rate \(sample) B/s")
+            return
+        }
+
+        let sampleU32 = UInt32(sample)
+        guard sampleU32 > peakReportedSpeed else {
+            logger.debug("Upload speed sample \(sampleU32) B/s ≤ session peak \(self.peakReportedSpeed), not reporting")
+            return
+        }
+
+        peakReportedSpeed = sampleU32
+        logger.info("New upload-speed peak this session: \(sampleU32) B/s — reporting to server")
+        try? await networkClient?.reportUploadSpeed(sampleU32)
     }
 
     // MARK: - Public API
@@ -1107,11 +1162,8 @@ public final class UploadManager {
 
             logger.info("Upload complete: \(filePath) (\(bytesTransferred) bytes in \(String(format: "%.1f", elapsed))s, \(Int64(avgSpeed)) B/s)")
 
-            // Report upload speed to server
-            let reportSpeed = UInt32(avgSpeed)
-            if reportSpeed > 0 {
-                try? await networkClient?.reportUploadSpeed(reportSpeed)
-            }
+            // Report upload speed to server (filtered, peak-tracked)
+            await reportUploadSpeedIfValid(bytesTransferred: bytesTransferred, elapsed: elapsed)
 
             transferState?.updateTransfer(id: transferId) { t in
                 t.status = .completed


### PR DESCRIPTION
### Description

This PR improves how upload speeds are reported to the Soulseek server by introducing logic to filter out unreliable samples and only report new session peak speeds. This prevents the user's server-side profile speed from being overwritten by noisy or unrepresentative measurements, such as those from small files or throttled peers. The main changes include tracking the highest valid upload speed observed in a session, applying stricter criteria before reporting, and centralizing the reporting logic.

**Upload speed reporting improvements:**

* Introduced a `peakReportedSpeed` property to track the highest valid upload speed sample observed during the session, ensuring only new peaks are reported to the server.
* Replaced direct upload speed reporting with a call to a new `reportUploadSpeedIfValid` method, which filters out unreliable samples and only reports speeds that exceed the session peak. [[1]](diffhunk://#diff-2aa0a9d6f24252af96ddfc97853caa2d3f8e4288175c1812030a4be98d6d410fL778-R801) [[2]](diffhunk://#diff-2aa0a9d6f24252af96ddfc97853caa2d3f8e4288175c1812030a4be98d6d410fL1110-R1166)
* Added the `reportUploadSpeedIfValid` method, which rejects samples that are too small (<1 MiB), too short (<2s), or implausibly high (>1 GiB/s), and only reports speeds that set a new session peak.
<!--
### Future work
A place to describe changes that can or will be done in follow-up PRs
-->

### How to test

- Ensure all checks pass

### Author checklist

This PR:

- [x] Satisfies a goal that is specific & clearly motivated
- [x] Adds value in isolation (whether user-facing or sustainability-related)
- [x] Contains a concise & easy-to-understand title + description
- [x] Adheres to [SRP](https://en.wikipedia.org/wiki/Single-responsibility_principle) by default
- [x] Presents the best possible implementation to meet its goal, given constraints at hand
