### PR TITLE
fix retry classifier + cancel pending retries on user action

### DIFF
--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Storage/DownloadManager.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Storage/DownloadManager.swift
@@ -2131,43 +2131,45 @@ public final class DownloadManager {
 
     // MARK: - Retry Logic (nicotine+ style)
 
-    /// Check if an error is retriable
-    private func isRetriableError(_ error: String?) -> Bool {
-        guard let error = error?.lowercased() else { return false }
+    /// Classify a download-failure reason as retriable. Used by both the
+    /// scheduled-retry path (after a transient failure) and
+    /// `resumeDownloadsOnConnect` (to decide which persisted `.failed` rows
+    /// to resurrect on next login).
+    ///
+    /// Retry-by-default. The old implementation used an allowlist of
+    /// substrings ("timeout", "connection", "network", …) and returned
+    /// false for anything unmatched, which meant common failure reasons
+    /// like `NetworkError.notConnected`'s "Not connected to server" or
+    /// `NWError.canceled`'s "Operation canceled" (American spelling vs our
+    /// British "cancelled") dropped straight through to "not retriable" —
+    /// no retry ever scheduled, no resume on reconnect. With the retry
+    /// count capped at `maxRetries = 4` the downside of an over-eager
+    /// retry is bounded, so we now flip the default: retry unless the
+    /// error matches an explicit user- or peer-driven stop reason.
+    static func isRetriableError(_ error: String?) -> Bool {
+        guard let lowered = error?.lowercased(), !lowered.isEmpty else {
+            return false
+        }
 
-        // Don't retry on explicit denials or user-initiated cancels
-        let nonRetriablePatterns = [
+        // Known terminal reasons — user action or peer-side decisions
+        // that re-asking won't change. `cancel` (bare stem) matches both
+        // "cancelled" and "canceled" spellings.
+        let terminalPatterns = [
+            "cancel",
             "denied",
             "not shared",
-            "cancelled",
             "not available",
             "file not found",
-            "too many"
+            "too many",
         ]
-
-        for pattern in nonRetriablePatterns {
-            if error.contains(pattern) {
-                return false
-            }
+        for pattern in terminalPatterns {
+            if lowered.contains(pattern) { return false }
         }
+        return true
+    }
 
-        // Retry on connection issues
-        let retriablePatterns = [
-            "timeout",
-            "connection",
-            "network",
-            "unreachable",
-            "firewall",
-            "incomplete"
-        ]
-
-        for pattern in retriablePatterns {
-            if error.contains(pattern) {
-                return true
-            }
-        }
-
-        return false
+    private func isRetriableError(_ error: String?) -> Bool {
+        Self.isRetriableError(error)
     }
 
     private static func formatRetryDelay(_ delay: TimeInterval) -> String {

--- a/seeleseek/App/AppState.swift
+++ b/seeleseek/App/AppState.swift
@@ -75,6 +75,14 @@ final class AppState {
         // buddies), so rows can surface offline state even for strangers.
         transferState.peerWatcher = socialState
 
+        // Cancel any pending retry Task when the user takes a transfer out
+        // of a retriable state (cancel, remove, manual retry, clear failed).
+        // Without this the retry Task sleeps up to 30 min before self-skipping
+        // via its status guard.
+        transferState.onDownloadTerminated = { [weak self] transferId in
+            self?.downloadManager.cancelRetry(transferId: transferId)
+        }
+
         uploadManager.uploadPermissionChecker = { [weak self] username in
             guard let self else { return true }
             let patterns = self.settings.activeBlockedPatterns

--- a/seeleseek/Features/Transfers/TransferState.swift
+++ b/seeleseek/Features/Transfers/TransferState.swift
@@ -422,10 +422,20 @@ final class TransferState: TransferTracking {
         }
     }
 
+    /// Invoked when a user-visible action takes a transfer out of a
+    /// retriable state (cancel, remove, manual retry). Set by AppState to
+    /// `downloadManager.cancelRetry(transferId:)` so any `pendingRetries`
+    /// Task that was sleeping for the next backoff tick is dropped
+    /// immediately instead of waking up to 30 min later and finding it
+    /// has no work to do. The status-guard inside the Task already makes
+    /// the no-op safe; this just stops the wasted sleep.
+    var onDownloadTerminated: ((UUID) -> Void)?
+
     func cancelTransfer(id: UUID) {
         updateTransfer(id: id) { transfer in
             transfer.status = .cancelled
         }
+        onDownloadTerminated?(id)
     }
 
     func retryTransfer(id: UUID) {
@@ -434,6 +444,9 @@ final class TransferState: TransferTracking {
             transfer.bytesTransferred = 0
             transfer.error = nil
         }
+        // The scheduled retry (if any) is now stale — the transfer is
+        // about to be re-driven through startDownload.
+        onDownloadTerminated?(id)
     }
 
     func removeTransfer(id: UUID) {
@@ -441,6 +454,7 @@ final class TransferState: TransferTracking {
         uploads.removeAll { $0.id == id }
         speedHistory.removeValue(forKey: id)
         reconcilePeerWatches()
+        onDownloadTerminated?(id)
 
         // Remove from database
         Task {
@@ -456,6 +470,8 @@ final class TransferState: TransferTracking {
         uploads.removeAll { $0.status == .completed }
         for id in removedIds { speedHistory.removeValue(forKey: id) }
         reconcilePeerWatches()
+        // Completed transfers can't have a pending retry Task, so skip
+        // the onDownloadTerminated fan-out here.
 
         // Clear from database
         Task {
@@ -471,6 +487,7 @@ final class TransferState: TransferTracking {
         uploads.removeAll { $0.status == .failed || $0.status == .cancelled }
         for id in removedIds { speedHistory.removeValue(forKey: id) }
         reconcilePeerWatches()
+        for id in removedIds { onDownloadTerminated?(id) }
 
         // Clear from database
         Task {

--- a/seeleseekTests/DownloadRetryClassifierTests.swift
+++ b/seeleseekTests/DownloadRetryClassifierTests.swift
@@ -1,0 +1,83 @@
+import Testing
+import Foundation
+@testable import SeeleseekCore
+
+/// Regression tests for `DownloadManager.isRetriableError`.
+///
+/// The old implementation used a narrow allowlist of substrings
+/// ("timeout", "connection", "network", "unreachable", "firewall",
+/// "incomplete") and returned false on the default path, so any
+/// `NWError` / `NetworkError` string that didn't happen to contain one
+/// of those tokens silently became non-retriable. The new implementation
+/// retries by default and only rejects known user/peer-stop reasons.
+@Suite("DownloadManager retry classifier")
+struct DownloadRetryClassifierTests {
+
+    // MARK: - Regressions: errors that the old classifier missed
+
+    @Test("NetworkError.notConnected's description retries",
+          arguments: ["Not connected to server"])
+    func notConnectedRetries(message: String) {
+        #expect(DownloadManager.isRetriableError(message) == true)
+    }
+
+    @Test("NWError canceled (American spelling) is treated as user cancel",
+          arguments: [
+            "Operation canceled",
+            "The operation couldn’t be completed. (Network.NWError error 89 - Operation canceled)",
+          ])
+    func canceledIsTerminal(message: String) {
+        #expect(DownloadManager.isRetriableError(message) == false)
+    }
+
+    @Test("British 'cancelled' is still treated as terminal")
+    func cancelledIsTerminal() {
+        #expect(DownloadManager.isRetriableError("Cancelled by user") == false)
+    }
+
+    @Test("Timed-out phrasing retries even without the 'timeout' token",
+          arguments: [
+            "The request timed out",
+            "Connection timed out",
+          ])
+    func timedOutRetries(message: String) {
+        #expect(DownloadManager.isRetriableError(message) == true)
+    }
+
+    @Test("Host-level failures retry",
+          arguments: [
+            "Host is down",
+            "No route to host",
+          ])
+    func hostFailuresRetry(message: String) {
+        #expect(DownloadManager.isRetriableError(message) == true)
+    }
+
+    // MARK: - Terminal reasons
+
+    @Test("Peer-driven stop reasons are not retried",
+          arguments: [
+            "Access denied",
+            "File not shared",
+            "File not found",
+            "File not available",
+            "Too many queued uploads",
+          ])
+    func peerStopReasonsAreTerminal(message: String) {
+        #expect(DownloadManager.isRetriableError(message) == false)
+    }
+
+    // MARK: - Edge cases
+
+    @Test("Nil or empty errors don't retry")
+    func nilOrEmptyIsNonRetriable() {
+        #expect(DownloadManager.isRetriableError(nil) == false)
+        #expect(DownloadManager.isRetriableError("") == false)
+    }
+
+    @Test("Unknown error messages retry by default")
+    func unknownRetries() {
+        #expect(DownloadManager.isRetriableError("Something went wrong") == true)
+        #expect(DownloadManager.isRetriableError("EOFException at byte 1024") == true)
+    }
+}


### PR DESCRIPTION
## Summary

`DownloadManager.isRetriableError` had a latent behavior bug: it used a narrow allowlist of substrings (`timeout`, `connection`, `network`, `unreachable`, `firewall`, `incomplete`) and defaulted to `false` for anything unmatched. Real-world failures slipped through to non-retriable → no retry was ever scheduled, and the same classifier gates `resumeDownloadsOnConnect`, so those rows also didn't auto-resume on reconnect.

Messages that **used to silently become non-retriable:**
- `NetworkError.notConnected`'s `"Not connected to server"` — has "connected", not "connection"
- `NWError` error 89's `"Operation canceled"` — American spelling vs our British "cancelled" pattern
- `"The request timed out"` — no "timeout" substring (it's "timed out")
- `"Host is down"`, `"No route to host"` — no pattern match

This PR flips the default: retry unless the error matches a known user/peer-stop reason (cancel/denied/not shared/not available/file not found/too many). Retry count is still capped at 4 with 30s→2m→10m→30m backoff, so over-eager retry is bounded. `"cancel"` bare stem now matches both "cancelled" and "canceled" spellings.

Also wired `TransferState.cancelTransfer` / `removeTransfer` / `retryTransfer` / `clearFailed` to `DownloadManager.cancelRetry` via a new `onDownloadTerminated` closure set by `AppState`. Previously a scheduled retry Task would keep sleeping up to 30 min after the user cancelled, self-skipping via its status guard on wake — safe but wasteful.

## Test plan

- [x] New `DownloadRetryClassifierTests` covers every regression case above, plus terminal-reason cases and nil/empty edge
- [x] Full unit test suite passes (all pre-existing tests green, no regressions)
- [ ] Manual: kick a download while offline, observe retry scheduled (previously: nothing scheduled)
- [ ] Manual: cancel a download mid-retry-sleep, observe no 30-min ghost Task hanging around

🤖 Generated with [Claude Code](https://claude.com/claude-code)