### PR TITLE
fix retry classifier

### DIFF
--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Storage/DownloadManager.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Storage/DownloadManager.swift
@@ -2131,43 +2131,45 @@ public final class DownloadManager {
 
     // MARK: - Retry Logic (nicotine+ style)
 
-    /// Check if an error is retriable
-    private func isRetriableError(_ error: String?) -> Bool {
-        guard let error = error?.lowercased() else { return false }
+    /// Classify a download-failure reason as retriable. Used by both the
+    /// scheduled-retry path (after a transient failure) and
+    /// `resumeDownloadsOnConnect` (to decide which persisted `.failed` rows
+    /// to resurrect on next login).
+    ///
+    /// Retry-by-default. The old implementation used an allowlist of
+    /// substrings ("timeout", "connection", "network", …) and returned
+    /// false for anything unmatched, which meant common failure reasons
+    /// like `NetworkError.notConnected`'s "Not connected to server" or
+    /// `NWError.canceled`'s "Operation canceled" (American spelling vs our
+    /// British "cancelled") dropped straight through to "not retriable" —
+    /// no retry ever scheduled, no resume on reconnect. With the retry
+    /// count capped at `maxRetries = 4` the downside of an over-eager
+    /// retry is bounded, so we now flip the default: retry unless the
+    /// error matches an explicit user- or peer-driven stop reason.
+    static func isRetriableError(_ error: String?) -> Bool {
+        guard let lowered = error?.lowercased(), !lowered.isEmpty else {
+            return false
+        }
 
-        // Don't retry on explicit denials or user-initiated cancels
-        let nonRetriablePatterns = [
+        // Known terminal reasons — user action or peer-side decisions
+        // that re-asking won't change. `cancel` (bare stem) matches both
+        // "cancelled" and "canceled" spellings.
+        let terminalPatterns = [
+            "cancel",
             "denied",
             "not shared",
-            "cancelled",
             "not available",
             "file not found",
-            "too many"
+            "too many",
         ]
-
-        for pattern in nonRetriablePatterns {
-            if error.contains(pattern) {
-                return false
-            }
+        for pattern in terminalPatterns {
+            if lowered.contains(pattern) { return false }
         }
+        return true
+    }
 
-        // Retry on connection issues
-        let retriablePatterns = [
-            "timeout",
-            "connection",
-            "network",
-            "unreachable",
-            "firewall",
-            "incomplete"
-        ]
-
-        for pattern in retriablePatterns {
-            if error.contains(pattern) {
-                return true
-            }
-        }
-
-        return false
+    private func isRetriableError(_ error: String?) -> Bool {
+        Self.isRetriableError(error)
     }
 
     private static func formatRetryDelay(_ delay: TimeInterval) -> String {

--- a/seeleseek/App/AppState.swift
+++ b/seeleseek/App/AppState.swift
@@ -75,6 +75,14 @@ final class AppState {
         // buddies), so rows can surface offline state even for strangers.
         transferState.peerWatcher = socialState
 
+        // Cancel any pending retry Task when the user takes a transfer out
+        // of a retriable state (cancel, remove, manual retry, clear failed).
+        // Without this the retry Task sleeps up to 30 min before self-skipping
+        // via its status guard.
+        transferState.onDownloadTerminated = { [weak self] transferId in
+            self?.downloadManager.cancelRetry(transferId: transferId)
+        }
+
         uploadManager.uploadPermissionChecker = { [weak self] username in
             guard let self else { return true }
             let patterns = self.settings.activeBlockedPatterns

--- a/seeleseek/Features/Transfers/TransferState.swift
+++ b/seeleseek/Features/Transfers/TransferState.swift
@@ -422,10 +422,20 @@ final class TransferState: TransferTracking {
         }
     }
 
+    /// Invoked when a user-visible action takes a transfer out of a
+    /// retriable state (cancel, remove, manual retry). Set by AppState to
+    /// `downloadManager.cancelRetry(transferId:)` so any `pendingRetries`
+    /// Task that was sleeping for the next backoff tick is dropped
+    /// immediately instead of waking up to 30 min later and finding it
+    /// has no work to do. The status-guard inside the Task already makes
+    /// the no-op safe; this just stops the wasted sleep.
+    var onDownloadTerminated: ((UUID) -> Void)?
+
     func cancelTransfer(id: UUID) {
         updateTransfer(id: id) { transfer in
             transfer.status = .cancelled
         }
+        onDownloadTerminated?(id)
     }
 
     func retryTransfer(id: UUID) {
@@ -434,6 +444,9 @@ final class TransferState: TransferTracking {
             transfer.bytesTransferred = 0
             transfer.error = nil
         }
+        // The scheduled retry (if any) is now stale — the transfer is
+        // about to be re-driven through startDownload.
+        onDownloadTerminated?(id)
     }
 
     func removeTransfer(id: UUID) {
@@ -441,6 +454,7 @@ final class TransferState: TransferTracking {
         uploads.removeAll { $0.id == id }
         speedHistory.removeValue(forKey: id)
         reconcilePeerWatches()
+        onDownloadTerminated?(id)
 
         // Remove from database
         Task {
@@ -456,6 +470,8 @@ final class TransferState: TransferTracking {
         uploads.removeAll { $0.status == .completed }
         for id in removedIds { speedHistory.removeValue(forKey: id) }
         reconcilePeerWatches()
+        // Completed transfers can't have a pending retry Task, so skip
+        // the onDownloadTerminated fan-out here.
 
         // Clear from database
         Task {
@@ -471,6 +487,7 @@ final class TransferState: TransferTracking {
         uploads.removeAll { $0.status == .failed || $0.status == .cancelled }
         for id in removedIds { speedHistory.removeValue(forKey: id) }
         reconcilePeerWatches()
+        for id in removedIds { onDownloadTerminated?(id) }
 
         // Clear from database
         Task {

--- a/seeleseekTests/DownloadRetryClassifierTests.swift
+++ b/seeleseekTests/DownloadRetryClassifierTests.swift
@@ -1,0 +1,83 @@
+import Testing
+import Foundation
+@testable import SeeleseekCore
+
+/// Regression tests for `DownloadManager.isRetriableError`.
+///
+/// The old implementation used a narrow allowlist of substrings
+/// ("timeout", "connection", "network", "unreachable", "firewall",
+/// "incomplete") and returned false on the default path, so any
+/// `NWError` / `NetworkError` string that didn't happen to contain one
+/// of those tokens silently became non-retriable. The new implementation
+/// retries by default and only rejects known user/peer-stop reasons.
+@Suite("DownloadManager retry classifier")
+struct DownloadRetryClassifierTests {
+
+    // MARK: - Regressions: errors that the old classifier missed
+
+    @Test("NetworkError.notConnected's description retries",
+          arguments: ["Not connected to server"])
+    func notConnectedRetries(message: String) {
+        #expect(DownloadManager.isRetriableError(message) == true)
+    }
+
+    @Test("NWError canceled (American spelling) is treated as user cancel",
+          arguments: [
+            "Operation canceled",
+            "The operation couldn’t be completed. (Network.NWError error 89 - Operation canceled)",
+          ])
+    func canceledIsTerminal(message: String) {
+        #expect(DownloadManager.isRetriableError(message) == false)
+    }
+
+    @Test("British 'cancelled' is still treated as terminal")
+    func cancelledIsTerminal() {
+        #expect(DownloadManager.isRetriableError("Cancelled by user") == false)
+    }
+
+    @Test("Timed-out phrasing retries even without the 'timeout' token",
+          arguments: [
+            "The request timed out",
+            "Connection timed out",
+          ])
+    func timedOutRetries(message: String) {
+        #expect(DownloadManager.isRetriableError(message) == true)
+    }
+
+    @Test("Host-level failures retry",
+          arguments: [
+            "Host is down",
+            "No route to host",
+          ])
+    func hostFailuresRetry(message: String) {
+        #expect(DownloadManager.isRetriableError(message) == true)
+    }
+
+    // MARK: - Terminal reasons
+
+    @Test("Peer-driven stop reasons are not retried",
+          arguments: [
+            "Access denied",
+            "File not shared",
+            "File not found",
+            "File not available",
+            "Too many queued uploads",
+          ])
+    func peerStopReasonsAreTerminal(message: String) {
+        #expect(DownloadManager.isRetriableError(message) == false)
+    }
+
+    // MARK: - Edge cases
+
+    @Test("Nil or empty errors don't retry")
+    func nilOrEmptyIsNonRetriable() {
+        #expect(DownloadManager.isRetriableError(nil) == false)
+        #expect(DownloadManager.isRetriableError("") == false)
+    }
+
+    @Test("Unknown error messages retry by default")
+    func unknownRetries() {
+        #expect(DownloadManager.isRetriableError("Something went wrong") == true)
+        #expect(DownloadManager.isRetriableError("EOFException at byte 1024") == true)
+    }
+}


### PR DESCRIPTION
### Description

This PR improves the reliability and maintainability of download retry logic by making the retry classifier more robust and ensuring that user actions immediately cancel any pending retry attempts. It also adds comprehensive regression tests for the new retry classifier.

**Download retry logic improvements:**

* Changed `DownloadManager.isRetriableError` to retry by default for unknown errors, only skipping retries for explicit user or peer stop reasons (e.g., cancel, denied, not shared). This fixes missed retries for common network errors and simplifies the logic.
* Added a full regression test suite for `DownloadManager.isRetriableError`, covering edge cases, regressions from the old implementation, and ensuring that only terminal errors are non-retriable.

**Retry task cancellation on user actions:**

* Introduced a new `onDownloadTerminated` callback in `TransferState`, which is invoked whenever a user-visible action (cancel, remove, manual retry, clear failed) takes a transfer out of a retriable state. This ensures that any pending retry task is canceled immediately, avoiding unnecessary waits. [[1]](diffhunk://#diff-e29ef511cb293c129709cc1f754dc3e39e9ad1f841e978e1983877b87d57af1bR425-R438) [[2]](diffhunk://#diff-e29ef511cb293c129709cc1f754dc3e39e9ad1f841e978e1983877b87d57af1bR447-R457) [[3]](diffhunk://#diff-e29ef511cb293c129709cc1f754dc3e39e9ad1f841e978e1983877b87d57af1bR490) [[4]](diffhunk://#diff-86c2cb35156f4fc4c3307607e46b123d081085dcc461222e54a9073c37d144f3R78-R85)
* Ensured that `onDownloadTerminated` is not called for completed transfers, as they cannot have pending retry tasks.

<!--
### Future work
A place to describe changes that can or will be done in follow-up PRs
-->

### How to test

- Ensure all checks pass

### Author checklist

This PR:

- [x] Satisfies a goal that is specific & clearly motivated
- [x] Adds value in isolation (whether user-facing or sustainability-related)
- [x] Contains a concise & easy-to-understand title + description
- [x] Adheres to [SRP](https://en.wikipedia.org/wiki/Single-responsibility_principle) by default
- [x] Presents the best possible implementation to meet its goal, given constraints at hand
