### PR TITLE
fix retain bug in peer pool cleanup timer

### DIFF
--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Connections/PeerConnectionPool.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Connections/PeerConnectionPool.swift
@@ -64,6 +64,12 @@ public final class PeerConnectionPool {
     private var lastBytesReceived: UInt64 = 0
     private var lastBytesSent: UInt64 = 0
 
+    // Owned long-running tasks. Stored so they release `self` when the
+    // pool goes away — without `[weak self]` + tracking, the infinite
+    // loops inside would retain the pool forever.
+    @ObservationIgnored private var speedTrackingTask: Task<Void, Never>?
+    @ObservationIgnored private var cleanupTask: Task<Void, Never>?
+
     // Geographic distribution (when available)
     public private(set) var peerLocations: [PeerLocation] = []
 
@@ -155,10 +161,11 @@ public final class PeerConnectionPool {
     }
 
     private func startCleanupTimer() {
-        Task {
-            while true {
+        cleanupTask = Task { [weak self] in
+            while !Task.isCancelled {
                 try? await Task.sleep(for: .seconds(30))
-                cleanupStaleConnections()
+                guard let self else { return }
+                self.cleanupStaleConnections()
             }
         }
     }
@@ -579,11 +586,11 @@ public final class PeerConnectionPool {
     }
 
     private func startSpeedTracking() {
-        Task { [weak self] in
+        speedTrackingTask = Task { [weak self] in
             while !Task.isCancelled {
                 try? await Task.sleep(for: .seconds(1))
-                if Task.isCancelled { break }
-                self?.captureSpeedSample()
+                guard let self else { return }
+                self.captureSpeedSample()
             }
         }
     }

--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/NetworkClient.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/NetworkClient.swift
@@ -1102,7 +1102,10 @@ public final class NetworkClient {
         let files = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<[SharedFile], Error>) in
             pendingBrowseSharesContinuations[username] = continuation
 
-            // Timeout after 30 seconds
+            // Timeout after 30 seconds. Fire-and-forget: idempotent via
+            // `removeValue` — if the reply arrives first the continuation
+            // is already gone, so this wakes to a no-op. Not worth tracking
+            // per-call; outer `browseUser` is coalesced and itself owned.
             Task { [weak self] in
                 try? await Task.sleep(for: .seconds(30))
                 if let cont = self?.pendingBrowseSharesContinuations.removeValue(forKey: username) {
@@ -1876,6 +1879,10 @@ public final class NetworkClient {
             // Wait for the reply via a per-user continuation, with a hard timeout.
             return try await withCheckedThrowingContinuation { (cont: CheckedContinuation<MessageParser.UserInfoReplyInfo, Error>) in
                 self.userInfoReplyContinuations[username] = cont
+                // Fire-and-forget 15s timeout. Idempotent via `removeValue`:
+                // if the reply arrives first the continuation is already
+                // resumed and removed, so this wake is a no-op. Outer task
+                // is owned by `userInfoInFlight`.
                 Task { [weak self] in
                     try? await Task.sleep(for: .seconds(15))
                     if let waiter = self?.userInfoReplyContinuations.removeValue(forKey: username) {
@@ -2077,7 +2084,9 @@ public final class NetworkClient {
                 return
             }
 
-            // Timeout: deliver nil to all waiters after 10s if no reply.
+            // Fire-and-forget 10s timeout. `deliverArtwork` is idempotent —
+            // if the real reply arrived first the entry is already gone, so
+            // the nil-delivery no-ops. Not worth tracking per-call.
             Task { [weak self] in
                 try? await Task.sleep(for: .seconds(10))
                 self?.deliverArtwork(key: key, data: nil)


### PR DESCRIPTION
### Description

This PR improves the management and documentation of long-running background tasks in both `PeerConnectionPool` and `NetworkClient`, ensuring that tasks are properly owned and don't inadvertently retain their parent objects. It also clarifies the idempotency and ownership of fire-and-forget timeout tasks, making the code safer and easier to maintain.

**Task management improvements in `PeerConnectionPool`:**
- Introduced explicit properties `speedTrackingTask` and `cleanupTask` to hold long-running background tasks, ensuring these tasks are owned by the pool and released appropriately to prevent memory leaks. (`PeerConnectionPool.swift`)
- Updated the cleanup and speed tracking routines to assign their tasks to the new properties and clarified their cancellation and self-retention logic. (`PeerConnectionPool.swift`) [[1]](diffhunk://#diff-b56ebc520dbee8cd683f123b7709cbfa882317690d4676417789071581ab8955L158-R168) [[2]](diffhunk://#diff-b56ebc520dbee8cd683f123b7709cbfa882317690d4676417789071581ab8955L582-R593)

**Timeout handling and documentation in `NetworkClient`:**
- Added documentation to clarify the idempotency and ownership of fire-and-forget timeout tasks for share browsing, user info, and artwork delivery, explaining why these don't require per-call tracking. (`NetworkClient.swift`) [[1]](diffhunk://#diff-f3aa9a82ee1ce3b938a3e39e5b875ff339f1ffad68029fbf374f19ebeaa6c60cL1105-R1108) [[2]](diffhunk://#diff-f3aa9a82ee1ce3b938a3e39e5b875ff339f1ffad68029fbf374f19ebeaa6c60cR1882-R1885) [[3]](diffhunk://#diff-f3aa9a82ee1ce3b938a3e39e5b875ff339f1ffad68029fbf374f19ebeaa6c60cL2080-R2089)
<!--
### Future work
A place to describe changes that can or will be done in follow-up PRs
-->

### How to test

- Ensure all checks pass

### Author checklist

This PR:

- [x] Satisfies a goal that is specific & clearly motivated
- [x] Adds value in isolation (whether user-facing or sustainability-related)
- [x] Contains a concise & easy-to-understand title + description
- [x] Adheres to [SRP](https://en.wikipedia.org/wiki/Single-responsibility_principle) by default
- [x] Presents the best possible implementation to meet its goal, given constraints at hand
