### PR TITLE
download architecture refactor

### DIFF
--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Models/PeerPoolEvent.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Models/PeerPoolEvent.swift
@@ -6,7 +6,6 @@ public enum PeerPoolEvent: Sendable {
     case searchResults(token: UInt32, results: [SearchResult])
     case sharesReceived(username: String, files: [SharedFile])
     case transferRequest(TransferRequest, connection: PeerConnection)
-    case incomingConnectionMatched(username: String, token: UInt32, connection: PeerConnection)
     case fileTransferConnection(username: String, token: UInt32, connection: PeerConnection)
     case pierceFirewall(token: UInt32, connection: PeerConnection)
     case uploadDenied(filename: String, reason: String)

--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Connections/PeerConnectionPool.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Connections/PeerConnectionPool.swift
@@ -493,16 +493,11 @@ public final class PeerConnectionPool {
     }
 
     /// Bump `lastActivity` for the connection that just emitted an event.
-    /// For outgoing connections we look up by `username-` prefix because
-    /// the connectionId was generated locally; for incoming we have it
-    /// directly.
-    private func touchActivity(connectionId: String, username: String, isIncoming: Bool) {
-        let now = Date()
-        if isIncoming {
-            connections[connectionId]?.lastActivity = now
-        } else if let key = connections.keys.first(where: { $0.hasPrefix("\(username)-") }) {
-            connections[key]?.lastActivity = now
-        }
+    /// `connectionId` is the dict key for both incoming and outgoing
+    /// connections (outgoing keys are `"\(username)-\(token)"`, set in
+    /// `connect(...)`), so this is a direct lookup — no prefix scan.
+    private func touchActivity(connectionId: String) {
+        connections[connectionId]?.lastActivity = Date()
     }
 
     public func cleanupStaleConnections() {
@@ -653,7 +648,7 @@ public final class PeerConnectionPool {
         // into `cleanupStaleConnections`'s "ghost" branch and got killed
         // 10-30s after creation regardless of whether it was being used —
         // forcing the peer to reconnect on every operation.
-        touchActivity(connectionId: connectionId, username: username, isIncoming: isIncoming)
+        touchActivity(connectionId: connectionId)
 
         switch event {
         case .stateChanged(let state):

--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Connections/PeerConnectionPool.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Connections/PeerConnectionPool.swift
@@ -32,7 +32,6 @@ public final class PeerConnectionPool {
     // MARK: - Connection Tracking
 
     public private(set) var connections: [String: PeerConnectionInfo] = [:]
-    public private(set) var pendingConnections: [UInt32: PendingConnection] = [:]
 
     // CRITICAL: Store actual PeerConnection objects to keep them alive!
     // Without this, connections get deallocated immediately after creation.
@@ -117,17 +116,6 @@ public final class PeerConnectionPool {
 
         public init(id: String, username: String, ip: String, port: Int, state: PeerConnection.State, connectionType: PeerConnection.ConnectionType, bytesReceived: UInt64 = 0, bytesSent: UInt64 = 0, connectedAt: Date? = nil, lastActivity: Date? = nil, currentSpeed: Double = 0, seeleSeekVersion: UInt8? = nil) {
             self.id = id; self.username = username; self.ip = ip; self.port = port; self.state = state; self.connectionType = connectionType; self.bytesReceived = bytesReceived; self.bytesSent = bytesSent; self.connectedAt = connectedAt; self.lastActivity = lastActivity; self.currentSpeed = currentSpeed; self.seeleSeekVersion = seeleSeekVersion
-        }
-    }
-
-    public struct PendingConnection {
-        public let username: String
-        public let token: UInt32
-        public let timestamp: Date
-        public var attempts: Int = 0
-
-        public init(username: String, token: UInt32, timestamp: Date, attempts: Int = 0) {
-            self.username = username; self.token = token; self.timestamp = timestamp; self.attempts = attempts
         }
     }
 
@@ -445,7 +433,6 @@ public final class PeerConnectionPool {
         }
         activeConnections_.removeAll()
         connections.removeAll()
-        pendingConnections.removeAll()
         activeConnections = 0
     }
 
@@ -491,20 +478,6 @@ public final class PeerConnectionPool {
         return nil
     }
 
-    // MARK: - Pending Connections
-
-    public func addPendingConnection(username: String, token: UInt32) {
-        pendingConnections[token] = PendingConnection(
-            username: username,
-            token: token,
-            timestamp: Date()
-        )
-    }
-
-    public func resolvePendingConnection(token: UInt32) -> PendingConnection? {
-        return pendingConnections.removeValue(forKey: token)
-    }
-
     // MARK: - Diagnostic Counters
 
     public func incrementConnectToPeerCount() {
@@ -519,12 +492,22 @@ public final class PeerConnectionPool {
         peerInitCount += 1
     }
 
+    /// Bump `lastActivity` for the connection that just emitted an event.
+    /// For outgoing connections we look up by `username-` prefix because
+    /// the connectionId was generated locally; for incoming we have it
+    /// directly.
+    private func touchActivity(connectionId: String, username: String, isIncoming: Bool) {
+        let now = Date()
+        if isIncoming {
+            connections[connectionId]?.lastActivity = now
+        } else if let key = connections.keys.first(where: { $0.hasPrefix("\(username)-") }) {
+            connections[key]?.lastActivity = now
+        }
+    }
+
     public func cleanupStaleConnections() {
         let timeout = Date().addingTimeInterval(-connectionTimeout)
         let shortTimeout = Date().addingTimeInterval(-10)  // 10s for connections with no activity
-
-        // Remove stale pending connections
-        pendingConnections = pendingConnections.filter { $0.value.timestamp > timeout }
 
         // Find stale connection IDs (30s idle) and ghost connections (10s with no activity)
         var toRemove: [String] = []
@@ -665,6 +648,13 @@ public final class PeerConnectionPool {
     }
 
     private func handlePeerEvent(_ event: PeerConnectionEvent, connection: PeerConnection, username: String, connectionId: String, capturedIP: String, isIncoming: Bool) {
+        // Touch the connection's lastActivity on every event. Without this,
+        // `lastActivity` was never set anywhere, so every connection fell
+        // into `cleanupStaleConnections`'s "ghost" branch and got killed
+        // 10-30s after creation regardless of whether it was being used —
+        // forcing the peer to reconnect on every operation.
+        touchActivity(connectionId: connectionId, username: username, isIncoming: isIncoming)
+
         switch event {
         case .stateChanged(let state):
             if isIncoming {
@@ -754,15 +744,20 @@ public final class PeerConnectionPool {
                 connections[connectionId] = existingInfo
             }
 
-            // Check if this matches a pending connection (for downloads)
-            if pendingConnections[token] != nil {
-                logger.info("Matched incoming connection to pending: \(discoveredUsername) token=\(token)")
-                pendingConnections.removeValue(forKey: token)
-                eventContinuation.yield(.incomingConnectionMatched(username: discoveredUsername, token: token, connection: connection))
-            }
-
         case .fileTransferConnection(let ftUsername, let token, let fileConnection):
             logger.info("File transfer connection: \(ftUsername) token=\(token)")
+            // Hand the F-connection off to DownloadManager and stop tracking
+            // it here. The pool's cleanupStaleConnections timer otherwise
+            // kills the underlying NWConnection 10-30s after handoff —
+            // mid-file-transfer for anything bigger than a few hundred KB —
+            // because the pool has no insight into raw file bytes flowing
+            // outside its peer-message framing. Same pattern as
+            // .pierceFirewall below; both events transfer ownership of the
+            // connection from pool to consumer.
+            decrementIPCounter(for: capturedIP)
+            connections.removeValue(forKey: connectionId)
+            activeConnections_.removeValue(forKey: connectionId)
+            activeConnections = connections.count
             eventContinuation.yield(.fileTransferConnection(username: ftUsername, token: token, connection: fileConnection))
 
         case .pierceFirewall(let token):

--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Connections/PeerConnectionPool.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Connections/PeerConnectionPool.swift
@@ -737,11 +737,11 @@ public final class PeerConnectionPool {
             // Hand the F-connection off to DownloadManager and stop tracking
             // it here. The pool's cleanupStaleConnections timer otherwise
             // kills the underlying NWConnection 10-30s after handoff —
-            // mid-file-transfer for anything bigger than a few hundred KB —
-            // because the pool has no insight into raw file bytes flowing
-            // outside its peer-message framing. Same pattern as
-            // .pierceFirewall below; both events transfer ownership of the
-            // connection from pool to consumer.
+            // long enough that any transfer that doesn't complete inside
+            // that window dies mid-flight — because the pool has no
+            // insight into raw file bytes flowing outside its peer-message
+            // framing. Same pattern as .pierceFirewall below; both events
+            // transfer ownership of the connection from pool to consumer.
             decrementIPCounter(for: capturedIP)
             connections.removeValue(forKey: connectionId)
             activeConnections_.removeValue(forKey: connectionId)
@@ -845,5 +845,29 @@ public final class PeerConnectionPool {
             .sorted { ($0.bytesReceived + $0.bytesSent) > ($1.bytesReceived + $1.bytesSent) }
             .prefix(10)
             .map { $0 }
+    }
+
+    // MARK: - Test-only accessors
+
+    internal func _seedConnectionForTest(_ info: PeerConnectionInfo) {
+        connections[info.id] = info
+        activeConnections = connections.count
+    }
+
+    internal func _connectionInfo(id: String) -> PeerConnectionInfo? {
+        connections[id]
+    }
+
+    internal func _touchActivityForTest(connectionId: String) {
+        touchActivity(connectionId: connectionId)
+    }
+
+    /// Drive the F-connection handoff branch directly. Real callers reach it
+    /// via the pool event stream after a peer's PeerInit type=F.
+    internal func _simulateFileTransferHandoffForTest(connectionId: String, ip: String) {
+        decrementIPCounter(for: ip)
+        connections.removeValue(forKey: connectionId)
+        activeConnections_.removeValue(forKey: connectionId)
+        activeConnections = connections.count
     }
 }

--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Connections/PeerConnectionPool.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Connections/PeerConnectionPool.swift
@@ -501,39 +501,32 @@ public final class PeerConnectionPool {
     }
 
     public func cleanupStaleConnections() {
-        let timeout = Date().addingTimeInterval(-connectionTimeout)
-        let shortTimeout = Date().addingTimeInterval(-10)  // 10s for connections with no activity
+        let idleCutoff = Date().addingTimeInterval(-connectionTimeout)
+        // Connections that haven't seen any event yet (lastActivity==nil) but
+        // were created more than 10s ago are considered "stuck handshake"
+        // and reaped early. With `touchActivity` bumping lastActivity on
+        // every event, a connection only ends up here if it never received
+        // a single event — i.e. it never even reached PeerInit.
+        let stuckHandshakeCutoff = Date().addingTimeInterval(-10)
 
-        // Find stale connection IDs (30s idle) and ghost connections (10s with no activity)
         var toRemove: [String] = []
-
         for (id, info) in connections {
             if let lastActivity = info.lastActivity {
-                // Regular idle timeout (30s)
-                if lastActivity <= timeout {
+                if lastActivity <= idleCutoff {
                     toRemove.append(id)
                 }
-            } else {
-                // Ghost connection - never had activity, close after 10s
-                if let connectedAt = info.connectedAt, connectedAt <= shortTimeout {
-                    toRemove.append(id)
-                }
+            } else if let connectedAt = info.connectedAt, connectedAt <= stuckHandshakeCutoff {
+                toRemove.append(id)
             }
         }
 
-        // Actually close and remove stale connections
         for id in toRemove {
-            // Decrement per-IP counter before removing
             if let info = connections[id] {
                 decrementIPCounter(for: info.ip)
             }
-
             if let conn = activeConnections_[id] {
-                Task {
-                    await conn.disconnect()
-                }
+                Task { await conn.disconnect() }
                 logger.info("Closed idle connection: \(id)")
-                logger.debug("Closed idle connection: \(id)")
             }
             connections.removeValue(forKey: id)
             activeConnections_.removeValue(forKey: id)

--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/NetworkClient.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/NetworkClient.swift
@@ -1091,8 +1091,15 @@ public final class NetworkClient {
         var receivedConnection: PeerConnection?  // Set if PierceFirewall arrives before we start waiting
         var timeoutTask: Task<Void, Never>?
         var timedOut = false
+        var failureReason: String?  // Set by CantConnectToPeer to fail the wait fast
     }
     private var pendingBrowseStates: [UInt32: PendingBrowseState] = [:]
+
+    /// Coalesce concurrent `establishPeerConnection` calls for the same peer.
+    /// Without this, N parallel downloads to one peer each kick off their own
+    /// ConnectToPeer + race, opening N independent TCP connections — wasteful
+    /// and historically the source of the localPort=2235 4-tuple collision.
+    private var pendingEstablishments: [String: Task<PeerConnection, Error>] = [:]
 
     /// Register a pending browse BEFORE sending ConnectToPeer (to avoid race condition)
     public func registerPendingBrowse(token: UInt32, username: String, timeout: TimeInterval) {
@@ -1125,7 +1132,7 @@ public final class NetworkClient {
 
     /// Wait for a previously registered pending browse to receive PierceFirewall
     public func waitForPendingBrowse(token: UInt32) async throws -> PeerConnection {
-        // Check if connection already arrived
+        // Check if connection already arrived (or failed)
         if let state = pendingBrowseStates[token] {
             if let connection = state.receivedConnection {
                 logger.debug("Browse: PierceFirewall already received for token=\(token)")
@@ -1135,6 +1142,10 @@ public final class NetworkClient {
             if state.timedOut {
                 pendingBrowseStates.removeValue(forKey: token)
                 throw NetworkError.timeout
+            }
+            if let reason = state.failureReason {
+                pendingBrowseStates.removeValue(forKey: token)
+                throw NetworkError.connectionFailed(reason)
             }
         }
 
@@ -1152,6 +1163,11 @@ public final class NetworkClient {
                     continuation.resume(throwing: NetworkError.timeout)
                     return
                 }
+                if let reason = state.failureReason {
+                    pendingBrowseStates.removeValue(forKey: token)
+                    continuation.resume(throwing: NetworkError.connectionFailed(reason))
+                    return
+                }
                 state.continuation = continuation
                 pendingBrowseStates[token] = state
             } else {
@@ -1159,6 +1175,20 @@ public final class NetworkClient {
                 continuation.resume(throwing: NetworkError.timeout)
             }
         }
+    }
+
+    /// Mark a pending browse as failed (e.g. server sent CantConnectToPeer).
+    /// The waiter, if any, fails fast instead of sitting on the 30s timeout.
+    public func failPendingBrowse(token: UInt32, reason: String) {
+        guard var state = pendingBrowseStates[token] else { return }
+        state.failureReason = reason
+        if let continuation = state.continuation {
+            state.continuation = nil
+            pendingBrowseStates.removeValue(forKey: token)
+            continuation.resume(throwing: NetworkError.connectionFailed(reason))
+            return
+        }
+        pendingBrowseStates[token] = state
     }
 
     /// Cancel a pending browse (used when direct connection succeeds or search delivery completes)
@@ -1841,14 +1871,20 @@ public final class NetworkClient {
     // MARK: - Peer Connection Establishment
 
     /// Opens (or reuses) a P-type peer connection, completing the handshake.
-    /// Used by `browseUser` and `fetchUserInfo` so the ConnectToPeer +
-    /// direct/indirect-race dance lives in one place.
+    /// The single home of the ConnectToPeer + direct/indirect-race dance —
+    /// used by browse, folder-contents, user-info, and downloads. Anyone
+    /// reaching out to a peer for the first time should go through here so
+    /// the firewall-traversal logic isn't reinvented per consumer.
+    ///
+    /// Concurrent calls for the same `username` are coalesced via
+    /// `pendingEstablishments`, so N parallel downloads to one peer share
+    /// one connection establishment instead of racing each other.
     ///
     /// - Parameter forceFresh: when `true`, always opens a new connection.
     ///   `browseUser` passes this because historically it was never documented
     ///   why it created a fresh one — preserving behaviour until someone
     ///   proves reuse is safe for share-list fetches.
-    private func establishPeerConnection(for username: String, forceFresh: Bool = false) async throws -> PeerConnection {
+    public func establishPeerConnection(for username: String, forceFresh: Bool = false) async throws -> PeerConnection {
         guard isConnected else {
             throw NetworkError.notConnected
         }
@@ -1857,6 +1893,26 @@ public final class NetworkClient {
             return existing
         }
 
+        if !forceFresh, let inFlight = pendingEstablishments[username] {
+            return try await inFlight.value
+        }
+
+        let task = Task { [weak self] in
+            defer {
+                Task { @MainActor [weak self] in
+                    self?.pendingEstablishments.removeValue(forKey: username)
+                }
+            }
+            guard let self else { throw NetworkError.notConnected }
+            return try await self.performEstablishPeerConnection(for: username)
+        }
+        if !forceFresh {
+            pendingEstablishments[username] = task
+        }
+        return try await task.value
+    }
+
+    private func performEstablishPeerConnection(for username: String) async throws -> PeerConnection {
         let token = UInt32.random(in: 0...UInt32.max)
         registerPendingBrowse(token: token, username: username, timeout: 30)
         await sendConnectToPeer(token: token, username: username, connectionType: "P")

--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/NetworkClient.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/NetworkClient.swift
@@ -1083,9 +1083,16 @@ public final class NetworkClient {
 
     private func _performBrowseUser(_ username: String) async throws -> [SharedFile] {
         logger.debug("Browse: START browseUser(\(username))")
-        // No more `forceFresh: true` — outer coalescing in `browseUser`
-        // ensures only one in-flight call per peer at a time, so reusing
-        // an existing pool connection is safe and saves a roundtrip.
+        // Earlier code passed `forceFresh: true` here. Tracing the history
+        // (c950b1f → b80a28e → 4b73571 → ...) the original commit added
+        // the behavior with the inline comment "Always create a fresh
+        // connection for browse" — no justification given. The later
+        // refactor that introduced `forceFresh` admitted as much
+        // ("preserved until we have evidence reuse is safe"). With no
+        // documented concrete failure mode, removed. Watch for browse-
+        // returning-stale-data or browse-blocking-other-messages
+        // regressions; if they appear, restore `forceFresh` and document
+        // the actual reason this time.
         let connection = try await establishPeerConnection(for: username)
 
         logger.debug("Browse: Requesting shares from \(username)...")

--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/NetworkClient.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/NetworkClient.swift
@@ -1049,13 +1049,44 @@ public final class NetworkClient {
     // When peer connects via PierceFirewall, they send the same token we used in ConnectToPeer
     // (pendingBrowseStates is defined below in the browse section)
 
-    /// Browse a user's shared files.
+    /// Browse a user's shared files. Concurrent callers for the same `username`
+    /// are coalesced into a single establishment + a single `requestShares`
+    /// roundtrip, and all receive the same `[SharedFile]` result.
+    ///
+    /// Two layers of coalescing happen here:
+    ///   1. `pendingBrowseUserCalls` dedups the *whole operation* (connection
+    ///      + request + reply wait) so we don't issue N requestShares to
+    ///      the same peer on N concurrent browses.
+    ///   2. `establishPeerConnection` (called inside) dedups just the
+    ///      connection establishment, which also benefits non-browse
+    ///      consumers like fetchUserInfo running in parallel.
     public func browseUser(_ username: String) async throws -> [SharedFile] {
+        if let inFlight = pendingBrowseUserCalls[username] {
+            return try await inFlight.value
+        }
+
+        let task = Task<[SharedFile], Error> { [weak self] in
+            defer {
+                Task { @MainActor [weak self] in
+                    self?.pendingBrowseUserCalls.removeValue(forKey: username)
+                }
+            }
+            guard let self else { throw NetworkError.notConnected }
+            return try await self._performBrowseUser(username)
+        }
+        pendingBrowseUserCalls[username] = task
+        return try await task.value
+    }
+
+    /// Coalesced concurrent `browseUser(_:)` calls.
+    private var pendingBrowseUserCalls: [String: Task<[SharedFile], Error>] = [:]
+
+    private func _performBrowseUser(_ username: String) async throws -> [SharedFile] {
         logger.debug("Browse: START browseUser(\(username))")
-        // Historical behaviour: browse always opens a fresh P connection
-        // rather than reusing one from the pool. Preserved via `forceFresh`
-        // until we have evidence reuse is safe for large share lists.
-        let connection = try await establishPeerConnection(for: username, forceFresh: true)
+        // No more `forceFresh: true` — outer coalescing in `browseUser`
+        // ensures only one in-flight call per peer at a time, so reusing
+        // an existing pool connection is safe and saves a roundtrip.
+        let connection = try await establishPeerConnection(for: username)
 
         logger.debug("Browse: Requesting shares from \(username)...")
         try await connection.requestShares()
@@ -1077,7 +1108,9 @@ public final class NetworkClient {
         return files
     }
 
-    /// Pending continuations for browse shares responses, keyed by username
+    /// Pending continuations for browse shares responses, keyed by username.
+    /// At most one continuation per user at a time — guaranteed by the
+    /// `pendingBrowseUserCalls` coalescing in `browseUser(_:)`.
     private var pendingBrowseSharesContinuations: [String: CheckedContinuation<[SharedFile], Error>] = [:]
 
     // Pending browse state - tracks both waiting and received connections
@@ -1876,24 +1909,13 @@ public final class NetworkClient {
     /// Concurrent calls for the same `username` are coalesced via
     /// `pendingEstablishments`, so N parallel downloads to one peer share
     /// one connection establishment instead of racing each other.
-    ///
-    /// - Parameter forceFresh: when `true`, always opens a new connection.
-    ///   `browseUser` passes this because historically it was never documented
-    ///   why it created a fresh one — preserving behaviour until someone
-    ///   proves reuse is safe for share-list fetches.
-    public func establishPeerConnection(for username: String, forceFresh: Bool = false) async throws -> PeerConnection {
+    public func establishPeerConnection(for username: String) async throws -> PeerConnection {
         guard isConnected else {
             throw NetworkError.notConnected
         }
 
-        if !forceFresh, let existing = await peerConnectionPool.getConnectionForUser(username) {
+        if let existing = await peerConnectionPool.getConnectionForUser(username) {
             return existing
-        }
-
-        // forceFresh callers always want a brand-new connection, so they
-        // bypass the dedup table entirely.
-        if forceFresh {
-            return try await performEstablishPeerConnection(for: username)
         }
 
         if let inFlight = pendingEstablishments[username] {
@@ -1993,6 +2015,21 @@ public final class NetworkClient {
     /// Pending artwork request callbacks keyed by token.
     private var artworkCallbacks: [UInt32: (Data?) -> Void] = [:]
 
+    /// Coalesce concurrent `requestArtwork` calls for the same (peer, file).
+    /// UI scenarios trigger multiple loaders for the same image (list cell +
+    /// detail view + hover preview) at the same moment; without this, each
+    /// loader opens its own token-based roundtrip and the peer is asked N
+    /// times for the same artwork.
+    private struct PendingArtworkRequest {
+        var token: UInt32
+        var waiters: [(Data?) -> Void]
+    }
+    private var pendingArtworkRequests: [String: PendingArtworkRequest] = [:]
+
+    private static func artworkKey(username: String, filePath: String) -> String {
+        "\(username)|\(filePath)"
+    }
+
     /// Request artwork from a SeeleSeek peer.
     /// The completion handler is called with image data, or nil if the peer doesn't respond / isn't SeeleSeek.
     /// Only works if we already have a connection to the peer (e.g., from search results).
@@ -2002,14 +2039,26 @@ public final class NetworkClient {
             return
         }
 
+        let key = Self.artworkKey(username: username, filePath: filePath)
+
+        // Coalesce: if a request for the same (peer, file) is in flight,
+        // attach as an additional waiter and return — peer is asked once.
+        if pendingArtworkRequests[key] != nil {
+            pendingArtworkRequests[key]?.waiters.append(completion)
+            return
+        }
+
         let token = UInt32.random(in: 1..<0x8000_0000)
-        artworkCallbacks[token] = completion
+        pendingArtworkRequests[key] = PendingArtworkRequest(token: token, waiters: [completion])
+        // Bridge token → key for the artworkReply event handler.
+        artworkCallbacks[token] = { [weak self] data in
+            self?.deliverArtwork(key: key, data: data)
+        }
 
         Task {
             guard let connection = await peerConnectionPool.getConnectionForUser(username) else {
                 logger.debug("No existing connection to \(username) for artwork request")
-                artworkCallbacks.removeValue(forKey: token)
-                completion(nil)
+                deliverArtwork(key: key, data: nil)
                 return
             }
 
@@ -2017,21 +2066,55 @@ public final class NetworkClient {
             do {
                 try await connection.send(request)
             } catch {
-                if let callback = artworkCallbacks.removeValue(forKey: token) {
-                    callback(nil)
-                }
+                deliverArtwork(key: key, data: nil)
                 return
             }
 
-            // Timeout: clean up after 10 seconds if no response
-            // The reply arrives via handlePoolEvent(.artworkReply) which calls artworkCallbacks
-            Task {
+            // Timeout: deliver nil to all waiters after 10s if no reply.
+            Task { [weak self] in
                 try? await Task.sleep(for: .seconds(10))
-                if let callback = self.artworkCallbacks.removeValue(forKey: token) {
-                    callback(nil)
-                }
+                self?.deliverArtwork(key: key, data: nil)
             }
         }
+    }
+
+    /// Deliver an artwork result to every waiter for `(peer, file)` and
+    /// clean up the coalesced entry. Idempotent — late timeout firing after
+    /// the real reply already delivered finds no entry and no-ops.
+    private func deliverArtwork(key: String, data: Data?) {
+        guard let pending = pendingArtworkRequests.removeValue(forKey: key) else { return }
+        artworkCallbacks.removeValue(forKey: pending.token)
+        for waiter in pending.waiters {
+            waiter(data)
+        }
+    }
+
+    /// Test-only: register an artwork waiter directly without a peer
+    /// connection. Returns the key used internally so tests can drive
+    /// `_deliverArtworkForTest`.
+    internal func _registerArtworkWaiterForTest(
+        username: String,
+        filePath: String,
+        completion: @escaping (Data?) -> Void
+    ) -> String {
+        let key = Self.artworkKey(username: username, filePath: filePath)
+        if pendingArtworkRequests[key] != nil {
+            pendingArtworkRequests[key]?.waiters.append(completion)
+        } else {
+            pendingArtworkRequests[key] = PendingArtworkRequest(
+                token: UInt32.random(in: 1..<0x8000_0000),
+                waiters: [completion]
+            )
+        }
+        return key
+    }
+
+    internal func _deliverArtworkForTest(key: String, data: Data?) {
+        deliverArtwork(key: key, data: data)
+    }
+
+    internal func _pendingArtworkWaiterCount(key: String) -> Int {
+        pendingArtworkRequests[key]?.waiters.count ?? 0
     }
 
     /// Request folder contents from a peer. Returns the token used so the

--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/NetworkClient.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/NetworkClient.swift
@@ -1177,6 +1177,7 @@ public final class NetworkClient {
     /// The waiter, if any, fails fast instead of sitting on the 30s timeout.
     public func failPendingBrowse(token: UInt32, reason: String) {
         guard var state = pendingBrowseStates[token] else { return }
+        state.timeoutTask?.cancel()
         state.failureReason = reason
         if let continuation = state.continuation {
             state.continuation = nil
@@ -1889,7 +1890,13 @@ public final class NetworkClient {
             return existing
         }
 
-        if !forceFresh, let inFlight = pendingEstablishments[username] {
+        // forceFresh callers always want a brand-new connection, so they
+        // bypass the dedup table entirely.
+        if forceFresh {
+            return try await performEstablishPeerConnection(for: username)
+        }
+
+        if let inFlight = pendingEstablishments[username] {
             return try await inFlight.value
         }
 
@@ -1902,9 +1909,7 @@ public final class NetworkClient {
             guard let self else { throw NetworkError.notConnected }
             return try await self.performEstablishPeerConnection(for: username)
         }
-        if !forceFresh {
-            pendingEstablishments[username] = task
-        }
+        pendingEstablishments[username] = task
         return try await task.value
     }
 

--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/NetworkClient.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/NetworkClient.swift
@@ -197,9 +197,6 @@ public final class NetworkClient {
         case .searchResults(let token, let results):
             onSearchResults?(token, results)
 
-        case .incomingConnectionMatched(let username, let token, let connection):
-            Task { await onIncomingConnectionMatched?(username, token, connection) }
-
         case .fileTransferConnection(let username, let token, let connection):
             Task { await onFileTransferConnection?(username, token, connection) }
 
@@ -285,7 +282,6 @@ public final class NetworkClient {
         peerAddressHandlers.append(handler)
         logger.debug("NetworkClient: Added peer address handler (total: \(self.peerAddressHandlers.count))")
     }
-    public var onIncomingConnectionMatched: ((String, UInt32, PeerConnection) async -> Void)?  // (username, token, connection)
     public var onFileTransferConnection: ((String, UInt32, PeerConnection) async -> Void)?  // (username, token, connection)
     public var onPierceFirewall: ((UInt32, PeerConnection) async -> Void)?  // (token, connection)
     public var onUploadDenied: ((String, String) -> Void)?  // (filename, reason)

--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Storage/DownloadManager.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Storage/DownloadManager.swift
@@ -325,8 +325,12 @@ public final class DownloadManager {
         guard let pending = pendingDownloads[token] else { return }
 
         // Stash IP/port for the F-fallback path in handleTransferRequest →
-        // initiateOutgoingFileConnection. The IP/port don't change between
-        // sessions, so caching them on the pending entry is safe.
+        // initiateOutgoingFileConnection. Acceptable to cache here because
+        // the F-fallback only runs within ~60s of TransferRequest arrival;
+        // the peer's listen address is unlikely to change in that window.
+        // (If they restart their app or move networks the F-fallback will
+        // fail, the user gets a "Peer unreachable" and the retry path
+        // re-resolves the address. Not catastrophic.)
         let info = connection.peerInfo
         if !info.ip.isEmpty, info.port > 0 {
             pendingDownloads[token]?.peerIP = info.ip
@@ -344,7 +348,11 @@ public final class DownloadManager {
             // After 60s with no PlaceInQueueReply or TransferRequest, flip
             // .connecting → .waiting so the UI doesn't claim we're still
             // mid-handshake when really we're sitting in the peer's queue.
-            // Fire-and-forget; the Task is short-lived.
+            // Fire-and-forget — the Task sleeps 60s then exits; if the
+            // manager is deinit'd in that window the [weak self] check
+            // makes it a no-op. Per-startDownload, so a busy folder
+            // download spawns N of these (acceptable; each is one Task,
+            // sleeping with no allocations).
             Task { [weak self] in
                 await self?.markWaitingIfStillConnecting(token: token)
             }
@@ -426,17 +434,40 @@ public final class DownloadManager {
 
         // Salvage path: the peer is offering a file we don't have in
         // pendingDownloads (cleared by app restart, or not yet registered
-        // because resumeDownloadsOnConnect hasn't reached it). If the user
-        // still wants this file (transferState shows it in a pre-transfer
-        // state), accept the offer on the fresh connection.
+        // because resumeDownloadsOnConnect hasn't reached it). Walk
+        // transferState for a matching user-intent entry and lift it into
+        // pendingDownloads.
+        //
+        // Guards (added in response to review):
+        //   1. Skip if any pendingDownload already exists for (peer, file).
+        //      Without this, a peer that re-sends TransferRequest before our
+        //      file-connection timeout fires would create a second pending
+        //      entry with a fresh random token; both would race to receive
+        //      the F-connection.
+        //   2. Refuse to salvage `.failed` transfers — if the user (or our
+        //      retry logic) gave up, accepting the peer's offer anyway
+        //      would silently restart a download the user thought was dead.
+        //      A retry will move it back to .queued via scheduleRetry/
+        //      retryFailedDownload, at which point the next TransferRequest
+        //      is salvageable again.
+        //   3. Use stable tiebreak (oldest startTime) when transferState
+        //      has multiple matching candidates. Pre-fix `first(where:)`
+        //      depended on dictionary ordering.
+        let alreadyPending = pendingDownloads.values.contains {
+            $0.username == peerUsername && $0.filename == request.filename
+        }
         if !peerUsername.isEmpty,
-           let transfer = transferState?.downloads.first(where: { t in
-               t.direction == .download &&
-               t.username == peerUsername &&
-               t.filename == request.filename &&
-               (t.status == .queued || t.status == .waiting ||
-                t.status == .connecting || t.status == .failed)
-           }) {
+           !alreadyPending,
+           let transfer = transferState?.downloads
+               .filter({ t in
+                   t.direction == .download &&
+                   t.username == peerUsername &&
+                   t.filename == request.filename &&
+                   (t.status == .queued || t.status == .waiting ||
+                    t.status == .connecting)
+               })
+               .min(by: { ($0.startTime ?? .distantFuture) < ($1.startTime ?? .distantFuture) })
+        {
             let salvagedToken = UInt32.random(in: 1...UInt32.max)
             let info = connection.peerInfo
             pendingDownloads[salvagedToken] = PendingDownload(
@@ -2262,4 +2293,98 @@ public final class DownloadManager {
         }
     }
 
+    // MARK: - Test-only accessors
+
+    internal var _pendingDownloadCount: Int { pendingDownloads.count }
+
+    internal func _pendingDownloadFor(username: String, filename: String) -> PendingDownload? {
+        pendingDownloads.values.first { $0.username == username && $0.filename == filename }
+    }
+
+    internal func _seedPendingDownloadForTest(_ pending: PendingDownload, token: UInt32) {
+        pendingDownloads[token] = pending
+    }
+
+    /// Test-only re-entry into the salvage path. Real callers go through the
+    /// pool event stream wired in `configure(...)`.
+    internal func _handlePoolTransferRequestForTest(
+        _ request: TransferRequest,
+        connection: PeerConnection
+    ) async {
+        await handlePoolTransferRequest(request, connection: connection)
+    }
+
+    /// Test-only: evaluate the routing DECISION for an incoming pool
+    /// TransferRequest without actually executing handleTransferRequest
+    /// (which would try to send TransferReply on `connection` and clean up
+    /// on failure — racy to test on a synthetic non-connected PeerConnection).
+    /// Returns what the routing layer would do and, for `salvaged`,
+    /// transitions pendingDownloads to the post-salvage state so the caller
+    /// can inspect the new entry.
+    internal enum PoolTransferDecision: Equatable {
+        case matched(token: UInt32)
+        case salvaged(token: UInt32, transferId: UUID)
+        case dropped
+    }
+
+    internal func _evaluatePoolTransferRequestForTest(
+        _ request: TransferRequest,
+        connection: PeerConnection
+    ) -> PoolTransferDecision {
+        let peerUsername = request.username.isEmpty ? connection.peerInfo.username : request.username
+        let normalized = request.username.isEmpty && !peerUsername.isEmpty
+            ? TransferRequest(direction: request.direction, token: request.token, filename: request.filename, size: request.size, username: peerUsername)
+            : request
+
+        if let token = matchPendingDownload(for: normalized) {
+            return .matched(token: token)
+        }
+
+        let alreadyPending = pendingDownloads.values.contains {
+            $0.username == peerUsername && $0.filename == request.filename
+        }
+        guard !peerUsername.isEmpty, !alreadyPending else {
+            return .dropped
+        }
+        guard let transfer = transferState?.downloads
+            .filter({ t in
+                t.direction == .download &&
+                t.username == peerUsername &&
+                t.filename == request.filename &&
+                (t.status == .queued || t.status == .waiting || t.status == .connecting)
+            })
+            .min(by: { ($0.startTime ?? .distantFuture) < ($1.startTime ?? .distantFuture) })
+        else {
+            return .dropped
+        }
+
+        let salvagedToken = UInt32.random(in: 1...UInt32.max)
+        let info = connection.peerInfo
+        pendingDownloads[salvagedToken] = PendingDownload(
+            transferId: transfer.id,
+            username: transfer.username,
+            filename: transfer.filename,
+            size: request.size,
+            peerIP: info.ip.isEmpty ? nil : info.ip,
+            peerPort: info.port > 0 ? info.port : nil
+        )
+        return .salvaged(token: salvagedToken, transferId: transfer.id)
+    }
+
+    /// Inject a TransferTracking implementation without going through full
+    /// `configure(...)` (which requires a NetworkClient). Tests use this to
+    /// drive logic that only touches transferState.
+    ///
+    /// The real `transferState` property is `weak` (production owns its
+    /// lifecycle). For tests we additionally retain the mock strongly via
+    /// `_testStrongTransferState` so it survives across awaits — without
+    /// this, test-local mocks get released by ARC before the assertion
+    /// runs, the weak ref nils out, and the salvage path's
+    /// `transferState?.downloads` lookup returns nil.
+    internal func _setTransferStateForTest(_ tracking: any TransferTracking) {
+        self._testStrongTransferState = tracking
+        self.transferState = tracking
+    }
+
+    private var _testStrongTransferState: (any TransferTracking)?
 }

--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Storage/DownloadManager.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Storage/DownloadManager.swift
@@ -2203,15 +2203,15 @@ public final class DownloadManager {
         pendingRetries[transferId] = task
     }
 
-    /// Reset a previously-failed (or cancelled) transfer so another
-    /// `requestDownload` can re-run from byte zero. Callers MUST ensure
-    /// the transfer is eligible first — the scheduled-retry path checks
-    /// `.failed` before calling this; `retryFailedDownload` checks
-    /// `.failed || .cancelled`.
+    /// Reset a previously-failed (or cancelled) transfer so `startDownload`
+    /// can re-run from byte zero. Callers MUST ensure the transfer is
+    /// eligible first — the scheduled-retry path checks `.failed` before
+    /// calling this; `retryFailedDownload` checks `.failed || .cancelled`.
     private func retryDownload(transferId: UUID, username: String, filename: String, size: UInt64, retryCount: Int) {
         logger.info("Retrying download: \(filename) (attempt \(retryCount))")
 
-        // Update the existing transfer record
+        // Update the existing transfer record. Reset to .queued so
+        // `startDownload` (which sets it to .connecting) sees a clean slate.
         transferState?.updateTransfer(id: transferId) { t in
             t.status = .queued
             t.error = nil
@@ -2219,9 +2219,22 @@ public final class DownloadManager {
             t.retryCount = retryCount
         }
 
-        // Re-initiate the download
+        // Re-initiate via the normal startDownload path so the retry uses
+        // the same `establishPeerConnection` + `queueOnConnection` flow as
+        // a fresh download. The old `requestDownload` helper bypassed this
+        // (called `getUserAddress` directly and relied on the now-removed
+        // `handlePeerAddress` to drive forward).
+        let transfer = Transfer(
+            id: transferId,
+            username: username,
+            filename: filename,
+            size: size,
+            direction: .download,
+            status: .queued,
+            retryCount: retryCount
+        )
         Task {
-            await requestDownload(username: username, filename: filename, size: size, existingTransferId: transferId)
+            await startDownload(transfer: transfer)
         }
     }
 
@@ -2249,45 +2262,4 @@ public final class DownloadManager {
         }
     }
 
-    /// Request download with optional existing transfer ID (for retries)
-    private func requestDownload(username: String, filename: String, size: UInt64, existingTransferId: UUID?) async {
-        guard let networkClient else { return }
-
-        // Get or create transfer
-        let transferId: UUID
-        if let existing = existingTransferId {
-            transferId = existing
-        } else {
-            let transfer = Transfer(
-                username: username,
-                filename: filename,
-                size: size,
-                direction: .download,
-                status: .queued
-            )
-            transferState?.addDownload(transfer)
-            transferId = transfer.id
-        }
-
-        do {
-            // Request peer address to establish connection
-            // This will trigger the normal download flow via handlePeerAddress callback
-            let token = UInt32.random(in: 1...UInt32.max)
-            pendingDownloads[token] = PendingDownload(
-                transferId: transferId,
-                username: username,
-                filename: filename,
-                size: size
-            )
-
-            try await networkClient.getUserAddress(username)
-            logger.info("Requested peer address for retry: \(username)")
-        } catch {
-            logger.error("Retry download failed: \(error.localizedDescription)")
-            transferState?.updateTransfer(id: transferId) { t in
-                t.status = .failed
-                t.error = error.localizedDescription
-            }
-        }
-    }
 }

--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Storage/DownloadManager.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Storage/DownloadManager.swift
@@ -47,7 +47,14 @@ public final class DownloadManager {
         public let username: String
         public let filename: String
         public var size: UInt64
-        public var peerConnection: PeerConnection?
+        // We deliberately do NOT cache a PeerConnection here. The pool is the
+        // single source of truth for live connections — caching one on the
+        // pending entry leads to stale references when the original
+        // connection dies between queueing the download and the peer
+        // actually delivering its TransferRequest hours later. Look up the
+        // current connection via `peerConnectionPool.getConnectionForUser`
+        // at send time, or use the connection that delivered the event you
+        // are reacting to.
         public var peerIP: String?       // Store peer IP for outgoing F connection
         public var peerPort: Int?        // Store peer port for outgoing F connection
         public var resumeOffset: UInt64 = 0  // For resuming partial downloads
@@ -55,14 +62,6 @@ public final class DownloadManager {
 
     // Track partial downloads for resume
     private var partialDownloads: [String: URL] = [:]  // filename -> partial file path
-
-    // MARK: - Pending Indirect Connection State (for racing direct vs PierceFirewall)
-    private struct PendingIndirectState {
-        let username: String
-        var receivedConnection: PeerConnection?
-        var failed = false  // Set by CantConnectToPeer
-    }
-    private var pendingIndirectStates: [UInt32: PendingIndirectState] = [:]
 
     public struct PendingFileTransfer {
         public let transferId: UUID
@@ -111,22 +110,14 @@ public final class DownloadManager {
         self.settings = settings
         self.metadataReader = metadataReader
 
-        // Set up callbacks for peer address responses using multi-listener pattern
-        logger.info("Adding peer address handler")
-        networkClient.addPeerAddressHandler { [weak self] username, ip, port in
-            self?.logger.debug("Peer address handler called: \(username) @ \(ip):\(port)")
-            Task { @MainActor in
-                await self?.handlePeerAddress(username: username, ip: ip, port: port)
-            }
-        }
-
-        // Set up callback for incoming connections that match pending downloads
-        networkClient.onIncomingConnectionMatched = { [weak self] username, token, connection in
-            guard let self else { return }
-            Task { @MainActor in
-                await self.handleIncomingConnection(username: username, token: token, connection: connection)
-            }
-        }
+        // Connection establishment for downloads now goes through
+        // NetworkClient.establishPeerConnection (which is shared with
+        // browse/folder-contents/user-info). That means DownloadManager no
+        // longer needs to react to GetPeerAddress responses or
+        // incomingConnectionMatched — the establishment helper drives the
+        // ConnectToPeer + direct/indirect race itself, so the previous
+        // addPeerAddressHandler / onIncomingConnectionMatched registrations
+        // are intentionally absent.
 
         // Set up callback for incoming file transfer connections
         networkClient.onFileTransferConnection = { [weak self] username, token, connection in
@@ -298,12 +289,10 @@ public final class DownloadManager {
 
         let token = UInt32.random(in: 0...UInt32.max)
 
-        // Update status to connecting
         transferState.updateTransfer(id: transfer.id) { t in
             t.status = .connecting
         }
 
-        // Store pending download
         pendingDownloads[token] = PendingDownload(
             transferId: transfer.id,
             username: transfer.username,
@@ -313,411 +302,110 @@ public final class DownloadManager {
             peerPort: nil
         )
 
-        logger.info("Starting download from \(transfer.username), token=\(token)")
-
-        // If a live P-connection to this peer already exists (e.g. from a
-        // recent folder-contents fetch or another download), reuse it instead
-        // of running another GetPeerAddress + ConnectToPeer + 30s race. The
-        // pool already prunes stale entries inside `getConnectionForUser`.
-        if let existing = await networkClient.peerConnectionPool.getConnectionForUser(transfer.username) {
-            await reuseConnectionForDownload(token: token, connection: existing)
-            return
-        }
-
         do {
-            // Step 1: Get peer address
-            logger.debug("Requesting peer address for \(transfer.username)")
-            try await networkClient.getUserAddress(transfer.username)
-
-            // Poll every 500ms for up to 30s, checking if connection was established
-            // handlePeerAddress() will set peerConnection or remove the pending entry
-            var elapsed: TimeInterval = 0
-            let timeoutSeconds: TimeInterval = 30
-            while elapsed < timeoutSeconds {
-                try await Task.sleep(for: .milliseconds(500))
-                elapsed += 0.5
-                // Connection established by handlePeerAddress
-                if pendingDownloads[token]?.peerConnection != nil { return }
-                // Already handled (removed from pending by handlePeerAddress or other handler)
-                if pendingDownloads[token] == nil { return }
-            }
-
-            // Timed out - mark as failed and schedule retry
-            if pendingDownloads[token] != nil {
-                let errorMsg = "Connection timeout"
-                let currentRetryCount = transferState.getTransfer(id: transfer.id)?.retryCount ?? 0
-
-                transferState.updateTransfer(id: transfer.id) { t in
-                    t.status = .failed
-                    t.error = errorMsg
-                }
-                pendingDownloads.removeValue(forKey: token)
-
-                // Auto-retry for connection timeouts
-                if currentRetryCount < maxRetries {
-                    scheduleRetry(
-                        transferId: transfer.id,
-                        username: transfer.username,
-                        filename: transfer.filename,
-                        size: transfer.size,
-                        retryCount: currentRetryCount
-                    )
-                }
-            }
+            // Single shared establishment dance — the same one browse,
+            // folder-contents, and user-info use. Reuses an existing pool
+            // connection if there is one; otherwise races direct vs
+            // PierceFirewall. Concurrent calls for the same peer are
+            // coalesced inside NetworkClient, so a folder-batch of N
+            // downloads opens one connection, not N.
+            let connection = try await networkClient.establishPeerConnection(for: transfer.username)
+            await queueOnConnection(token: token, connection: connection)
         } catch {
-            logger.error("Download failed: \(error.localizedDescription)")
-            let currentRetryCount = transferState.getTransfer(id: transfer.id)?.retryCount ?? 0
-
-            transferState.updateTransfer(id: transfer.id) { t in
-                t.status = .failed
-                t.error = error.localizedDescription
-            }
-            pendingDownloads.removeValue(forKey: token)
-
-            // Auto-retry for retriable errors
-            if isRetriableError(error.localizedDescription) && currentRetryCount < maxRetries {
-                scheduleRetry(
-                    transferId: transfer.id,
-                    username: transfer.username,
-                    filename: transfer.filename,
-                    size: transfer.size,
-                    retryCount: currentRetryCount
-                )
-            }
+            logger.error("startDownload(\(transfer.filename)): \(error.localizedDescription)")
+            failPending(token: token, reason: error.localizedDescription)
         }
     }
 
-    /// Queue a download on an already-live peer connection. Mirrors the
-    /// existing-connection branch inside `handlePeerAddress` but is reachable
-    /// from `startDownload` directly so we can skip the address-lookup +
-    /// ConnectToPeer dance entirely when the pool already has a connection.
-    private func reuseConnectionForDownload(token: UInt32, connection: PeerConnection) async {
-        guard let transferState, let pending = pendingDownloads[token] else { return }
+    /// Send QueueDownload + PlaceInQueueRequest for a pending download on a
+    /// live connection. Used by every "kick this download forward" call site
+    /// (start, resume, periodic re-queue, salvage). Does NOT cache the
+    /// connection — see `PendingDownload`'s docstring.
+    private func queueOnConnection(token: UInt32, connection: PeerConnection) async {
+        guard let pending = pendingDownloads[token] else { return }
 
-        // Stash IP/port from the live connection so the later
-        // outbound-F-connection fallback (NAT traversal in
-        // initiateOutgoingFileConnection) still has a target if the peer
-        // can't reach us directly for the file transfer.
+        // Stash IP/port for the F-fallback path in handleTransferRequest →
+        // initiateOutgoingFileConnection. The IP/port don't change between
+        // sessions, so caching them on the pending entry is safe.
         let info = connection.peerInfo
         if !info.ip.isEmpty, info.port > 0 {
             pendingDownloads[token]?.peerIP = info.ip
             pendingDownloads[token]?.peerPort = info.port
         }
-        pendingDownloads[token]?.peerConnection = connection
-
-        logger.info("Reusing existing connection to \(pending.username) for \(pending.filename)")
 
         do {
-            await setupTransferRequestCallback(token: token, connection: connection)
             try await connection.queueDownload(filename: pending.filename)
             do {
                 try await connection.sendPlaceInQueueRequest(filename: pending.filename)
             } catch {
-                logger.warning("sendPlaceInQueueRequest(\(pending.filename)) failed: \(error.localizedDescription)")
+                logger.warning("PlaceInQueueRequest(\(pending.filename)) failed: \(error.localizedDescription)")
             }
-            await waitForTransferResponse(token: token)
+            logger.info("Queued \(pending.filename) with \(pending.username)")
+            // After 60s with no PlaceInQueueReply or TransferRequest, flip
+            // .connecting → .waiting so the UI doesn't claim we're still
+            // mid-handshake when really we're sitting in the peer's queue.
+            // Fire-and-forget; the Task is short-lived.
+            Task { [weak self] in
+                await self?.markWaitingIfStillConnecting(token: token)
+            }
         } catch {
-            logger.error("Failed to queue on reused connection: \(error.localizedDescription)")
+            logger.error("queueOnConnection(\(pending.filename)): \(error.localizedDescription)")
+            failPending(token: token, reason: error.localizedDescription)
+        }
+    }
+
+    private func markWaitingIfStillConnecting(token: UInt32) async {
+        try? await Task.sleep(for: .seconds(60))
+        guard let transferState, let pending = pendingDownloads[token] else { return }
+        if let current = transferState.getTransfer(id: pending.transferId), current.status == .connecting {
             transferState.updateTransfer(id: pending.transferId) { t in
-                t.status = .failed
-                t.error = error.localizedDescription
+                t.status = .waiting
             }
-            pendingDownloads.removeValue(forKey: token)
         }
     }
 
-    private func handlePeerAddress(username: String, ip: String, port: Int) async {
-        guard let networkClient, let transferState else {
-            logger.error("handlePeerAddress: NetworkClient or TransferState is nil")
-            return
+    /// Fail a pending download, remove its entry, and schedule a retry if
+    /// eligible. Centralizes the error-handling that used to be sprinkled
+    /// across startDownload/handlePeerAddress/queue paths.
+    private func failPending(token: UInt32, reason: String) {
+        guard let transferState, let pending = pendingDownloads[token] else { return }
+        let currentRetryCount = transferState.getTransfer(id: pending.transferId)?.retryCount ?? 0
+        transferState.updateTransfer(id: pending.transferId) { t in
+            t.status = .failed
+            t.error = reason
         }
-
-        // Find ALL pending downloads for this user (not just first)
-        let matchingEntries = pendingDownloads.filter { $0.value.username == username }
-        guard !matchingEntries.isEmpty else {
-            logger.debug("No pending download for \(username)")
-            return
+        pendingDownloads.removeValue(forKey: token)
+        if isRetriableError(reason) && currentRetryCount < maxRetries {
+            scheduleRetry(
+                transferId: pending.transferId,
+                username: pending.username,
+                filename: pending.filename,
+                size: pending.size,
+                retryCount: currentRetryCount
+            )
         }
-
-        // Use first entry as the "primary" for connection establishment
-        let (token, pending) = matchingEntries.first!
-        let additionalEntries = matchingEntries.filter { $0.key != token }
-
-        logger.info("Peer address for \(username): \(ip):\(port), token=\(token) (\(matchingEntries.count) pending downloads)")
-
-        // Store peer address for all pending downloads
-        for (t, _) in matchingEntries {
-            pendingDownloads[t]?.peerIP = ip
-            pendingDownloads[t]?.peerPort = port
-        }
-
-        // First, check if we already have a connection to this user (from incoming connections)
-        if let existingConnection = await networkClient.peerConnectionPool.getConnectionForUser(username) {
-            logger.info("Reusing existing connection to \(username)")
-            pendingDownloads[token]?.peerConnection = existingConnection
-
-            do {
-                await setupTransferRequestCallback(token: token, connection: existingConnection)
-                try await existingConnection.queueDownload(filename: pending.filename)
-                do {
-                    try await existingConnection.sendPlaceInQueueRequest(filename: pending.filename)
-                } catch {
-                    logger.warning("sendPlaceInQueueRequest(\(pending.filename)) failed: \(error.localizedDescription)")
-                }
-                logger.info("Sent QueueDownload for \(pending.filename)")
-
-                // Also queue additional downloads on the same connection
-                for (extraToken, extraPending) in additionalEntries {
-                    pendingDownloads[extraToken]?.peerConnection = existingConnection
-                    await setupTransferRequestCallback(token: extraToken, connection: existingConnection)
-                    do {
-                        try await existingConnection.queueDownload(filename: extraPending.filename)
-                        try await existingConnection.sendPlaceInQueueRequest(filename: extraPending.filename)
-                    } catch {
-                        logger.warning("Failed to batch-queue \(extraPending.filename): \(error.localizedDescription)")
-                    }
-                    logger.info("Sent QueueDownload for additional: \(extraPending.filename)")
-                }
-
-                await waitForTransferResponse(token: token)
-            } catch {
-                logger.error("Failed to queue download on existing connection: \(error.localizedDescription)")
-                transferState.updateTransfer(id: pending.transferId) { t in
-                    t.status = .failed
-                    t.error = error.localizedDescription
-                }
-                pendingDownloads.removeValue(forKey: token)
-            }
-            return
-        }
-
-        // CRITICAL: Register pending indirect BEFORE sending ConnectToPeer to avoid race condition
-        // PierceFirewall can arrive immediately after ConnectToPeer is sent!
-        registerPendingIndirect(token: token, username: username, timeout: 30)
-
-        // Send ConnectToPeer to server - starts indirect path in parallel
-        // Server will tell the peer to connect to us via PierceFirewall
-        await networkClient.sendConnectToPeer(token: token, username: username, connectionType: "P")
-        logger.info("Sent ConnectToPeer for \(username), racing direct vs indirect...")
-
-        // Race: direct connection + handshake (10s) vs indirect (PierceFirewall)
-        var connection: PeerConnection
-        var isIndirect = false
-
-        do {
-            connection = try await withThrowingTaskGroup(of: PeerConnection.self) { group in
-                group.addTask {
-                    let conn = try await networkClient.peerConnectionPool.connect(
-                        to: username, ip: ip, port: port, token: token
-                    )
-                    // Must also complete handshake - peer may not respond if they
-                    // already connected to us via PierceFirewall
-                    try await conn.waitForPeerHandshake(timeout: .seconds(8))
-                    return conn
-                }
-                group.addTask {
-                    try await Task.sleep(for: .seconds(10))
-                    throw NetworkError.timeout
-                }
-                let result = try await group.next()!
-                group.cancelAll()
-                return result
-            }
-            cancelPendingIndirect(token: token)
-            logger.info("Direct connection + handshake to \(username) succeeded")
-        } catch {
-            // Direct timed out or failed - wait for indirect (PierceFirewall) connection
-            logger.info("Direct connection failed (\(error.localizedDescription)), waiting for indirect...")
-            transferState.updateTransfer(id: pending.transferId) { t in
-                t.status = .connecting
-                t.error = "Trying indirect connection..."
-            }
-
-            do {
-                connection = try await waitForPendingIndirect(token: token)
-                isIndirect = true
-                logger.info("Got indirect connection from \(username)")
-            } catch {
-                // Both paths failed - fail all pending downloads for this user
-                logger.error("Both direct and indirect connections to \(username) failed")
-                let isSameNetwork = networkClient.externalIP == ip
-                let errorMsg = isSameNetwork
-                    ? "Same network - hairpin NAT limitation"
-                    : "Connection timeout - peer unreachable"
-
-                for (failToken, failPending) in matchingEntries {
-                    let currentRetryCount = transferState.getTransfer(id: failPending.transferId)?.retryCount ?? 0
-                    transferState.updateTransfer(id: failPending.transferId) { t in
-                        t.status = .failed
-                        t.error = errorMsg
-                    }
-                    pendingDownloads.removeValue(forKey: failToken)
-
-                    if !isSameNetwork && currentRetryCount < maxRetries {
-                        scheduleRetry(
-                            transferId: failPending.transferId,
-                            username: failPending.username,
-                            filename: failPending.filename,
-                            size: failPending.size,
-                            retryCount: currentRetryCount
-                        )
-                    }
-                }
-                return
-            }
-        }
-
-        if isIndirect {
-            // Resume receive loop - PierceFirewall stops it assuming file transfer mode,
-            // but P connections need to continue receiving peer messages
-            await connection.resumeReceivingForPeerConnection()
-        }
-
-        // Got a connection - send QueueDownload for all pending downloads
-        pendingDownloads[token]?.peerConnection = connection
-
-        do {
-            if isIndirect {
-                // For indirect connections, identify ourselves to the peer
-                try await connection.sendPeerInit(username: networkClient.username)
-                logger.debug("Sent PeerInit via indirect connection")
-            }
-
-            await setupTransferRequestCallback(token: token, connection: connection)
-            try await connection.queueDownload(filename: pending.filename)
-            do {
-                try await connection.sendPlaceInQueueRequest(filename: pending.filename)
-            } catch {
-                logger.warning("sendPlaceInQueueRequest(\(pending.filename)) failed: \(error.localizedDescription)")
-            }
-            logger.info("Sent QueueDownload for \(pending.filename)")
-
-            // Also queue additional downloads on the same connection
-            for (extraToken, extraPending) in additionalEntries {
-                pendingDownloads[extraToken]?.peerConnection = connection
-                await setupTransferRequestCallback(token: extraToken, connection: connection)
-                do {
-                    try await connection.queueDownload(filename: extraPending.filename)
-                    try await connection.sendPlaceInQueueRequest(filename: extraPending.filename)
-                } catch {
-                    logger.warning("Failed to batch-queue \(extraPending.filename): \(error.localizedDescription)")
-                }
-                logger.info("Sent QueueDownload for additional: \(extraPending.filename)")
-            }
-
-            await waitForTransferResponse(token: token)
-        } catch {
-            logger.error("Failed to queue download: \(error.localizedDescription)")
-            transferState.updateTransfer(id: pending.transferId) { t in
-                t.status = .failed
-                t.error = error.localizedDescription
-            }
-            pendingDownloads.removeValue(forKey: token)
-        }
-    }
-
-    // MARK: - Pending Indirect Connection Helpers
-
-    /// Register a pending indirect download BEFORE sending ConnectToPeer (to avoid race condition)
-    private func registerPendingIndirect(token: UInt32, username: String, timeout: TimeInterval) {
-        pendingIndirectStates[token] = PendingIndirectState(username: username)
-    }
-
-    /// Wait for PierceFirewall to arrive for a previously registered token (polling-based, no continuation leak)
-    private func waitForPendingIndirect(token: UInt32, timeout: TimeInterval = 30) async throws -> PeerConnection {
-        let deadline = Date().addingTimeInterval(timeout)
-
-        while Date() < deadline {
-            if let state = pendingIndirectStates[token] {
-                if let connection = state.receivedConnection {
-                    pendingIndirectStates.removeValue(forKey: token)
-                    return connection
-                }
-                if state.failed {
-                    pendingIndirectStates.removeValue(forKey: token)
-                    throw NetworkError.connectionFailed("Peer unreachable")
-                }
-            } else {
-                // State was removed (cancelled)
-                throw NetworkError.timeout
-            }
-
-            try await Task.sleep(for: .milliseconds(100))
-        }
-
-        // Timed out
-        pendingIndirectStates.removeValue(forKey: token)
-        throw NetworkError.timeout
-    }
-
-    /// Cancel a pending indirect download (used when direct connection succeeds)
-    private func cancelPendingIndirect(token: UInt32) {
-        pendingIndirectStates.removeValue(forKey: token)
-    }
-
-    /// Called when PierceFirewall arrives - check if it matches a racing download
-    /// Returns true if it was handled
-    private func handlePierceFirewallForRace(token: UInt32, connection: PeerConnection) -> Bool {
-        guard let state = pendingIndirectStates[token] else {
-            return false
-        }
-
-        logger.info("PierceFirewall token=\(token) matched racing download for \(state.username)")
-
-        Task {
-            await connection.setPeerUsername(state.username)
-        }
-
-        pendingIndirectStates[token]?.receivedConnection = connection
-        return true
-    }
-
-    /// TransferRequest routing is now handled centrally via the pool event stream.
-    /// All transfer requests arrive through NetworkClient.onTransferRequest → handlePoolTransferRequest.
-    /// This method is kept as a no-op to avoid changing all call sites.
-    private func setupTransferRequestCallback(token: UInt32, connection: PeerConnection) async {
-        logger.debug("TransferRequest routing via pool event stream (token=\(token))")
     }
 
     private func matchPendingDownload(for request: TransferRequest) -> UInt32? {
-        let (token, ambiguous) = Self.matchPendingDownload(request: request, pending: pendingDownloads)
-        if ambiguous {
-            logger.warning("Refusing ambiguous TransferRequest match for filename \(request.filename)")
-        }
-        return token
+        Self.matchPendingDownload(request: request, pending: pendingDownloads)
     }
 
-    /// Token → (username, filename) → filename-only (only when unambiguous).
-    /// Reused connections can arrive with empty `request.username`, so a
-    /// filename-only fallback is retained — but ambiguous cases return `nil`
-    /// rather than guess. `ambiguous` is true when the fallback refused to match.
+    /// Token → (username, filename). The earlier filename-only fallback
+    /// could misroute when two different peers happened to be sending the
+    /// same filename; it was only needed because `request.username` used
+    /// to arrive empty on reused connections. `handlePoolTransferRequest`
+    /// now normalizes the request with the connection's authoritative
+    /// `peerInfo.username` before calling this, so the fallback is gone.
     static func matchPendingDownload(
         request: TransferRequest,
         pending: [UInt32: PendingDownload]
-    ) -> (token: UInt32?, ambiguous: Bool) {
+    ) -> UInt32? {
         if pending[request.token] != nil {
-            return (request.token, false)
+            return request.token
         }
-        if let (token, _) = pending.first(where: { (_, p) in
+        return pending.first { (_, p) in
             p.username == request.username && p.filename == request.filename
-        }) {
-            return (token, false)
-        }
-        let filenameMatches = pending.filter { (_, p) in p.filename == request.filename }
-        if filenameMatches.count == 1 {
-            return (filenameMatches.first?.key, false)
-        }
-        return (nil, filenameMatches.count > 1)
-    }
-
-    private func handleTransferRequestByFilename(request: TransferRequest, fallbackToken: UInt32) async {
-        if let token = matchPendingDownload(for: request) {
-            logger.debug("Matched TransferRequest to pending download: user=\(request.username) file=\(request.filename)")
-            await handleTransferRequest(token: token, request: request)
-        } else {
-            logger.debug("No match for TransferRequest, using fallback token=\(fallbackToken)")
-            await handleTransferRequest(token: fallbackToken, request: request)
-        }
+        }?.key
     }
 
     private func handlePoolTransferRequest(_ request: TransferRequest, connection: PeerConnection) async {
@@ -731,14 +419,8 @@ public final class DownloadManager {
             : request
 
         if let token = matchPendingDownload(for: normalizedRequest) {
-            // Replace the cached connection. The one we stashed when first
-            // queueing the download (e.g. an early incoming connection) is
-            // often dead by the time the peer's upload queue drains and
-            // they reach us with TransferRequest. The fresh connection that
-            // delivered THIS request is the one we must reply on.
-            pendingDownloads[token]?.peerConnection = connection
             logger.info("Pool TransferRequest matched pending download: user=\(peerUsername) file=\(request.filename)")
-            await handleTransferRequest(token: token, request: normalizedRequest)
+            await handleTransferRequest(token: token, request: normalizedRequest, connection: connection)
             return
         }
 
@@ -762,63 +444,40 @@ public final class DownloadManager {
                 username: transfer.username,
                 filename: transfer.filename,
                 size: request.size,
-                peerConnection: connection,
                 peerIP: info.ip.isEmpty ? nil : info.ip,
                 peerPort: info.port > 0 ? info.port : nil
             )
             logger.info("Pool TransferRequest salvaged from transferState: user=\(peerUsername) file=\(request.filename) (token=\(salvagedToken))")
-            await handleTransferRequest(token: salvagedToken, request: normalizedRequest)
+            await handleTransferRequest(token: salvagedToken, request: normalizedRequest, connection: connection)
             return
         }
 
         logger.info("Pool TransferRequest dropped — no pending or transferState match: user=\(peerUsername) file=\(request.filename)")
     }
 
-    private func waitForTransferResponse(token: UInt32) async {
-        guard let transferState, let pending = pendingDownloads[token] else { return }
-
-        // Wait for the transfer to complete or timeout
-        do {
-            try await Task.sleep(for: .seconds(60))
-
-            // Still waiting - only mark as waiting if still in .connecting status
-            // Don't overwrite .transferring or other statuses
-            if pendingDownloads[token] != nil {
-                await MainActor.run {
-                    if let currentTransfer = transferState.getTransfer(id: pending.transferId),
-                       currentTransfer.status == .connecting {
-                        transferState.updateTransfer(id: pending.transferId) { t in
-                            t.status = .waiting
-                        }
-                    }
-                }
-            }
-        } catch {
-            // Task was cancelled or other error
-        }
-    }
-
-    private func handleTransferRequest(token: UInt32, request: TransferRequest) async {
+    private func handleTransferRequest(token: UInt32, request: TransferRequest, connection: PeerConnection) async {
         guard let transferState, let pending = pendingDownloads[token] else { return }
 
         let directionStr = request.direction == .upload ? "upload" : "download"
         logger.info("Transfer request received: direction=\(directionStr) size=\(request.size) from \(request.username)")
 
         if request.direction == .upload {
-            // Peer is ready to upload to us - send acceptance reply
-            if let connection = pending.peerConnection {
-                do {
-                    try await connection.sendTransferReply(token: request.token, allowed: true)
-                    logger.info("Sent transfer reply accepting upload for token \(request.token)")
-                } catch {
-                    logger.error("Failed to send transfer reply: \(error.localizedDescription)")
-                    transferState.updateTransfer(id: pending.transferId) { t in
-                        t.status = .failed
-                        t.error = "Failed to accept transfer"
-                    }
-                    pendingDownloads.removeValue(forKey: token)
-                    return
+            // Peer is ready to upload to us — send acceptance reply on the
+            // connection that delivered THIS request, not on a cached one.
+            // The cached one is often dead by the time the peer's queue
+            // drains; replying on it surfaces as "send() - no connection!"
+            // and the peer never gets our acceptance.
+            do {
+                try await connection.sendTransferReply(token: request.token, allowed: true)
+                logger.info("Sent transfer reply accepting upload for token \(request.token)")
+            } catch {
+                logger.error("Failed to send transfer reply: \(error.localizedDescription)")
+                transferState.updateTransfer(id: pending.transferId) { t in
+                    t.status = .failed
+                    t.error = "Failed to accept transfer"
                 }
+                pendingDownloads.removeValue(forKey: token)
+                return
             }
 
             // Register pending file transfer - peer will connect to us with type "F"
@@ -1550,45 +1209,13 @@ public final class DownloadManager {
 
     // MARK: - Incoming Connection Handling
 
-    /// Called when we receive an indirect connection from a peer
-    public func handleIncomingConnection(username: String, token: UInt32, connection: PeerConnection) async {
-        guard let pending = pendingDownloads[token] else {
-            // Not a download we're waiting for
-            return
-        }
-
-        guard let networkClient else {
-            logger.error("NetworkClient is nil in handleIncomingConnection")
-            return
-        }
-
-        logger.info("Indirect connection established with \(username) for token \(token)")
-
-        pendingDownloads[token]?.peerConnection = connection
-
-        // Send PeerInit + QueueDownload
-        // Per protocol: We need to send PeerInit to identify ourselves before QueueUpload
-        do {
-            // Send PeerInit FIRST - identifies us to the peer (token=0 for P connections)
-            try await connection.sendPeerInit(username: networkClient.username)
-            logger.debug("Sent PeerInit via indirect connection")
-
-            // Set up callback BEFORE sending QueueDownload to avoid race condition
-            await setupTransferRequestCallback(token: token, connection: connection)
-
-            try await connection.queueDownload(filename: pending.filename)
-            do {
-                try await connection.sendPlaceInQueueRequest(filename: pending.filename)
-            } catch {
-                logger.warning("sendPlaceInQueueRequest(\(pending.filename)) failed: \(error.localizedDescription)")
-            }
-            logger.info("Sent QueueDownload via indirect connection")
-
-            await waitForTransferResponse(token: token)
-        } catch {
-            logger.error("Failed to queue download: \(error.localizedDescription)")
-        }
-    }
+    // The old `handleIncomingConnection(username:token:connection:)` lived
+    // here. It was wired to `NetworkClient.onIncomingConnectionMatched`, which
+    // fires when an incoming PeerInit's token matches `pendingConnections` in
+    // the pool. Nothing populates `pendingConnections` (no caller of
+    // `addPendingConnection`), so the path was dead. The
+    // ConnectToPeer/PierceFirewall race is now owned end-to-end by
+    // NetworkClient.establishPeerConnection.
 
     /// Called when a peer opens a file transfer connection to us (type "F")
     /// Per SoulSeek protocol: After PeerInit, uploader sends FileTransferInit token (4 bytes)
@@ -2127,46 +1754,40 @@ public final class DownloadManager {
 
     // MARK: - PierceFirewall Handling (Indirect Connections)
 
-    /// Called when a peer sends PierceFirewall - indirect connection established
+    /// Called when a peer sends PierceFirewall — indirect connection established.
+    /// NetworkClient already routes browse/folder/userinfo/download race winners
+    /// via `handlePierceFirewallForBrowse` (since downloads now use the shared
+    /// `establishPeerConnection` path). What's left to handle here is the
+    /// upload-side delegation: PierceFirewall arrives in response to a peer's
+    /// pending upload, and UploadManager owns that flow.
     public func handlePierceFirewall(token: UInt32, connection: PeerConnection) async {
         logger.debug("handlePierceFirewall: token=\(token)")
 
-        // Check if this matches a racing download (handlePeerAddress is waiting for this)
-        if handlePierceFirewallForRace(token: token, connection: connection) {
-            logger.debug("PierceFirewall handled by download race")
-            return
-        }
-
-        // Check if this is for a pending upload
         if let uploadManager, uploadManager.hasPendingUpload(token: token) {
             logger.debug("PierceFirewall token \(token) delegated to UploadManager")
             await uploadManager.handlePierceFirewall(token: token, connection: connection)
             return
         }
 
-        logger.debug("No pending download/upload for PierceFirewall token \(token)")
+        logger.debug("No pending upload for PierceFirewall token \(token)")
     }
 
     // MARK: - CantConnectToPeer Handling
 
-    /// Server tells us the peer couldn't connect to us — fail-fast instead of waiting for timeout
+    /// Server tells us the peer couldn't connect to us — fail fast instead of
+    /// waiting for the 30s timeout. Browse/folder/userinfo/download races all
+    /// share `pendingBrowseStates` in NetworkClient, so we forward there;
+    /// uploads have their own pending tracking in UploadManager.
     private func handleCantConnectToPeer(token: UInt32) {
-        // Check if this matches a racing download waiting for indirect connection
-        if var state = pendingIndirectStates[token] {
-            logger.warning("CantConnectToPeer for download token \(token) — failing indirect wait")
-            state.failed = true
-            pendingIndirectStates[token] = state
-            return
-        }
+        networkClient?.failPendingBrowse(token: token, reason: "Peer unreachable (CantConnectToPeer)")
 
-        // Check if this is for a pending upload
         if let uploadManager, uploadManager.hasPendingUpload(token: token) {
             logger.warning("CantConnectToPeer for upload token \(token) — failing upload")
             uploadManager.handleCantConnectToPeer(token: token)
             return
         }
 
-        logger.debug("CantConnectToPeer token \(token) — no matching pending transfer")
+        logger.debug("CantConnectToPeer token \(token) — forwarded to pending-browse + upload paths")
     }
 
     // MARK: - Periodic Re-Queue (nicotine+ style)

--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Storage/UploadManager.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Storage/UploadManager.swift
@@ -44,8 +44,14 @@ public final class UploadManager {
         public let filename: String
         public let localPath: String
         public let size: UInt64
-        public let connection: PeerConnection
         public let queuedAt: Date
+        // We deliberately do NOT cache a PeerConnection here. The cached
+        // connection is the one the peer used at the moment of QueueUpload;
+        // by the time we get around to broadcasting queue positions or
+        // starting the upload it's often dead, and `send()` fails silently
+        // on a closed connection. Resolve via
+        // `peerConnectionPool.getConnectionForUser(username)` at every send
+        // site instead. Same fix as the DownloadManager refactor.
     }
 
     public struct ActiveUpload {

--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Storage/UploadManager.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Storage/UploadManager.swift
@@ -19,7 +19,12 @@ public final class UploadManager {
     private var uploadQueue: [QueuedUpload] = []
     private var activeUploads: [UUID: ActiveUpload] = [:]
     private var pendingTransfers: [UInt32: PendingUpload] = [:]  // token -> pending
-    private var pendingAddressLookups: [String: [(PendingUpload, UInt32)]] = [:]  // username -> [(pending, token)]
+    /// Per-token timeout for "peer didn't reply to TransferRequest". Cancelled
+    /// by handleTransferResponse so the timer doesn't fire after the response
+    /// arrives — without this, the same `pendingTransfers[token]` entry that
+    /// gets re-registered for PierceFirewall handling would be falsely
+    /// flagged as a no-response timeout 60s after the original TransferRequest.
+    private var transferResponseTimeouts: [UInt32: Task<Void, Never>] = [:]
 
     // Configuration
     public var maxConcurrentUploads = 3
@@ -72,7 +77,7 @@ public final class UploadManager {
         public let localPath: String
         public let size: UInt64
         public let token: UInt32
-        public let connection: PeerConnection
+        // No cached PeerConnection — see QueuedUpload's docstring for why.
     }
 
     // MARK: - Errors
@@ -137,16 +142,11 @@ public final class UploadManager {
             }
         }
 
-        // Set up callback for peer address using multi-listener pattern
-        // This replaces the fragile callback chaining approach that could break if
-        // DownloadManager was configured after UploadManager
-        networkClient.addPeerAddressHandler { [weak self] username, ip, port in
-            self?.logger.debug("Peer address handler called: \(username) @ \(ip):\(port)")
-            guard let self else { return }
-            Task { @MainActor in
-                await self.handlePeerAddressForUpload(username: username, ip: ip, port: port)
-            }
-        }
+        // Peer-address resolution for uploads now uses
+        // `NetworkClient.getPeerAddress(for:timeout:)` directly inside
+        // `handleTransferResponse` (await-style with timeout). The previous
+        // addPeerAddressHandler + pendingAddressLookups dance was a manual
+        // re-implementation of the same coalescing logic.
 
         logger.info("UploadManager configured")
     }
@@ -217,10 +217,20 @@ public final class UploadManager {
 
     /// Tell all queued peers their updated queue position
     private func broadcastQueuePositions() async {
+        guard let pool = networkClient?.peerConnectionPool else { return }
         for (index, upload) in uploadQueue.enumerated() {
             let position = UInt32(index + 1)
+            // Resolve the live connection at send time. Caching the one the
+            // peer used at QueueUpload meant broadcasts often went to a dead
+            // connection and the failure was silent (logged at .debug).
+            // If the peer has no live connection, skip — they'll reconnect
+            // and re-request position when they want it.
+            guard let connection = await pool.getConnectionForUser(upload.username) else {
+                logger.debug("No live connection to \(upload.username) — skipping queue-position broadcast")
+                continue
+            }
             do {
-                try await upload.connection.sendPlaceInQueue(filename: upload.filename, place: position)
+                try await connection.sendPlaceInQueue(filename: upload.filename, place: position)
             } catch {
                 logger.debug("Failed to send queue position to \(upload.username): \(error.localizedDescription)")
             }
@@ -311,7 +321,6 @@ public final class UploadManager {
             filename: filename,
             localPath: indexedFile.localPath,
             size: indexedFile.size,
-            connection: connection,
             queuedAt: Date()
         )
         uploadQueue.append(queued)
@@ -358,26 +367,21 @@ public final class UploadManager {
             filename: upload.filename,
             localPath: upload.localPath,
             size: upload.size,
-            token: token,
-            connection: upload.connection
+            token: token
         )
         pendingTransfers[token] = pending
 
         logger.info("Starting upload: \(upload.filename) to \(upload.username), token=\(token)")
 
-        // Get a fresh connection -- the one stored at queue time may be stale
-        let connection: PeerConnection
-        if await upload.connection.isConnected {
-            connection = upload.connection
-        } else if let fresh = await networkClient?.peerConnectionPool.getConnectionForUser(upload.username) {
-            logger.info("Using fresh connection for upload to \(upload.username) (original was stale)")
-            connection = fresh
-        } else {
+        // Always look up the connection fresh — the one the peer used to
+        // send QueueUpload may have died waiting in our queue.
+        guard let connection = await networkClient?.peerConnectionPool.getConnectionForUser(upload.username) else {
             logger.warning("No active connection to \(upload.username), upload cannot proceed")
             transferState?.updateTransfer(id: transfer.id) { t in
                 t.status = .failed
                 t.error = "Peer disconnected"
             }
+            pendingTransfers.removeValue(forKey: token)
             await processQueue()
             return
         }
@@ -392,17 +396,19 @@ public final class UploadManager {
             )
             logger.info("Sent TransferRequest for \(upload.filename)")
 
-            // Wait for response (timeout after 60 seconds)
-            Task {
+            // Schedule a 60s "no TransferResponse" timeout. The Task is
+            // tracked in `transferResponseTimeouts` so handleTransferResponse
+            // can cancel it when the peer replies — otherwise the timer
+            // would fire later and stomp the entry that we re-register for
+            // PierceFirewall handling.
+            transferResponseTimeouts[token] = Task { [weak self] in
                 try? await Task.sleep(for: .seconds(60))
-                if pendingTransfers[token] != nil {
-                    // Timed out waiting for response
-                    pendingTransfers.removeValue(forKey: token)
-                    await MainActor.run {
-                        self.transferState?.updateTransfer(id: transfer.id) { t in
-                            t.status = .failed
-                            t.error = "Timeout waiting for peer response"
-                        }
+                guard !Task.isCancelled, let self else { return }
+                self.transferResponseTimeouts.removeValue(forKey: token)
+                if let pending = self.pendingTransfers.removeValue(forKey: token) {
+                    self.transferState?.updateTransfer(id: pending.transferId) { t in
+                        t.status = .failed
+                        t.error = "Timeout waiting for peer response"
                     }
                 }
             }
@@ -413,6 +419,7 @@ public final class UploadManager {
                 t.error = error.localizedDescription
             }
             pendingTransfers.removeValue(forKey: token)
+            transferResponseTimeouts.removeValue(forKey: token)?.cancel()
         }
     }
 
@@ -425,6 +432,12 @@ public final class UploadManager {
     /// the right TransferStatus so the row doesn't misleadingly show as
     /// Failed when the peer is actually in the process of queuing us.
     private func handleTransferResponse(token: UInt32, allowed: Bool, reason: String?, connection: PeerConnection) async {
+        // Cancel the no-response timeout — peer replied. Without this, the
+        // timer would fire 60s after our original TransferRequest and stomp
+        // the same `pendingTransfers[token]` entry that we re-register
+        // below for PierceFirewall handling.
+        transferResponseTimeouts.removeValue(forKey: token)?.cancel()
+
         guard let pending = pendingTransfers.removeValue(forKey: token) else {
             logger.debug("No pending upload for token \(token)")
             return
@@ -444,19 +457,16 @@ public final class UploadManager {
         logger.info("Peer accepted upload for \(pending.filename), opening F connection")
 
         // Peer accepted - now we need to open an F (file) connection to their listen port
-        // First, we need to get their address
         guard let networkClient else {
             logger.error("NetworkClient not available")
             return
         }
 
-        // Update status
         transferState?.updateTransfer(id: pending.transferId) { t in
             t.status = .transferring
             t.startTime = Date()
         }
 
-        // Track as active upload
         let active = ActiveUpload(
             transferId: pending.transferId,
             username: pending.username,
@@ -468,30 +478,24 @@ public final class UploadManager {
         )
         activeUploads[pending.transferId] = active
 
-        // Per protocol: Send ConnectToPeer FIRST, then GetPeerAddress
-        // ConnectToPeer (code 18) tells the server to forward our connection request to the peer
-        // If our direct connection fails, the peer will connect back to us with PierceFirewall
-
-        // Step 1: Send ConnectToPeer to server
-        // Use type "F" since this is for a file transfer connection
+        // Send ConnectToPeer (type "F") first so the server forwards our
+        // connection request to the peer in parallel; if our direct
+        // connection fails the peer will connect back to us via PierceFirewall.
         await networkClient.sendConnectToPeer(token: token, username: pending.username, connectionType: "F")
         logger.debug("Sent ConnectToPeer to server for upload to \(pending.username)")
 
-        // Register pending transfer BEFORE getting address, so PierceFirewall can find it
+        // Re-register pending transfer so PierceFirewall can find it. (The
+        // 60s response-timeout above is already cancelled, so it can't fire
+        // and falsely fail this re-registration.)
         pendingTransfers[token] = pending
         logger.debug("Registered pending upload token=\(token) for PierceFirewall")
 
-        // Step 2: Request peer address for direct F connection attempt
-        // IMPORTANT: Always use getUserAddress to get the peer's actual LISTEN port,
-        // not the ephemeral source port from the existing P connection
+        // Resolve the peer's listen port (NOT the ephemeral source port from
+        // the existing P-connection) and open the direct F-connection.
+        let ip: String
+        let port: Int
         do {
-            logger.info("Requesting peer address for F connection to \(pending.username)")
-            pendingAddressLookups[pending.username, default: []].append((pending, token))
-            logger.info("Stored pending address lookup: \(pending.username) -> token=\(token)")
-            try await networkClient.getUserAddress(pending.username)
-            logger.debug("GetPeerAddress request sent for \(pending.username)")
-            // The actual F connection will be triggered by handlePeerAddressForUpload callback
-
+            (ip, port) = try await networkClient.getPeerAddress(for: pending.username, timeout: .seconds(10))
         } catch {
             logger.error("Failed to get peer address: \(error.localizedDescription)")
             transferState?.updateTransfer(id: pending.transferId) { t in
@@ -499,40 +503,20 @@ public final class UploadManager {
                 t.error = "Failed to connect to peer"
             }
             activeUploads.removeValue(forKey: pending.transferId)
-        }
-    }
-
-    /// Handle peer address callback for pending uploads
-    private func handlePeerAddressForUpload(username: String, ip: String, port: Int) async {
-        guard var entries = pendingAddressLookups[username], !entries.isEmpty else {
+            pendingTransfers.removeValue(forKey: token)
             return
         }
 
-        // Pop the first pending upload for this user
-        let (pending, token) = entries.removeFirst()
-        if entries.isEmpty {
-            pendingAddressLookups.removeValue(forKey: username)
-        } else {
-            pendingAddressLookups[username] = entries
-            // Re-request address for remaining entries (server only sends one response per request)
-            Task { [weak self] in
-                do {
-                    try await self?.networkClient?.getUserAddress(username)
-                } catch {
-                    self?.logger.warning("getUserAddress(\(username)) failed: \(error.localizedDescription)")
-                }
-            }
-        }
-
-        logger.info("Received peer address for upload to \(username): \(ip):\(port)")
+        logger.info("Received peer address for upload to \(pending.username): \(ip):\(port)")
 
         guard port > 0 else {
-            logger.warning("Invalid port for \(username)")
+            logger.warning("Invalid port for \(pending.username)")
             transferState?.updateTransfer(id: pending.transferId) { t in
                 t.status = .failed
                 t.error = "Could not get peer address"
             }
             activeUploads.removeValue(forKey: pending.transferId)
+            pendingTransfers.removeValue(forKey: token)
             return
         }
 

--- a/seeleseekTests/PeerConnectivityFixTests.swift
+++ b/seeleseekTests/PeerConnectivityFixTests.swift
@@ -105,9 +105,7 @@ struct PeerConnectivityFixTests {
         let request = TransferRequest(
             direction: .upload, token: 42, filename: "ANY.flac", size: 1000, username: "zzz"
         )
-        let (matched, ambiguous) = DownloadManager.matchPendingDownload(request: request, pending: pending)
-        #expect(matched == 42)
-        #expect(ambiguous == false)
+        #expect(DownloadManager.matchPendingDownload(request: request, pending: pending) == 42)
     }
 
     @Test("(username, filename) wins when token doesn't match")
@@ -119,37 +117,23 @@ struct PeerConnectivityFixTests {
         let request = TransferRequest(
             direction: .upload, token: 999, filename: "shared.flac", size: 1000, username: "bob"
         )
-        let (matched, ambiguous) = DownloadManager.matchPendingDownload(request: request, pending: pending)
-        #expect(matched == 2)
-        #expect(ambiguous == false)
+        #expect(DownloadManager.matchPendingDownload(request: request, pending: pending) == 2)
     }
 
-    @Test("Ambiguous same-filename fallback refuses to guess")
-    func transferRoutingRefusesAmbiguousFallback() {
-        let pending: [UInt32: DownloadManager.PendingDownload] = [
-            1: .init(transferId: UUID(), username: "alice", filename: "shared.flac", size: 1000),
-            2: .init(transferId: UUID(), username: "bob",   filename: "shared.flac", size: 1000)
-        ]
-        // request.username is empty (reused-connection path) — can't disambiguate.
-        let request = TransferRequest(
-            direction: .upload, token: 999, filename: "shared.flac", size: 1000, username: ""
-        )
-        let (matched, ambiguous) = DownloadManager.matchPendingDownload(request: request, pending: pending)
-        #expect(matched == nil)
-        #expect(ambiguous == true)
-    }
-
-    @Test("Single filename candidate still resolves via loose fallback")
-    func transferRoutingResolvesUniqueFilename() {
+    @Test("Empty request.username refuses to match — caller must normalize")
+    func transferRoutingRequiresUsername() {
+        // request.username is empty (the connection identification didn't make it
+        // into the request payload). The filename-only fallback was removed
+        // because it could misroute when two peers happen to be sending the same
+        // filename. handlePoolTransferRequest is responsible for filling in the
+        // username from the delivering connection's peerInfo before matching.
         let pending: [UInt32: DownloadManager.PendingDownload] = [
             5: .init(transferId: UUID(), username: "alice", filename: "only.flac", size: 1000)
         ]
         let request = TransferRequest(
             direction: .upload, token: 999, filename: "only.flac", size: 1000, username: ""
         )
-        let (matched, ambiguous) = DownloadManager.matchPendingDownload(request: request, pending: pending)
-        #expect(matched == 5)
-        #expect(ambiguous == false)
+        #expect(DownloadManager.matchPendingDownload(request: request, pending: pending) == nil)
     }
 
     // MARK: - Outbound parameters

--- a/seeleseekTests/PeerConnectivityFixTests.swift
+++ b/seeleseekTests/PeerConnectivityFixTests.swift
@@ -208,4 +208,84 @@ struct PeerConnectivityFixTests {
         #expect(PeerConnection.isBindFailure(NWError.posix(.ECONNREFUSED)) == false)
         #expect(PeerConnection.isBindFailure(NWError.posix(.ETIMEDOUT)) == false)
     }
+
+    // MARK: - Artwork coalescing
+
+    @Test("Concurrent artwork requests for the same (peer, file) coalesce into one")
+    func artworkCoalescesSamePeerSameFile() async {
+        let client = await NetworkClient()
+
+        // Two waiters for the SAME (peer, file) key.
+        let result1 = LockedResult<Data?>()
+        let result2 = LockedResult<Data?>()
+        let key1 = await client._registerArtworkWaiterForTest(
+            username: "alice", filePath: "Music/foo.mp3"
+        ) { result1.set($0) }
+        let key2 = await client._registerArtworkWaiterForTest(
+            username: "alice", filePath: "Music/foo.mp3"
+        ) { result2.set($0) }
+        #expect(key1 == key2, "same (peer, file) must produce same coalescing key")
+
+        let count = await client._pendingArtworkWaiterCount(key: key1)
+        #expect(count == 2, "both waiters share one pending entry")
+
+        // One delivery fans out to all waiters.
+        let payload = Data([0xCA, 0xFE])
+        await client._deliverArtworkForTest(key: key1, data: payload)
+
+        #expect(result1.get() == payload)
+        #expect(result2.get() == payload)
+
+        let countAfter = await client._pendingArtworkWaiterCount(key: key1)
+        #expect(countAfter == 0, "delivery cleans up the coalesced entry")
+    }
+
+    @Test("Different (peer, file) keys do NOT coalesce")
+    func artworkDoesNotCoalesceDifferentKeys() async {
+        let client = await NetworkClient()
+
+        let resultA = LockedResult<Data?>()
+        let resultB = LockedResult<Data?>()
+        let keyA = await client._registerArtworkWaiterForTest(
+            username: "alice", filePath: "Music/a.mp3"
+        ) { resultA.set($0) }
+        let keyB = await client._registerArtworkWaiterForTest(
+            username: "bob", filePath: "Music/a.mp3"
+        ) { resultB.set($0) }
+        #expect(keyA != keyB, "different peers for same filename must NOT share a key")
+
+        await client._deliverArtworkForTest(key: keyA, data: Data([0x01]))
+        #expect(resultA.get() == Data([0x01]))
+        #expect(resultB.get() == nil, "delivering A must not trigger B's waiter")
+
+        await client._deliverArtworkForTest(key: keyB, data: Data([0x02]))
+        #expect(resultB.get() == Data([0x02]))
+    }
+
+    @Test("Late artwork delivery (timeout firing after reply) is a no-op")
+    func artworkLateDeliveryIsIdempotent() async {
+        let client = await NetworkClient()
+
+        let result = LockedResult<Data?>()
+        let key = await client._registerArtworkWaiterForTest(
+            username: "alice", filePath: "Music/foo.mp3"
+        ) { result.set($0) }
+
+        await client._deliverArtworkForTest(key: key, data: Data([0xFF]))
+        #expect(result.get() == Data([0xFF]))
+
+        // A second delivery (e.g. timeout firing late) must not crash or
+        // double-call the waiter.
+        await client._deliverArtworkForTest(key: key, data: nil)
+        // Result still the original payload — nothing was overwritten.
+        #expect(result.get() == Data([0xFF]))
+    }
+}
+
+/// Thread-safe single-value sink for capturing async callback results from tests.
+final class LockedResult<T>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value: T?
+    func set(_ v: T) { lock.lock(); value = v; lock.unlock() }
+    func get() -> T? { lock.lock(); defer { lock.unlock() }; return value }
 }

--- a/seeleseekTests/PeerConnectivityFixTests.swift
+++ b/seeleseekTests/PeerConnectivityFixTests.swift
@@ -280,6 +280,212 @@ struct PeerConnectivityFixTests {
         // Result still the original payload — nothing was overwritten.
         #expect(result.get() == Data([0xFF]))
     }
+
+    // MARK: - Pool: F-connection handoff (regression for transfers killed mid-flight)
+
+    @Test("Pool removes F-connection from tracking on handoff")
+    func poolRemovesFConnectionOnHandoff() async {
+        let pool = await PeerConnectionPool()
+
+        let info = await PeerConnectionPool.PeerConnectionInfo(
+            id: "incoming-TEST",
+            username: "alice",
+            ip: "10.0.0.5",
+            port: 12345,
+            state: .connected,
+            connectionType: .peer,
+            connectedAt: Date()
+        )
+        await pool._seedConnectionForTest(info)
+        #expect(await pool._connectionInfo(id: "incoming-TEST") != nil,
+                "precondition: connection seeded")
+
+        // Simulate the .fileTransferConnection event arriving — the pool
+        // must hand the connection off (untrack it) so `cleanupStaleConnections`
+        // can't kill it mid-transfer.
+        await pool._simulateFileTransferHandoffForTest(connectionId: "incoming-TEST", ip: "10.0.0.5")
+
+        #expect(await pool._connectionInfo(id: "incoming-TEST") == nil,
+                "F-connection must be removed from pool tracking after handoff")
+    }
+
+    // MARK: - Pool: lastActivity bumped on event
+
+    @Test("touchActivity updates lastActivity so cleanup doesn't reap a live connection")
+    func poolTouchActivityKeepsConnectionFresh() async {
+        let pool = await PeerConnectionPool()
+
+        // Seed a connection that's been "alive" longer than the 10s
+        // stuck-handshake cutoff but with no activity yet.
+        let staleConnectedAt = Date().addingTimeInterval(-15)
+        let info = await PeerConnectionPool.PeerConnectionInfo(
+            id: "alice-42",
+            username: "alice",
+            ip: "10.0.0.6",
+            port: 2234,
+            state: .connected,
+            connectionType: .peer,
+            connectedAt: staleConnectedAt
+        )
+        await pool._seedConnectionForTest(info)
+        #expect(await pool._connectionInfo(id: "alice-42")?.lastActivity == nil,
+                "precondition: lastActivity unset")
+
+        // Real wiring: handlePeerEvent calls this on every event.
+        await pool._touchActivityForTest(connectionId: "alice-42")
+
+        let after = await pool._connectionInfo(id: "alice-42")
+        #expect(after?.lastActivity != nil, "lastActivity must be set after activity")
+        // Now run cleanup. The stuck-handshake branch only fires when
+        // lastActivity is nil — with our touch, it should be skipped.
+        await pool.cleanupStaleConnections()
+        #expect(await pool._connectionInfo(id: "alice-42") != nil,
+                "live connection must survive cleanup tick")
+    }
+
+    // MARK: - DownloadManager: salvage path
+
+    /// These tests use `_evaluatePoolTransferRequestForTest` rather than
+    /// `_handlePoolTransferRequestForTest` so the assertion observes the
+    /// routing DECISION rather than the side effect. The full
+    /// `handlePoolTransferRequest` pipeline calls `handleTransferRequest`
+    /// which tries to send TransferReply on the connection and removes
+    /// the pending entry on failure — racy to assert against on a
+    /// synthetic non-connected PeerConnection.
+
+    @Test("Salvage lifts a transferState entry into pendingDownloads")
+    func salvageLiftsTransferStateEntry() async {
+        let dm = await DownloadManager()
+        let tracking = await MockTransferTracking()
+        await dm._setTransferStateForTest(tracking)
+
+        let transferId = UUID()
+        await tracking.addDownload(Transfer(
+            id: transferId,
+            username: "alice",
+            filename: "Music/song.mp3",
+            size: 5_000_000,
+            direction: .download,
+            status: .queued
+        ))
+
+        let conn = PeerConnection(peerInfo: .init(username: "alice", ip: "10.0.0.7", port: 2234))
+        let decision = await dm._evaluatePoolTransferRequestForTest(
+            TransferRequest(direction: .upload, token: 999,
+                            filename: "Music/song.mp3", size: 5_000_000,
+                            username: "alice"),
+            connection: conn
+        )
+
+        guard case .salvaged(let salvagedToken, let salvagedTransferId) = decision else {
+            Issue.record("expected .salvaged, got \(decision)")
+            return
+        }
+        #expect(salvagedTransferId == transferId, "salvaged decision must reference the matching transferState transfer")
+
+        let pending = await dm._pendingDownloadFor(username: "alice", filename: "Music/song.mp3")
+        #expect(pending?.transferId == transferId)
+        #expect(pending?.size == 5_000_000)
+        #expect(pending?.peerIP == "10.0.0.7")
+        #expect(pending?.peerPort == 2234)
+        #expect(salvagedToken != 0)
+    }
+
+    @Test("Salvage refuses to duplicate when a pendingDownload already exists")
+    func salvageSkipsWhenPendingExists() async {
+        let dm = await DownloadManager()
+        let tracking = await MockTransferTracking()
+        await dm._setTransferStateForTest(tracking)
+
+        let transferId = UUID()
+        await dm._seedPendingDownloadForTest(
+            DownloadManager.PendingDownload(
+                transferId: transferId,
+                username: "alice",
+                filename: "Music/song.mp3",
+                size: 5_000_000,
+                peerIP: "10.0.0.7",
+                peerPort: 2234
+            ),
+            token: 7
+        )
+
+        await tracking.addDownload(Transfer(
+            id: transferId,
+            username: "alice",
+            filename: "Music/song.mp3",
+            size: 5_000_000,
+            direction: .download,
+            status: .queued
+        ))
+
+        let conn = PeerConnection(peerInfo: .init(username: "alice", ip: "10.0.0.7", port: 2234))
+        let decision = await dm._evaluatePoolTransferRequestForTest(
+            TransferRequest(direction: .upload, token: 999,
+                            filename: "Music/song.mp3", size: 5_000_000,
+                            username: "alice"),
+            connection: conn
+        )
+
+        // Token 999 doesn't match our seed (token 7), but (alice, song.mp3)
+        // does — expect a `matched` decision pointing at our seeded token.
+        // Critically, NOT a `salvaged` decision creating a duplicate entry.
+        #expect(decision == .matched(token: 7))
+        let count = await dm._pendingDownloadCount
+        #expect(count == 1, "no duplicate pending entry created")
+    }
+
+    @Test("Salvage refuses .failed transfers — user gave up; peer offer is stale")
+    func salvageRefusesFailedTransfers() async {
+        let dm = await DownloadManager()
+        let tracking = await MockTransferTracking()
+        await dm._setTransferStateForTest(tracking)
+
+        await tracking.addDownload(Transfer(
+            id: UUID(),
+            username: "alice",
+            filename: "Music/song.mp3",
+            size: 5_000_000,
+            direction: .download,
+            status: .failed,
+            error: "Manually cancelled by user"
+        ))
+
+        let conn = PeerConnection(peerInfo: .init(username: "alice", ip: "10.0.0.7", port: 2234))
+        let decision = await dm._evaluatePoolTransferRequestForTest(
+            TransferRequest(direction: .upload, token: 999,
+                            filename: "Music/song.mp3", size: 5_000_000,
+                            username: "alice"),
+            connection: conn
+        )
+
+        #expect(decision == .dropped, ".failed transfers must NOT be silently re-accepted via salvage")
+        let count = await dm._pendingDownloadCount
+        #expect(count == 0)
+    }
+}
+
+// MARK: - Test fixtures
+
+@MainActor
+final class MockTransferTracking: TransferTracking, @unchecked Sendable {
+    var downloads: [Transfer] = []
+    var uploads: [Transfer] = []
+
+    func addDownload(_ transfer: Transfer) { downloads.append(transfer) }
+    func addUpload(_ transfer: Transfer) { uploads.append(transfer) }
+
+    func updateTransfer(id: UUID, update: (inout Transfer) -> Void) {
+        if let idx = downloads.firstIndex(where: { $0.id == id }) {
+            update(&downloads[idx])
+        } else if let idx = uploads.firstIndex(where: { $0.id == id }) {
+            update(&uploads[idx])
+        }
+    }
+
+    func getTransfer(id: UUID) -> Transfer? {
+        downloads.first(where: { $0.id == id }) ?? uploads.first(where: { $0.id == id })
+    }
 }
 
 /// Thread-safe single-value sink for capturing async callback results from tests.


### PR DESCRIPTION
### Description

This PR removes the pending connection tracking system from `PeerConnectionPool` and introduces several improvements to connection management and the `browseUser` API. The changes streamline connection handling, prevent premature connection cleanup, and improve concurrent access patterns for browsing user shares. The most important changes are grouped below:

**Connection Management Simplification and Bug Fixes**

* Removed the pending connection tracking mechanism from `PeerConnectionPool`, including the `PendingConnection` struct, related dictionary, and all associated methods and event cases. This simplifies connection state management and reduces code complexity. [[1]](diffhunk://#diff-b56ebc520dbee8cd683f123b7709cbfa882317690d4676417789071581ab8955L35) [[2]](diffhunk://#diff-b56ebc520dbee8cd683f123b7709cbfa882317690d4676417789071581ab8955L123-L133) [[3]](diffhunk://#diff-b56ebc520dbee8cd683f123b7709cbfa882317690d4676417789071581ab8955L448) [[4]](diffhunk://#diff-b56ebc520dbee8cd683f123b7709cbfa882317690d4676417789071581ab8955L494-L507) [[5]](diffhunk://#diff-9725d037dc944f106c56bb5ac3fb256eb30d465c7f68a46728c00d2266de589bL9) [[6]](diffhunk://#diff-f3aa9a82ee1ce3b938a3e39e5b875ff339f1ffad68029fbf374f19ebeaa6c60cL200-L202) [[7]](diffhunk://#diff-f3aa9a82ee1ce3b938a3e39e5b875ff339f1ffad68029fbf374f19ebeaa6c60cL288)
* Fixed a bug where connections were cleaned up too aggressively by introducing a `touchActivity` method that updates a connection's `lastActivity` timestamp on every event, ensuring only truly idle or stuck connections are reaped. [[1]](diffhunk://#diff-b56ebc520dbee8cd683f123b7709cbfa882317690d4676417789071581ab8955L522-L558) [[2]](diffhunk://#diff-b56ebc520dbee8cd683f123b7709cbfa882317690d4676417789071581ab8955R639-R645)

**File Transfer Connection Handling**

* Improved handling of file transfer connections by explicitly removing them from the pool when ownership is handed off (e.g., to the `DownloadManager`), preventing premature cleanup during long transfers.

**Testing Support**

* Added internal test-only accessors and helpers to seed connections, retrieve connection info, simulate activity, and directly drive file transfer handoff logic for improved testability.

**Concurrent Browse and Connection Coalescing**

* Enhanced the `browseUser(_:)` API to deduplicate concurrent browse requests for the same user, ensuring only one connection and share request is made per user at a time. Also, removed unnecessary forced fresh connections for browse, relying on connection reuse unless a concrete issue is observed. [[1]](diffhunk://#diff-f3aa9a82ee1ce3b938a3e39e5b875ff339f1ffad68029fbf374f19ebeaa6c60cL1056-R1096) [[2]](diffhunk://#diff-f3aa9a82ee1ce3b938a3e39e5b875ff339f1ffad68029fbf374f19ebeaa6c60cL1084-R1120)
* Added a mechanism to coalesce concurrent connection establishments for the same peer, preventing redundant TCP connections and avoiding resource exhaustion or port collisions.

**Robust Pending Browse Failure Handling**

* Improved error handling for pending browse operations by allowing fast-fail on connection errors (e.g., when the server sends a failure), rather than waiting for a timeout. [[1]](diffhunk://#diff-f3aa9a82ee1ce3b938a3e39e5b875ff339f1ffad68029fbf374f19ebeaa6c60cR1182-R1185) [[2]](diffhunk://#diff-f3aa9a82ee1ce3b938a3e39e5b875ff339f1ffad68029fbf374f19ebeaa6c60cR1202-R1206) [[3]](diffhunk://#diff-f3aa9a82ee1ce3b938a3e39e5b875ff339f1ffad68029fbf374f19ebeaa6c60cR1216-R1230)

These changes collectively make the connection pool more robust, efficient, and easier to maintain.

<!--
### Future work
A place to describe changes that can or will be done in follow-up PRs
-->

### How to test

- Ensure all checks pass

### Author checklist

This PR:

- [x] Satisfies a goal that is specific & clearly motivated
- [x] Adds value in isolation (whether user-facing or sustainability-related)
- [x] Contains a concise & easy-to-understand title + description
- [x] Adheres to [SRP](https://en.wikipedia.org/wiki/Single-responsibility_principle) by default
- [x] Presents the best possible implementation to meet its goal, given constraints at hand
