### PR TITLE
index salvage lookup + evict stale connectionattempts

### DIFF
--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Connections/PeerConnectionPool.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Connections/PeerConnectionPool.swift
@@ -534,6 +534,17 @@ public final class PeerConnectionPool {
 
         activeConnections = connections.count
 
+        // Evict rate-limit history for IPs whose most-recent attempt falls
+        // outside the window. Without this pass the dict's key set never
+        // shrinks — an IP that tries once and never comes back lingers
+        // forever. The per-IP filter inside `handleIncomingConnection`
+        // only prunes an IP's timestamps when that same IP re-attempts.
+        let windowCutoff = Date().addingTimeInterval(-rateLimitWindow)
+        connectionAttempts = connectionAttempts.filter { _, timestamps in
+            guard let newest = timestamps.last else { return false }
+            return newest > windowCutoff
+        }
+
         if !toRemove.isEmpty {
             logger.info("Cleaned up \(toRemove.count) stale connections, \(self.activeConnections) active")
         }

--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Protocols.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Protocols.swift
@@ -60,6 +60,13 @@ public protocol TransferTracking: AnyObject, Sendable {
     func addUpload(_ transfer: Transfer)
     func updateTransfer(id: UUID, update: (inout Transfer) -> Void)
     func getTransfer(id: UUID) -> Transfer?
+    /// Indexed lookup for the salvage path in `DownloadManager`: returns the
+    /// download (if any) for `(username, filename)` whose status is still
+    /// eligible to be lifted into `pendingDownloads` when the peer sends an
+    /// unsolicited TransferRequest. Eligible = `.queued`, `.waiting`, or
+    /// `.connecting`. Must be O(1) relative to total history size — the old
+    /// implementation filtered every entry in `downloads` per peer message.
+    func findSalvageableDownload(username: String, filename: String) -> Transfer?
 }
 
 // MARK: - Statistics Recording

--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Storage/DownloadManager.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Storage/DownloadManager.swift
@@ -456,17 +456,20 @@ public final class DownloadManager {
         let alreadyPending = pendingDownloads.values.contains {
             $0.username == peerUsername && $0.filename == request.filename
         }
+        // Salvage lookup goes through the `salvageableDownloadIDs` index on
+        // TransferState (O(1)) rather than filtering all of `.downloads`.
+        // Index already restricts to `.queued | .waiting | .connecting`, so
+        // the status guard is redundant here but kept defensive. The old
+        // `.min(by: startTime)` tiebreak is gone — the index is keyed by
+        // `(user, filename)` so it holds at most one entry per key, which
+        // was the effective behavior anyway.
         if !peerUsername.isEmpty,
            !alreadyPending,
-           let transfer = transferState?.downloads
-               .filter({ t in
-                   t.direction == .download &&
-                   t.username == peerUsername &&
-                   t.filename == request.filename &&
-                   (t.status == .queued || t.status == .waiting ||
-                    t.status == .connecting)
-               })
-               .min(by: { ($0.startTime ?? .distantFuture) < ($1.startTime ?? .distantFuture) })
+           let transfer = transferState?.findSalvageableDownload(
+               username: peerUsername,
+               filename: request.filename
+           ),
+           transfer.direction == .download
         {
             let salvagedToken = UInt32.random(in: 1...UInt32.max)
             let info = connection.peerInfo

--- a/seeleseek/Features/Transfers/TransferState.swift
+++ b/seeleseek/Features/Transfers/TransferState.swift
@@ -151,13 +151,30 @@ final class TransferState: TransferTracking {
     // MARK: - Download Status Index (O(1) lookup)
     private(set) var downloadStatusIndex: [String: Transfer.TransferStatus] = [:]
 
+    /// Per-`(user, filename)` lookup used by `DownloadManager`'s salvage path
+    /// (peer sent a TransferRequest for a download we haven't lifted into
+    /// `pendingDownloads` yet). Holds only entries whose status is still
+    /// eligible for salvage: `.queued`, `.waiting`, `.connecting`. Rebuilt
+    /// alongside `downloadStatusIndex` so it tracks live downloads — completed
+    /// and failed entries fall out automatically.
+    private(set) var salvageableDownloadIDs: [String: UUID] = [:]
+
     private func rebuildDownloadIndex() {
-        var index: [String: Transfer.TransferStatus] = [:]
-        index.reserveCapacity(downloads.count)
+        var statusIndex: [String: Transfer.TransferStatus] = [:]
+        var salvageIndex: [String: UUID] = [:]
+        statusIndex.reserveCapacity(downloads.count)
         for transfer in downloads {
-            index["\(transfer.username)\0\(transfer.filename)"] = transfer.status
+            let key = "\(transfer.username)\0\(transfer.filename)"
+            statusIndex[key] = transfer.status
+            switch transfer.status {
+            case .queued, .waiting, .connecting:
+                salvageIndex[key] = transfer.id
+            default:
+                break
+            }
         }
-        downloadStatusIndex = index
+        downloadStatusIndex = statusIndex
+        salvageableDownloadIDs = salvageIndex
     }
 
     /// Count of downloads that are queued, waiting, connecting, or actively
@@ -346,6 +363,11 @@ final class TransferState: TransferTracking {
             return transfer
         }
         return uploads.first(where: { $0.id == id })
+    }
+
+    func findSalvageableDownload(username: String, filename: String) -> Transfer? {
+        guard let id = salvageableDownloadIDs["\(username)\0\(filename)"] else { return nil }
+        return downloads.first(where: { $0.id == id })
     }
 
     /// Check if a file is already queued or downloading

--- a/seeleseekTests/PeerConnectivityFixTests.swift
+++ b/seeleseekTests/PeerConnectivityFixTests.swift
@@ -486,6 +486,13 @@ final class MockTransferTracking: TransferTracking, @unchecked Sendable {
     func getTransfer(id: UUID) -> Transfer? {
         downloads.first(where: { $0.id == id }) ?? uploads.first(where: { $0.id == id })
     }
+
+    func findSalvageableDownload(username: String, filename: String) -> Transfer? {
+        downloads.first { t in
+            t.username == username && t.filename == filename &&
+            (t.status == .queued || t.status == .waiting || t.status == .connecting)
+        }
+    }
 }
 
 /// Thread-safe single-value sink for capturing async callback results from tests.

--- a/seeleseekTests/TransferStateSalvageIndexTests.swift
+++ b/seeleseekTests/TransferStateSalvageIndexTests.swift
@@ -1,0 +1,74 @@
+import Testing
+import Foundation
+@testable import SeeleseekCore
+@testable import seeleseek
+
+/// Verifies `TransferState.salvageableDownloadIDs` stays in sync with
+/// `downloads`, so the salvage path on `DownloadManager.handlePoolTransferRequest`
+/// can look up candidates in O(1) instead of filtering every history entry.
+@Suite("TransferState salvage index")
+@MainActor
+struct TransferStateSalvageIndexTests {
+
+    @Test("Salvageable statuses land in the index")
+    func salvageableStatusesLandInIndex() {
+        let state = TransferState()
+        let id = UUID()
+        state.downloads = [
+            Transfer(id: id, username: "alice", filename: "song.mp3",
+                     size: 100, direction: .download, status: .queued)
+        ]
+        let found = state.findSalvageableDownload(username: "alice", filename: "song.mp3")
+        #expect(found?.id == id)
+    }
+
+    @Test("Terminal statuses are excluded from the index")
+    func terminalStatusesExcluded() {
+        let state = TransferState()
+        state.downloads = [
+            Transfer(id: UUID(), username: "alice", filename: "a.mp3",
+                     size: 1, direction: .download, status: .completed),
+            Transfer(id: UUID(), username: "alice", filename: "b.mp3",
+                     size: 1, direction: .download, status: .failed),
+            Transfer(id: UUID(), username: "alice", filename: "c.mp3",
+                     size: 1, direction: .download, status: .cancelled),
+            Transfer(id: UUID(), username: "alice", filename: "d.mp3",
+                     size: 1, direction: .download, status: .transferring),
+        ]
+        #expect(state.findSalvageableDownload(username: "alice", filename: "a.mp3") == nil)
+        #expect(state.findSalvageableDownload(username: "alice", filename: "b.mp3") == nil)
+        #expect(state.findSalvageableDownload(username: "alice", filename: "c.mp3") == nil)
+        #expect(state.findSalvageableDownload(username: "alice", filename: "d.mp3") == nil)
+    }
+
+    @Test("Status transition updates the index")
+    func statusTransitionUpdatesIndex() {
+        let state = TransferState()
+        let id = UUID()
+        state.downloads = [
+            Transfer(id: id, username: "alice", filename: "song.mp3",
+                     size: 100, direction: .download, status: .queued)
+        ]
+        #expect(state.findSalvageableDownload(username: "alice", filename: "song.mp3") != nil)
+
+        state.updateTransfer(id: id) { $0.status = .completed }
+        #expect(state.findSalvageableDownload(username: "alice", filename: "song.mp3") == nil,
+                "completed entries must fall out of the salvage index")
+    }
+
+    @Test("Bulk history does not poison the salvage lookup")
+    func bulkHistoryIgnored() {
+        let state = TransferState()
+        let liveID = UUID()
+        var entries: [Transfer] = (0..<5_000).map { i in
+            Transfer(id: UUID(), username: "alice", filename: "done-\(i).mp3",
+                     size: 1, direction: .download, status: .completed)
+        }
+        entries.append(Transfer(id: liveID, username: "alice", filename: "live.mp3",
+                                size: 1, direction: .download, status: .queued))
+        state.downloads = entries
+
+        #expect(state.findSalvageableDownload(username: "alice", filename: "live.mp3")?.id == liveID)
+        #expect(state.findSalvageableDownload(username: "alice", filename: "done-1234.mp3") == nil)
+    }
+}


### PR DESCRIPTION
### Description

This PR optimizes the lookup of salvageable downloads in the transfer management system, making the process significantly more efficient and maintainable. It introduces a dedicated index for quickly finding eligible downloads (those in `.queued`, `.waiting`, or `.connecting` states), updates related protocols and implementations, and adds comprehensive tests to ensure correctness. Additionally, it includes a memory leak fix for rate-limit tracking in peer connections.

**Performance and correctness improvements for download salvage:**

* Added a `salvageableDownloadIDs` index to `TransferState`, enabling O(1) lookup of downloads eligible for salvage by `(username, filename)`. This index is kept in sync with the main downloads list and only tracks entries with statuses `.queued`, `.waiting`, or `.connecting`. (`seeleseek/Features/Transfers/TransferState.swift` [[1]](diffhunk://#diff-e29ef511cb293c129709cc1f754dc3e39e9ad1f841e978e1983877b87d57af1bR154-R177) [[2]](diffhunk://#diff-e29ef511cb293c129709cc1f754dc3e39e9ad1f841e978e1983877b87d57af1bR368-R372)
* Updated the `TransferTracking` protocol to include the new `findSalvageableDownload(username:filename:)` method, requiring conformers to provide efficient salvage lookups. (`Packages/SeeleseekCore/Sources/SeeleseekCore/Protocols.swift` [Packages/SeeleseekCore/Sources/SeeleseekCore/Protocols.swiftR63-R69](diffhunk://#diff-3b01a9057aa5176c8561c7397b4496cc3a3609e977835cfd781bcfe44d09f579R63-R69))
* Refactored `DownloadManager` to use the new salvage index instead of filtering all downloads, eliminating unnecessary status checks and tiebreak logic. (`Packages/SeeleseekCore/Sources/SeeleseekCore/Storage/DownloadManager.swift` [Packages/SeeleseekCore/Sources/SeeleseekCore/Storage/DownloadManager.swiftR459-R472](diffhunk://#diff-473413f7f7c0b9edac4781f0bf57f99ae1309950eb2d67ce1c095e6485308d58R459-R472))
* Updated the mock transfer tracker for tests to implement the new salvage lookup method. (`seeleseekTests/PeerConnectivityFixTests.swift` [seeleseekTests/PeerConnectivityFixTests.swiftR489-R495](diffhunk://#diff-8e1f179140b5e8293c0a7a61d3254eebebd1588c425cfd810b3bd397801bfc9aR489-R495))
* Added a new test suite, `TransferStateSalvageIndexTests`, to verify the correctness and performance of the salvage index, including edge cases and status transitions. (`seeleseekTests/TransferStateSalvageIndexTests.swift` [seeleseekTests/TransferStateSalvageIndexTests.swiftR1-R74](diffhunk://#diff-140556ad06fc7260d5a6b20e94f733867f3e5c52c7c7b016f8561ac3eb07839dR1-R74))

**Resource management:**

* Fixed a memory leak in `PeerConnectionPool` by evicting rate-limit history for IPs whose last attempt falls outside the configured window, preventing unbounded growth of the tracking dictionary. (`Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Connections/PeerConnectionPool.swift` [Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Connections/PeerConnectionPool.swiftR537-R547](diffhunk://#diff-b56ebc520dbee8cd683f123b7709cbfa882317690d4676417789071581ab8955R537-R547))

<!--
### Future work
A place to describe changes that can or will be done in follow-up PRs
-->

### How to test

- Ensure all checks pass

### Author checklist

This PR:

- [x] Satisfies a goal that is specific & clearly motivated
- [x] Adds value in isolation (whether user-facing or sustainability-related)
- [x] Contains a concise & easy-to-understand title + description
- [x] Adheres to [SRP](https://en.wikipedia.org/wiki/Single-responsibility_principle) by default
- [x] Presents the best possible implementation to meet its goal, given constraints at hand
