### PR TITLE
fix handshake symmetry

### DIFF
--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Connections/PeerConnection.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Connections/PeerConnection.swift
@@ -380,7 +380,15 @@ public actor PeerConnection {
         logger.debug("PeerInit sent, handshake marked complete")
 
         // Send SeeleSeek handshake so the peer knows we support extensions
-        try? await send(MessageBuilder.seeleseekHandshakeMessage())
+        try? await sendSeeleSeekHandshake()
+    }
+
+    /// Send the SeeleSeek capability handshake (code 10000). Non-SeeleSeek
+    /// peers drop it as an unknown code. Only safe on P-type sockets — F-type
+    /// connections switch to raw file-transfer bytes after init and would
+    /// misinterpret this message as file data.
+    public func sendSeeleSeekHandshake() async throws {
+        try await send(MessageBuilder.seeleseekHandshakeMessage())
     }
 
     public func sendPierceFirewall() async throws {
@@ -1143,6 +1151,10 @@ public actor PeerConnection {
                 } else {
                     // Regular peer connection - notify the pool
                     eventContinuation.yield(.usernameDiscovered(username: username, token: peerToken))
+                    // Reciprocate the SeeleSeek handshake so the initiator learns
+                    // we're also a SeeleSeek client. Only on P-type sockets —
+                    // F-type is handled above and returns before this point.
+                    try? await sendSeeleSeekHandshake()
                 }
             }
             handshakeComplete = true

--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Handlers/ServerMessageHandler.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Handlers/ServerMessageHandler.swift
@@ -479,6 +479,12 @@ public final class ServerMessageHandler {
             logger.debug("connectToPeerThrottled: connection established, sending PierceFirewall...")
 
             try await connection.sendPierceFirewall()
+            // Announce ourselves as a SeeleSeek client on P-type sockets only.
+            // F-type flips to raw file-transfer bytes after PierceFirewall and
+            // would misinterpret an extra 13-byte message as file data.
+            if connectionType == "P" {
+                try? await connection.sendSeeleSeekHandshake()
+            }
             logger.info("connectToPeerThrottled SUCCESS: \(username)")
 
         } catch {


### PR DESCRIPTION
### Description

This PR enhances the seeleseek handshake process to ensure that all P-type peer connections correctly announce seeleseek capability, improving compatibility and feature negotiation between clients. The changes introduce a dedicated method for sending the seeleseek handshake and ensure it's sent at appropriate points during connection establishment and handshake reciprocation.

**Handshake protocol improvements:**

* Added a new public method `sendSeeleSeekHandshake()` to `PeerConnection`, encapsulating the logic for sending the seeleseek capability handshake message and clarifying its safe use only on P-type sockets.
* Modified the peer connection handshake flow to reciprocate the seeleseek handshake on P-type sockets, ensuring both peers are aware of seeleseek support.
* Updated `ServerMessageHandler` to send the seeleseek handshake after establishing a P-type connection, preventing misinterpretation on F-type connections.
* 
<!--
### Future work
A place to describe changes that can or will be done in follow-up PRs
-->

### How to test

- Ensure all checks pass

### Author checklist

This PR:

- [x] Satisfies a goal that is specific & clearly motivated
- [x] Adds value in isolation (whether user-facing or sustainability-related)
- [x] Contains a concise & easy-to-understand title + description
- [x] Adheres to [SRP](https://en.wikipedia.org/wiki/Single-responsibility_principle) by default
- [x] Presents the best possible implementation to meet its goal, given constraints at hand
