### PR TITLE
fix download retries and coalesce 

### DIFF
--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Models/PeerPoolEvent.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Models/PeerPoolEvent.swift
@@ -5,7 +5,7 @@ import Foundation
 public enum PeerPoolEvent: Sendable {
     case searchResults(token: UInt32, results: [SearchResult])
     case sharesReceived(username: String, files: [SharedFile])
-    case transferRequest(TransferRequest)
+    case transferRequest(TransferRequest, connection: PeerConnection)
     case incomingConnectionMatched(username: String, token: UInt32, connection: PeerConnection)
     case fileTransferConnection(username: String, token: UInt32, connection: PeerConnection)
     case pierceFirewall(token: UInt32, connection: PeerConnection)

--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Connections/PeerConnection.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Connections/PeerConnection.swift
@@ -1097,7 +1097,13 @@ public actor PeerConnection {
 
             if let (username, usernameLen) = payload.readString(at: offset) {
                 offset += usernameLen
-                peerUsername = username
+                // Use setPeerUsername so the nonisolated peerInfo.username
+                // mirror is also updated. Consumers like
+                // DownloadManager.handlePoolTransferRequest read peerInfo
+                // synchronously to identify which peer delivered an event,
+                // so leaving peerInfo.username empty after PeerInit causes
+                // routing fallbacks to fail.
+                setPeerUsername(username)
 
                 var peerToken: UInt32 = 0
                 var connType: String = "P"

--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Connections/PeerConnectionPool.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Connections/PeerConnectionPool.swift
@@ -221,9 +221,6 @@ public final class PeerConnectionPool {
     /// Our username for PeerInit messages
     public var ourUsername: String = ""
 
-    /// Our listen port for NAT traversal (bind outgoing connections to same port)
-    public var listenPort: UInt16 = 0
-
     /// Connect to a peer
     /// - Parameters:
     ///   - username: Peer's username
@@ -252,9 +249,14 @@ public final class PeerConnectionPool {
         }
 
         let peerInfo = PeerConnection.PeerInfo(username: username, ip: ip, port: port)
-        // Pass listen port for NAT traversal - binding outgoing connections to our listen port
-        // can help with NAT hole punching
-        let connection = PeerConnection(peerInfo: peerInfo, token: token, localPort: listenPort)
+        // Outbound P-connections use ephemeral source ports. Binding to our
+        // listen port pinned every outbound dial to the same 4-tuple
+        // (127.0.0.1:listen → peerIP:peerPort), which the kernel rejects
+        // (POSIX EEXIST/17) as soon as a second download to the same peer
+        // starts. There's no NAT-hole-punching benefit here either: peers
+        // reach us via PierceFirewall on the listen port, not by dialing the
+        // ephemeral source port of one of our outbound TCP sessions.
+        let connection = PeerConnection(peerInfo: peerInfo, token: token)
 
         // Start consuming events BEFORE connecting to avoid missing early events
         let outgoingId = "\(username)-\(token)"
@@ -705,7 +707,7 @@ public final class PeerConnectionPool {
             eventContinuation.yield(.sharesReceived(username: peerUsername, files: files))
 
         case .transferRequest(let request):
-            eventContinuation.yield(.transferRequest(request))
+            eventContinuation.yield(.transferRequest(request, connection: connection))
 
         case .usernameDiscovered(let discoveredUsername, let token):
             logger.info("Username discovered: \(discoveredUsername) token=\(token)")

--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/NetworkClient.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/NetworkClient.swift
@@ -225,8 +225,8 @@ public final class NetworkClient {
         case .folderContentsResponse(let token, let folder, let files):
             onFolderContentsResponse?(token, folder, files)
 
-        case .transferRequest(let request):
-            onTransferRequest?(request)
+        case .transferRequest(let request, let connection):
+            onTransferRequest?(request, connection)
 
         case .placeInQueueRequest(let username, let filename, let connection):
             Task { await onPlaceInQueueRequest?(username, filename, connection) }
@@ -294,7 +294,7 @@ public final class NetworkClient {
     public var onTransferResponse: ((UInt32, Bool, UInt64?, String?, PeerConnection) async -> Void)?  // (token, allowed, filesize?, reason?, connection)
     public var onFolderContentsRequest: ((String, UInt32, String, PeerConnection) async -> Void)?  // (username, token, folder, connection) - peer wants folder contents
     public var onFolderContentsResponse: ((UInt32, String, [SharedFile]) -> Void)?  // (token, folder, files)
-    public var onTransferRequest: ((TransferRequest) -> Void)?  // Pool-level TransferRequest (for connections not directly managed by DownloadManager)
+    public var onTransferRequest: ((TransferRequest, PeerConnection) -> Void)?  // (request, connection that delivered it). The connection is critical: peers can deliver TransferRequests on a different connection than the one we cached when queueing the download.
     public var onPlaceInQueueRequest: ((String, String, PeerConnection) async -> Void)?  // (username, filename, connection)
     public var onPlaceInQueueReply: ((String, String, UInt32) async -> Void)?  // (username, filename, position)
 
@@ -405,7 +405,6 @@ public final class NetworkClient {
             let ports = try await listenerService.start(preferredPort: preferredListenPort)
             listenPort = ports.port
             obfuscatedPort = ports.obfuscatedPort
-            peerConnectionPool.listenPort = ports.port  // For NAT traversal - bind outgoing connections to listen port
             logger.info("Listening on port \(self.listenPort)")
             logger.info("Listening on port \(self.listenPort) (obfuscated: \(self.obfuscatedPort))")
 

--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/NetworkClient.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/NetworkClient.swift
@@ -1978,32 +1978,25 @@ public final class NetworkClient {
         }
     }
 
-    /// Request folder contents from a peer
-    public func requestFolderContents(from username: String, folder: String) async throws {
+    /// Request folder contents from a peer. Returns the token used so the
+    /// caller can correlate the eventual `onFolderContentsResponse` event
+    /// back to the originating request (multiple concurrent folder requests
+    /// otherwise race on `(folder, peer)` alone).
+    ///
+    /// Routes through `establishPeerConnection`, which races a direct TCP
+    /// connect against a server-mediated PierceFirewall indirect connection
+    /// (10 s budget) — essential for firewalled peers whose listen port is
+    /// unreachable. A bare `peerConnectionPool.connect(...)` here would hang
+    /// on TCP SYN for ~75 s with no fallback, which is the entire failure
+    /// mode this helper exists to solve. Do not bypass it.
+    @discardableResult
+    public func requestFolderContents(from username: String, folder: String) async throws -> UInt32 {
         guard isConnected else { throw NetworkError.notConnected }
 
         let token = UInt32.random(in: 0...UInt32.max)
-
-        // Check if we have an existing connection to this user
-        if let existingConnection = await peerConnectionPool.getConnectionForUser(username) {
-            try await existingConnection.requestFolderContents(token: token, folder: folder)
-            return
-        }
-
-        // Need to establish connection first - use concurrent-safe method
-        let (ip, port) = try await getPeerAddress(for: username)
-
-        // Connect to peer
-        let connectionToken = UInt32.random(in: 0...UInt32.max)
-        let connection = try await peerConnectionPool.connect(
-            to: username,
-            ip: ip,
-            port: port,
-            token: connectionToken
-        )
-
-        // Request folder contents
+        let connection = try await establishPeerConnection(for: username)
         try await connection.requestFolderContents(token: token, folder: folder)
+        return token
     }
 
     // MARK: - Share Updates

--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Storage/DownloadManager.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Storage/DownloadManager.swift
@@ -29,9 +29,13 @@ public final class DownloadManager {
     /// Directories that already have folder icons applied (avoid redundant work)
     private var iconAppliedDirs: Set<URL> = []
 
-    // MARK: - Retry Configuration (nicotine+ style)
-    private let maxRetries = 3
-    private let baseRetryDelay: TimeInterval = 5  // Start with 5 seconds
+    // MARK: - Retry Configuration
+    // Soulseek peer upload queues are commonly measured in minutes to hours.
+    // The previous 5s/15s/45s ladder exhausted in ~65s — long before a busy
+    // peer's queue ever drained — so the eventual TransferRequest arrived
+    // after pendingDownloads had been swept and was silently dropped.
+    private let retryDelays: [TimeInterval] = [30, 120, 600, 1800]  // 30s, 2m, 10m, 30m
+    private var maxRetries: Int { retryDelays.count }
     private var pendingRetries: [UUID: Task<Void, Never>] = [:]  // Track retry tasks
     private var reQueueTimer: Task<Void, Never>?  // Periodic re-queue timer (60s)
     private var connectionRetryTimer: Task<Void, Never>?  // Retry failed connections (3 min)
@@ -158,10 +162,11 @@ public final class DownloadManager {
         }
 
         // Set up callback for pool-level TransferRequests (arrives on connections not directly managed by us,
-        // e.g. stale direct connections when PierceFirewall won the race)
-        networkClient.onTransferRequest = { [weak self] request in
+        // e.g. stale direct connections when PierceFirewall won the race, or fresh
+        // incoming connections opened later when the peer's upload queue drains).
+        networkClient.onTransferRequest = { [weak self] request, connection in
             Task { @MainActor in
-                await self?.handlePoolTransferRequest(request)
+                await self?.handlePoolTransferRequest(request, connection: connection)
             }
         }
 
@@ -310,6 +315,15 @@ public final class DownloadManager {
 
         logger.info("Starting download from \(transfer.username), token=\(token)")
 
+        // If a live P-connection to this peer already exists (e.g. from a
+        // recent folder-contents fetch or another download), reuse it instead
+        // of running another GetPeerAddress + ConnectToPeer + 30s race. The
+        // pool already prunes stale entries inside `getConnectionForUser`.
+        if let existing = await networkClient.peerConnectionPool.getConnectionForUser(transfer.username) {
+            await reuseConnectionForDownload(token: token, connection: existing)
+            return
+        }
+
         do {
             // Step 1: Get peer address
             logger.debug("Requesting peer address for \(transfer.username)")
@@ -370,6 +384,45 @@ public final class DownloadManager {
                     retryCount: currentRetryCount
                 )
             }
+        }
+    }
+
+    /// Queue a download on an already-live peer connection. Mirrors the
+    /// existing-connection branch inside `handlePeerAddress` but is reachable
+    /// from `startDownload` directly so we can skip the address-lookup +
+    /// ConnectToPeer dance entirely when the pool already has a connection.
+    private func reuseConnectionForDownload(token: UInt32, connection: PeerConnection) async {
+        guard let transferState, let pending = pendingDownloads[token] else { return }
+
+        // Stash IP/port from the live connection so the later
+        // outbound-F-connection fallback (NAT traversal in
+        // initiateOutgoingFileConnection) still has a target if the peer
+        // can't reach us directly for the file transfer.
+        let info = connection.peerInfo
+        if !info.ip.isEmpty, info.port > 0 {
+            pendingDownloads[token]?.peerIP = info.ip
+            pendingDownloads[token]?.peerPort = info.port
+        }
+        pendingDownloads[token]?.peerConnection = connection
+
+        logger.info("Reusing existing connection to \(pending.username) for \(pending.filename)")
+
+        do {
+            await setupTransferRequestCallback(token: token, connection: connection)
+            try await connection.queueDownload(filename: pending.filename)
+            do {
+                try await connection.sendPlaceInQueueRequest(filename: pending.filename)
+            } catch {
+                logger.warning("sendPlaceInQueueRequest(\(pending.filename)) failed: \(error.localizedDescription)")
+            }
+            await waitForTransferResponse(token: token)
+        } catch {
+            logger.error("Failed to queue on reused connection: \(error.localizedDescription)")
+            transferState.updateTransfer(id: pending.transferId) { t in
+                t.status = .failed
+                t.error = error.localizedDescription
+            }
+            pendingDownloads.removeValue(forKey: token)
         }
     }
 
@@ -667,13 +720,58 @@ public final class DownloadManager {
         }
     }
 
-    private func handlePoolTransferRequest(_ request: TransferRequest) async {
-        if let token = matchPendingDownload(for: request) {
-            logger.info("Pool TransferRequest matched pending download: user=\(request.username) file=\(request.filename)")
-            await handleTransferRequest(token: token, request: request)
-        } else {
-            logger.debug("Pool TransferRequest: no matching pending download for user=\(request.username) file=\(request.filename)")
+    private func handlePoolTransferRequest(_ request: TransferRequest, connection: PeerConnection) async {
+        // Authoritative peer username: prefer the live connection's peerInfo
+        // over `request.username`, which is empty when the request arrives on
+        // a connection whose handshake didn't carry a username (e.g. a peer
+        // reusing a stream they identified on earlier).
+        let peerUsername = request.username.isEmpty ? connection.peerInfo.username : request.username
+        let normalizedRequest = request.username.isEmpty && !peerUsername.isEmpty
+            ? TransferRequest(direction: request.direction, token: request.token, filename: request.filename, size: request.size, username: peerUsername)
+            : request
+
+        if let token = matchPendingDownload(for: normalizedRequest) {
+            // Replace the cached connection. The one we stashed when first
+            // queueing the download (e.g. an early incoming connection) is
+            // often dead by the time the peer's upload queue drains and
+            // they reach us with TransferRequest. The fresh connection that
+            // delivered THIS request is the one we must reply on.
+            pendingDownloads[token]?.peerConnection = connection
+            logger.info("Pool TransferRequest matched pending download: user=\(peerUsername) file=\(request.filename)")
+            await handleTransferRequest(token: token, request: normalizedRequest)
+            return
         }
+
+        // Salvage path: the peer is offering a file we don't have in
+        // pendingDownloads (cleared by app restart, or not yet registered
+        // because resumeDownloadsOnConnect hasn't reached it). If the user
+        // still wants this file (transferState shows it in a pre-transfer
+        // state), accept the offer on the fresh connection.
+        if !peerUsername.isEmpty,
+           let transfer = transferState?.downloads.first(where: { t in
+               t.direction == .download &&
+               t.username == peerUsername &&
+               t.filename == request.filename &&
+               (t.status == .queued || t.status == .waiting ||
+                t.status == .connecting || t.status == .failed)
+           }) {
+            let salvagedToken = UInt32.random(in: 1...UInt32.max)
+            let info = connection.peerInfo
+            pendingDownloads[salvagedToken] = PendingDownload(
+                transferId: transfer.id,
+                username: transfer.username,
+                filename: transfer.filename,
+                size: request.size,
+                peerConnection: connection,
+                peerIP: info.ip.isEmpty ? nil : info.ip,
+                peerPort: info.port > 0 ? info.port : nil
+            )
+            logger.info("Pool TransferRequest salvaged from transferState: user=\(peerUsername) file=\(request.filename) (token=\(salvagedToken))")
+            await handleTransferRequest(token: salvagedToken, request: normalizedRequest)
+            return
+        }
+
+        logger.info("Pool TransferRequest dropped — no pending or transferState match: user=\(peerUsername) file=\(request.filename)")
     }
 
     private func waitForTransferResponse(token: UInt32) async {
@@ -845,9 +943,10 @@ public final class DownloadManager {
                 port: nwPort
             )
 
-            let listenPort = networkClient?.listenPort ?? 0
-            let bindPort: UInt16? = listenPort > 0 ? listenPort : nil
-            let connection = try await openFileConnectionWithRetry(to: endpoint, bindTo: bindPort)
+            // Use an ephemeral source port (bindTo: nil). Pinning to listenPort
+            // collides with concurrent F-connections to the same peer on the
+            // same 4-tuple (POSIX EEXIST/17) and offers no NAT benefit.
+            let connection = try await openFileConnectionOnce(to: endpoint, bindTo: nil)
 
             logger.info("Outgoing F connection established to \(username)")
 
@@ -929,21 +1028,6 @@ public final class DownloadManager {
         } catch {
             logger.error("Outgoing F connection failed: \(error.localizedDescription)")
             // Don't mark as failed yet - the timeout will handle that
-        }
-    }
-
-    /// Open an outbound F-connection bound to `localPort`; retry unbound once
-    /// if the OS refuses the bind.
-    private func openFileConnectionWithRetry(
-        to endpoint: NWEndpoint,
-        bindTo localPort: UInt16?
-    ) async throws -> NWConnection {
-        do {
-            return try await openFileConnectionOnce(to: endpoint, bindTo: localPort)
-        } catch let error where PeerConnection.isBindFailure(error) {
-            guard localPort != nil else { throw error }
-            logger.warning("Bound F connect failed (\(error.localizedDescription)); retrying unbound")
-            return try await openFileConnectionOnce(to: endpoint, bindTo: nil)
         }
     }
 
@@ -2431,20 +2515,27 @@ public final class DownloadManager {
         return false
     }
 
-    /// Schedule automatic retry for a failed transfer with exponential backoff
+    private static func formatRetryDelay(_ delay: TimeInterval) -> String {
+        let seconds = Int(delay)
+        if seconds < 60 { return "\(seconds)s" }
+        let minutes = seconds / 60
+        return "\(minutes)m"
+    }
+
+    /// Schedule automatic retry for a failed transfer with backoff measured
+    /// in minutes (see `retryDelays`).
     private func scheduleRetry(transferId: UUID, username: String, filename: String, size: UInt64, retryCount: Int) {
         guard retryCount < self.maxRetries else {
             logger.info("Max retries (\(self.maxRetries)) reached for \(filename)")
             return
         }
 
-        // Exponential backoff: 5s, 15s, 45s
-        let delay = baseRetryDelay * pow(3.0, Double(retryCount))
+        let delay = retryDelays[retryCount]
         logger.info("Scheduling retry #\(retryCount + 1) for \(filename) in \(delay)s")
 
         // Update status to show pending retry
         transferState?.updateTransfer(id: transferId) { t in
-            t.error = "Retrying in \(Int(delay))s..."
+            t.error = "Retrying in \(Self.formatRetryDelay(delay))..."
         }
 
         // Cancel any prior pending retry for this transfer first —

--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Storage/UploadManager.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Storage/UploadManager.swift
@@ -556,14 +556,10 @@ public final class UploadManager {
             port: nwPort
         )
 
-        let listenPort = networkClient.listenPort
-        let bindPort: UInt16? = listenPort > 0 ? listenPort : nil
-
-        var attemptResult = await Self.attemptFileConnect(to: endpoint, bindTo: bindPort)
-        if case .bindFailed = attemptResult, bindPort != nil {
-            logger.warning("Bound F connect to \(ip):\(port) failed (bind); retrying unbound")
-            attemptResult = await Self.attemptFileConnect(to: endpoint, bindTo: nil)
-        }
+        // Use an ephemeral source port (bindTo: nil). Pinning to listenPort
+        // collides with concurrent F-connections to the same peer on the
+        // same 4-tuple (POSIX EEXIST/17) and offers no NAT benefit.
+        let attemptResult = await Self.attemptFileConnect(to: endpoint, bindTo: nil)
 
         let connected: Bool
         let connection: NWConnection

--- a/seeleseek/App/AppState.swift
+++ b/seeleseek/App/AppState.swift
@@ -113,6 +113,29 @@ final class AppState {
             }
         }
 
+        // Folder-download response handler: a search-row right-click → "Download
+        // entire folder" triggers `requestFolderContents`, which eventually
+        // lands here with the file list. Match by token to the username that
+        // initiated the request and queue every file. No ActivityLog entry —
+        // individual downloads surface in the Transfers tab and will emit
+        // their own logDownloadCompleted when they finish, matching the
+        // single-file download path.
+        //
+        // The `folder` argument is passed into `queueFolderDownload` because
+        // some peers (e.g. vanilla Nicotine+) send full paths as each file's
+        // `filename`, while others (seen in the wild) send only basenames.
+        // The queue path uses `folder` to reconstruct the full Soulseek path
+        // when the peer sent a basename — otherwise the QueueUpload request
+        // we later send to them comes back `File not shared`.
+        client.onFolderContentsResponse = { [weak self] token, folder, files in
+            guard let self,
+                  let username = self.pendingFolderDownloads.removeValue(forKey: token) else {
+                return
+            }
+            let queued = self.queueFolderDownload(files: files, from: username, folder: folder)
+            self.logger.info("Folder download from \(username) in '\(folder)': queued \(queued)/\(files.count) files")
+        }
+
         client.searchResponseFilter = { [weak self] in
             guard let settings = self?.settings else {
                 return (enabled: true, minQueryLength: 3, maxResults: 50)
@@ -124,6 +147,109 @@ final class AppState {
             )
         }
     }
+
+    // MARK: - Folder Download Coordinator
+    // Maps the token returned by `requestFolderContents` to the username we
+    // asked — response events only carry `(token, folder, files)`, so we
+    // need this side-table to know where to queue the downloads.
+    private var pendingFolderDownloads: [UInt32: String] = [:]
+
+    /// Right-click "Download entire folder" entrypoint for a search result.
+    /// Derives the containing folder from the Soulseek path (backslash-
+    /// separated), asks the peer for its contents, and queues every returned
+    /// file once the response arrives. Pending tokens are auto-cleaned after
+    /// 60 s if the peer never responds, so `pendingFolderDownloads` can't grow
+    /// unbounded. No ActivityLog entries — folder downloads surface through
+    /// the same Transfers-tab path as single-file downloads, matching the
+    /// app's "log on completion, not on intent" convention.
+    func downloadContainingFolder(of result: SearchResult) async {
+        let folder = Self.containingSoulseekFolder(of: result.filename)
+        guard !folder.isEmpty else {
+            logger.warning("Could not derive containing folder from filename: \(result.filename)")
+            return
+        }
+        do {
+            let token = try await networkClient.requestFolderContents(
+                from: result.username,
+                folder: folder
+            )
+            pendingFolderDownloads[token] = result.username
+            logger.info("Requested folder contents '\(folder)' from \(result.username) (token=\(token))")
+            scheduleFolderDownloadTimeout(token: token, username: result.username, folder: folder)
+        } catch {
+            logger.error("Failed to request folder contents: \(error.localizedDescription)")
+        }
+    }
+
+    /// Drop the pending entry after 60 s if the peer never replied. No-op
+    /// if the response already arrived and removed it.
+    private func scheduleFolderDownloadTimeout(token: UInt32, username: String, folder: String) {
+        Task { [weak self] in
+            try? await Task.sleep(for: .seconds(60))
+            guard let self,
+                  self.pendingFolderDownloads.removeValue(forKey: token) != nil else {
+                return
+            }
+            self.logger.info("Folder contents request timed out: \(username) '\(folder)' (token=\(token))")
+        }
+    }
+
+    /// Queue every file from a folder-contents response, skipping files
+    /// already queued for this user. Returns the number actually queued.
+    ///
+    /// `folder` is the full Soulseek folder path the peer listed (as it
+    /// appeared in `FolderContentsReply`). Some peers embed the full path
+    /// in each file's `filename`; others send only basenames. If we just
+    /// forward the basename, the peer's subsequent QueueUpload lookup fails
+    /// with `File not shared` (they key their share index by full path).
+    /// We detect the basename-only case and prepend `folder` so the queued
+    /// SearchResult carries the path the peer expects.
+    private func queueFolderDownload(files: [SharedFile], from username: String, folder: String) -> Int {
+        var queued = 0
+        for file in files {
+            let fullPath = Self.fullSoulseekPath(folder: folder, filename: file.filename)
+            if transferState.isFileQueued(filename: fullPath, username: username) { continue }
+            let result = SearchResult(
+                username: username,
+                filename: fullPath,
+                size: file.size,
+                bitrate: file.bitrate,
+                duration: file.duration,
+                isVBR: false,
+                freeSlots: true,
+                uploadSpeed: 0,
+                queueLength: 0
+            )
+            downloadManager.queueDownload(from: result)
+            queued += 1
+        }
+        return queued
+    }
+
+    /// Combine `folder` and `filename` into a full Soulseek path, detecting
+    /// whether the peer already embedded the full path in `filename`. Heuristic:
+    /// if `filename` contains a backslash, trust it verbatim (either a full
+    /// path or a nested sub-path both of which the peer indexes directly);
+    /// otherwise prepend `folder` and the backslash separator. Empty `folder`
+    /// falls through to the bare filename — defensive; the caller already
+    /// guards against the empty-folder case upstream.
+    private static func fullSoulseekPath(folder: String, filename: String) -> String {
+        if filename.contains("\\") || folder.isEmpty {
+            return filename
+        }
+        let separator = folder.hasSuffix("\\") ? "" : "\\"
+        return "\(folder)\(separator)\(filename)"
+    }
+
+    /// Soulseek paths use backslash separators — e.g.
+    /// `@@hddmusic\Music\Artist\Album\01 - Track.flac`. Returns the path
+    /// with the trailing component dropped, or empty if there isn't one.
+    private static func containingSoulseekFolder(of filename: String) -> String {
+        let components = filename.components(separatedBy: "\\")
+        guard components.count > 1 else { return "" }
+        return components.dropLast().joined(separator: "\\")
+    }
+
 
     // MARK: - Download Manager
     let downloadManager = DownloadManager()

--- a/seeleseek/Features/Search/Views/SearchResultRow.swift
+++ b/seeleseek/Features/Search/Views/SearchResultRow.swift
@@ -488,6 +488,11 @@ struct SearchResultRow: View {
         }
         .disabled(isQueued || isIgnored)
 
+        Button(action: downloadContainingFolder) {
+            Label("Download entire folder", systemImage: "arrow.down.square.fill")
+        }
+        .disabled(isIgnored)
+
         Button(action: browseFolder) {
             Label("Browse folder", systemImage: "folder.badge.questionmark")
         }
@@ -544,6 +549,10 @@ struct SearchResultRow: View {
     private func browseFolder() {
         appState.browseState.browseUser(result.username, targetPath: result.filename)
         appState.sidebarSelection = .browse
+    }
+
+    private func downloadContainingFolder() {
+        Task { await appState.downloadContainingFolder(of: result) }
     }
 
     private func copyFilename() {

--- a/seeleseek/Features/Transfers/TransferState.swift
+++ b/seeleseek/Features/Transfers/TransferState.swift
@@ -141,7 +141,10 @@ final class TransferState: TransferTracking {
     }
     // MARK: - Transfers
     var downloads: [Transfer] = [] {
-        didSet { rebuildDownloadIndex() }
+        didSet {
+            rebuildDownloadIndex()
+            refreshDownloadsInProgressCount()
+        }
     }
     var uploads: [Transfer] = []
 
@@ -155,6 +158,29 @@ final class TransferState: TransferTracking {
             index["\(transfer.username)\0\(transfer.filename)"] = transfer.status
         }
         downloadStatusIndex = index
+    }
+
+    /// Count of downloads that are queued, waiting, connecting, or actively
+    /// transferring. Surfaced to the sidebar badge.
+    ///
+    /// Stored (not computed) so observers subscribe only to this `Int`, not
+    /// to `downloads` itself — mutating `downloads[i].bytesTransferred` on
+    /// every progress update would otherwise fan-out observable
+    /// invalidation to the sidebar. The setter guard below only writes
+    /// when the value actually changes, so progress updates (which call
+    /// `downloads.didSet` but leave the count identical) are free.
+    private(set) var downloadsInProgressCount: Int = 0
+
+    private func refreshDownloadsInProgressCount() {
+        var count = 0
+        for transfer in downloads {
+            if transfer.isActive || transfer.status == .queued || transfer.status == .waiting {
+                count += 1
+            }
+        }
+        if count != downloadsInProgressCount {
+            downloadsInProgressCount = count
+        }
     }
 
     // MARK: - History

--- a/seeleseek/Navigation/Sidebar.swift
+++ b/seeleseek/Navigation/Sidebar.swift
@@ -117,6 +117,13 @@ struct SidebarRow: View {
             return appState.socialState.onlineBuddies.count
         case .wishlists:
             return appState.wishlistState.unviewedResultCount
+        case .transfers:
+            // `downloadsInProgressCount` is a dedicated stored Int on
+            // TransferState that is written only when the count actually
+            // changes — reading it here avoids subscribing the sidebar to
+            // the full `downloads` array which mutates on every byte-progress
+            // tick. Do not swap this for `activeDownloads.count`.
+            return appState.transferState.downloadsInProgressCount
         default:
             return 0
         }
@@ -134,6 +141,12 @@ struct SidebarRow: View {
                     .font(.system(size: SeeleSpacing.iconSizeSmall, weight: .medium))
                     .foregroundStyle(isSelected ? SeeleColors.accent : SeeleColors.textSecondary)
                     .frame(width: 18)
+                    // Subtle bounce on badge changes — covers both "new thing
+                    // arrived" (count increased) and "thing finished" (count
+                    // decreased). Driven by SF Symbol animation so no layout
+                    // churn; `value:` keys the effect so it only fires when
+                    // the count actually changes, not on every re-render.
+                    .symbolEffect(.bounce, value: badgeCount)
 
                 Text(item.title)
                     .font(SeeleTypography.body)


### PR DESCRIPTION
### Description

This PR significantly improves the reliability and correctness of peer-to-peer file transfers, especially in handling upload queues, connection reuse, and NAT traversal. The changes ensure that transfer requests are always associated with the correct live connection, retries are scheduled with more realistic backoff intervals, and ephemeral ports are used for outgoing connections to prevent conflicts. Additionally, the handling of folder content requests is made more robust by guaranteeing proper connection establishment.

**Peer connection and transfer request handling:**
- `PeerPoolEvent`, `PeerConnectionPool`, `NetworkClient`, `DownloadManager`: Transfer requests now always include the associated `PeerConnection`, ensuring that the correct, live connection is used for file transfers. This fixes issues where stale or mismatched connections could cause failed downloads or dropped requests. [[1]](diffhunk://#diff-9725d037dc944f106c56bb5ac3fb256eb30d465c7f68a46728c00d2266de589bL8-R8) [[2]](diffhunk://#diff-b56ebc520dbee8cd683f123b7709cbfa882317690d4676417789071581ab8955L708-R710) Ff405cddL1097R1097, [[3]](diffhunk://#diff-f3aa9a82ee1ce3b938a3e39e5b875ff339f1ffad68029fbf374f19ebeaa6c60cL228-R229) [[4]](diffhunk://#diff-f3aa9a82ee1ce3b938a3e39e5b875ff339f1ffad68029fbf374f19ebeaa6c60cL297-R297) [[5]](diffhunk://#diff-473413f7f7c0b9edac4781f0bf57f99ae1309950eb2d67ce1c095e6485308d58L161-R169) [[6]](diffhunk://#diff-473413f7f7c0b9edac4781f0bf57f99ae1309950eb2d67ce1c095e6485308d58L670-R774)

**Connection reuse and NAT traversal improvements:**
- `PeerConnectionPool`, `NetworkClient`, `DownloadManager`: Outgoing peer and file connections now use ephemeral source ports instead of binding to the listen port, preventing port collision errors and offering no NAT traversal disadvantage. The logic for connection reuse is improved, allowing downloads to leverage existing connections and avoid unnecessary reconnections. [[1]](diffhunk://#diff-b56ebc520dbee8cd683f123b7709cbfa882317690d4676417789071581ab8955L224-L226) [[2]](diffhunk://#diff-b56ebc520dbee8cd683f123b7709cbfa882317690d4676417789071581ab8955L255-R259) [[3]](diffhunk://#diff-f3aa9a82ee1ce3b938a3e39e5b875ff339f1ffad68029fbf374f19ebeaa6c60cL408) [[4]](diffhunk://#diff-473413f7f7c0b9edac4781f0bf57f99ae1309950eb2d67ce1c095e6485308d58R318-R326) [[5]](diffhunk://#diff-473413f7f7c0b9edac4781f0bf57f99ae1309950eb2d67ce1c095e6485308d58L848-R949) [[6]](diffhunk://#diff-473413f7f7c0b9edac4781f0bf57f99ae1309950eb2d67ce1c095e6485308d58L935-L949)

**Download retry logic enhancements:**
- [`DownloadManager`](diffhunk://#diff-473413f7f7c0b9edac4781f0bf57f99ae1309950eb2d67ce1c095e6485308d58L32-R38): Retry delays are now much longer (minutes instead of seconds) to match real-world peer upload queue times, preventing premature exhaustion of retries and dropped downloads. The retry status message is also improved for clarity. [[1]](diffhunk://#diff-473413f7f7c0b9edac4781f0bf57f99ae1309950eb2d67ce1c095e6485308d58L32-R38) [[2]](diffhunk://#diff-473413f7f7c0b9edac4781f0bf57f99ae1309950eb2d67ce1c095e6485308d58L2434-R2538)

**Robust folder contents request flow:**
- [`NetworkClient`](diffhunk://#diff-f3aa9a82ee1ce3b938a3e39e5b875ff339f1ffad68029fbf374f19ebeaa6c60cL1981-R1998): Folder contents requests now always route through the connection-establishment helper, ensuring proper handling of firewalled peers and returning the token used for request tracking.

**Peer username synchronization:**
- [`PeerConnection`](diffhunk://#diff-d706c86a469135e21918307a668b2a2cf738f80364802caea506c4ed865fbf8dL1100-R1106): The peer username is now set using a dedicated method to ensure that both the connection and its mirrored `peerInfo` struct are updated, which is critical for correct event routing.


### Future work
- further networking refactoring 

### How to test

- ensure checks pass

### Author checklist

This PR:

- [x] Satisfies a goal that is specific & clearly motivated
- [x] Adds value in isolation (whether user-facing or sustainability-related)
- [x] Contains a concise & easy-to-understand title + description
- [x] Adheres to [SRP](https://en.wikipedia.org/wiki/Single-responsibility_principle) by default
- [x] Presents the best possible implementation to meet its goal, given constraints at hand
