### PR TITLE
fix update view reentry

### DIFF
--- a/seeleseek/Features/Update/UpdateState.swift
+++ b/seeleseek/Features/Update/UpdateState.swift
@@ -1,7 +1,6 @@
 import Foundation
 import os
 #if os(macOS)
-import AppKit
 import SeeleseekCore
 #endif
 
@@ -102,8 +101,15 @@ final class UpdateState {
         }
     }
 
-    func downloadAndInstall() async {
-        guard let pkgAsset = latestPkgURL, let version = latestVersion else { return }
+    /// Download the pkg and return a local URL on success, or nil on
+    /// failure. Does NOT hand the pkg to `NSWorkspace` — the caller is
+    /// responsible for opening it *after* closing the update-prompt
+    /// window, so macOS's window restoration doesn't re-open the prompt
+    /// on the next launch (the installer force-quits us while the window
+    /// is still on screen, and restoration then reopens it regardless of
+    /// the version comparison result). The update-nag loop lived here.
+    func downloadPkg() async -> URL? {
+        guard let pkgAsset = latestPkgURL, let version = latestVersion else { return nil }
 
         isDownloading = true
         downloadProgress = 0
@@ -123,15 +129,13 @@ final class UpdateState {
             downloadedPkgURL = pkgURL
             isDownloading = false
             downloadProgress = nil
-
-            #if os(macOS)
-            NSWorkspace.shared.open(pkgURL)
-            #endif
+            return pkgURL
         } catch {
             logger.error("Download failed: \(error.localizedDescription)")
             errorMessage = error.localizedDescription
             isDownloading = false
             downloadProgress = nil
+            return nil
         }
     }
 

--- a/seeleseek/Features/Update/Views/UpdatePromptSheet.swift
+++ b/seeleseek/Features/Update/Views/UpdatePromptSheet.swift
@@ -1,4 +1,7 @@
 import SwiftUI
+#if os(macOS)
+import AppKit
+#endif
 import SeeleseekCore
 
 struct UpdatePromptSheet: View {
@@ -83,7 +86,23 @@ struct UpdatePromptSheet: View {
                 downloadProgress
             } else {
                 Button("Download & Install") {
-                    Task { await updateState.downloadAndInstall() }
+                    // Sequence is load-bearing: download, then dismiss
+                    // this window, *then* hand the pkg to Installer.app.
+                    // If we leave the window visible when Installer
+                    // force-quits us, macOS restores it on next launch
+                    // regardless of the version comparison result — the
+                    // long-running "update-prompt loops after install"
+                    // bug. Closing first ensures restoration won't
+                    // re-open it.
+                    Task {
+                        guard let pkgURL = await updateState.downloadPkg() else {
+                            return
+                        }
+                        close()
+                        #if os(macOS)
+                        NSWorkspace.shared.open(pkgURL)
+                        #endif
+                    }
                 }
                 .keyboardShortcut(.defaultAction)
                 .disabled(updateState.latestPkgURL == nil)

--- a/seeleseek/Features/Update/Views/UpdateSettingsSection.swift
+++ b/seeleseek/Features/Update/Views/UpdateSettingsSection.swift
@@ -1,4 +1,7 @@
 import SwiftUI
+#if os(macOS)
+import AppKit
+#endif
 import SeeleseekCore
 
 struct UpdateSettingsSection: View {
@@ -145,7 +148,14 @@ struct UpdateSettingsSection: View {
                     } else {
                         HStack {
                             Button("Download & Install") {
-                                Task { await updateState.downloadAndInstall() }
+                                Task {
+                                    guard let pkgURL = await updateState.downloadPkg() else {
+                                        return
+                                    }
+                                    #if os(macOS)
+                                    NSWorkspace.shared.open(pkgURL)
+                                    #endif
+                                }
                             }
                             .font(SeeleTypography.body)
                             .foregroundStyle(SeeleColors.accent)

--- a/seeleseek/Navigation/MainView.swift
+++ b/seeleseek/Navigation/MainView.swift
@@ -5,6 +5,7 @@ struct MainView: View {
     @Environment(\.appState) private var appState
     #if os(macOS)
     @Environment(\.openWindow) private var openWindow
+    @Environment(\.dismissWindow) private var dismissWindow
     #endif
 
     var body: some View {
@@ -18,13 +19,24 @@ struct MainView: View {
         .preferredColorScheme(.dark)
         #if os(macOS)
         .onChange(of: appState.updateState.showUpdatePrompt) { _, show in
-            if show { openWindow(id: "update-prompt") }
+            if show {
+                openWindow(id: "update-prompt")
+            } else {
+                dismissWindow(id: "update-prompt")
+            }
         }
         .task {
             // Catch the case where checkForUpdate() already flipped the flag
             // before onChange had a chance to install.
             if appState.updateState.showUpdatePrompt {
                 openWindow(id: "update-prompt")
+            } else {
+                // Defense: if macOS's window restoration re-opened the
+                // update-prompt window from a previous session (the
+                // Installer force-quit us before we could dismiss it),
+                // dismiss it now. We only reach this branch when there's
+                // no update to show, so any restored window is stale.
+                dismissWindow(id: "update-prompt")
             }
         }
         #endif


### PR DESCRIPTION
### Description

This PR refactors the update process on macOS to fix a long-standing bug where the update prompt window would reappear after installing an update. The main improvement is to ensure the update prompt window is closed before launching the installer, preventing macOS from restoring the window on the next launch. The update logic is also split so that downloading and installing are handled separately.

**Update process improvements:**

* Refactored the update logic by splitting the `downloadAndInstall` method into a new `downloadPkg` method, which only downloads the package and returns its URL; the responsibility for opening the installer and closing the update prompt window now belongs to the caller. This prevents the update prompt window from being restored after installation. [[1]](diffhunk://#diff-f049c0dec2fb328f8479386f614b8d62efaf98d3be160c7cebf784519b97f5f5L105-R112) [[2]](diffhunk://#diff-f049c0dec2fb328f8479386f614b8d62efaf98d3be160c7cebf784519b97f5f5L126-R138)
* Updated both `UpdatePromptSheet` and `UpdateSettingsSection` views to first download the package, then close the update prompt window (if applicable), and only then open the installer using `NSWorkspace.shared.open(pkgURL)`. This fixes the "update-prompt loops after install" bug. [[1]](diffhunk://#diff-27a2511c032d94b296be688b7e08ce125297ecd03ea092ee788d68f0cddbe571L86-R105) [[2]](diffhunk://#diff-3f2661797184b73acd47ad47598da037692dfa7fd4cd08310c0732b1292927f5L148-R158)

**macOS window management:**

* Added usage of the `dismissWindow` environment value in `MainView` to allow programmatic dismissal of the update prompt window.
* Enhanced window management in `MainView` so that the update prompt window is explicitly dismissed when not needed, including after restoration from a previous session, ensuring no stale update prompts are shown.

**Dependency and import adjustments:**

* Moved `AppKit` imports to the correct files and under `#if os(macOS)` guards to ensure platform-specific code is only included where necessary. [[1]](diffhunk://#diff-f049c0dec2fb328f8479386f614b8d62efaf98d3be160c7cebf784519b97f5f5L4) [[2]](diffhunk://#diff-27a2511c032d94b296be688b7e08ce125297ecd03ea092ee788d68f0cddbe571R2-R4) [[3]](diffhunk://#diff-3f2661797184b73acd47ad47598da037692dfa7fd4cd08310c0732b1292927f5R2-R4)
<!--
### Future work
A place to describe changes that can or will be done in follow-up PRs
-->

### How to test

- Ensure all checks pass

### Author checklist

This PR:

- [x] Satisfies a goal that is specific & clearly motivated
- [x] Adds value in isolation (whether user-facing or sustainability-related)
- [x] Contains a concise & easy-to-understand title + description
- [x] Adheres to [SRP](https://en.wikipedia.org/wiki/Single-responsibility_principle) by default
- [x] Presents the best possible implementation to meet its goal, given constraints at hand
