### PR TITLE
fix stale social statuses

### DIFF
--- a/seeleseek/App/AppState.swift
+++ b/seeleseek/App/AppState.swift
@@ -71,6 +71,9 @@ final class AppState {
                 // Re-send peer-status watches (earlier attempts made
                 // during the connecting phase may have been dropped).
                 self.socialState.resubscribeWatchedPeers()
+                // The server wipes buddy watches and interests on every
+                // disconnect. Restore them on each connect
+                self.socialState.resubscribeOnConnect()
             case .disconnected:
                 self.connection.setDisconnected()
             case .connecting:

--- a/seeleseek/Features/Social/SocialState.swift
+++ b/seeleseek/Features/Social/SocialState.swift
@@ -130,21 +130,19 @@ final class SocialState: PeerWatching {
     }
 
     /// Begin watching `username` for live status updates. Ref-counted —
-    /// callers must pair each call with `unwatchPeer`. Buddies don't need
-    /// `watchUser` (the server auto-pushes), but we still issue an
-    /// explicit `getUserStatus` to pull a fresh reading into the cache.
+    /// callers must pair each call with `unwatchPeer`. `watchUser` is
+    /// sent for every peer, buddy or not. The server pushes status only
+    /// for users watched in the CURRENT session; there is no automatic
+    /// push for buddies.
     func watchPeer(_ username: String) {
         guard !username.isEmpty else { return }
         let count = (peerWatchRefCounts[username] ?? 0) + 1
         peerWatchRefCounts[username] = count
         guard count == 1 else { return }   // already subscribed
-        let isBuddy = buddies.contains(where: { $0.username == username })
         Task { [weak self] in
             guard let self, let client = self.networkClient else { return }
             do {
-                if !isBuddy {
-                    try await client.watchUser(username)
-                }
+                try await client.watchUser(username)
                 // Pull a status immediately rather than waiting for the
                 // server to push one — ensures rows for failed persisted
                 // transfers reflect offline state as soon as we connect.
@@ -166,11 +164,8 @@ final class SocialState: PeerWatching {
         Task { [weak self] in
             guard let self, let client = self.networkClient else { return }
             for peer in peers {
-                let isBuddy = self.buddies.contains(where: { $0.username == peer })
                 do {
-                    if !isBuddy {
-                        try await client.watchUser(peer)
-                    }
+                    try await client.watchUser(peer)
                     try await client.getUserStatus(peer)
                 } catch {
                     self.logger.error("resubscribeWatchedPeers(\(peer)) failed: \(error.localizedDescription)")
@@ -179,11 +174,23 @@ final class SocialState: PeerWatching {
         }
     }
 
+    /// Restore every server-side subscription that a disconnect wipes:
+    /// buddy watches and interests. Call on each `.connected` event.
+    /// The login race makes a fixed-delay rewatch unreliable, so the
+    /// connection event is the trigger.
+    func resubscribeOnConnect() {
+        Task { [weak self] in
+            guard let self else { return }
+            await self.rewatchAllBuddies()
+            await self.reregisterInterests()
+        }
+    }
+
     /// Release one watch on `username`. When the refcount hits zero the
-    /// server subscription is torn down. For buddies we keep the
-    /// `peerStatuses` entry around (it's seeded from the buddy list and
-    /// kept fresh by the auto-pushed buddy status updates) so the buddy's
-    /// row still shows a status after the last transfer goes away.
+    /// server subscription is torn down. For buddies the subscription
+    /// and the `peerStatuses` entry stay: `rewatchAllBuddies` owns the
+    /// buddy watch, so the buddy's row still shows a live status after
+    /// the last transfer goes away.
     func unwatchPeer(_ username: String) {
         guard !username.isEmpty else { return }
         let count = (peerWatchRefCounts[username] ?? 0) - 1
@@ -372,9 +379,12 @@ final class SocialState: PeerWatching {
                 leechSettings = try JSONDecoder().decode(LeechSettings.self, from: data)
             }
 
-            // Request status updates for all buddies and re-register interests after a short delay
-            Task {
-                try? await Task.sleep(for: .seconds(2))
+            // The `.connected` event triggers the normal rewatch. This
+            // covers the reverse order: the connection came up before
+            // the buddy list finished loading, so that trigger ran with
+            // zero buddies. `watchUser` is idempotent, so an overlap
+            // with the event-driven pass is harmless.
+            if networkClient?.isConnected == true {
                 await rewatchAllBuddies()
                 await reregisterInterests()
             }


### PR DESCRIPTION
### Description

This PR addresses the restoration of server-side subscriptions (buddy watches and interests) after a disconnect, and clarifies/refines the peer watching logic to match updated server behavior. The most important changes are grouped below.

**Restoration of server-side subscriptions on reconnect:**

* Added a new `resubscribeOnConnect` method to `SocialState` that restores all buddy watches and interests on each `.connected` event, ensuring the client properly re-establishes state with the server after a disconnect. This is now triggered from `AppState` when a connection is established. [[1]](diffhunk://#diff-86c2cb35156f4fc4c3307607e46b123d081085dcc461222e54a9073c37d144f3R74-R76) [[2]](diffhunk://#diff-aad5c15cbd52ed027fad5be74c9409c9d6e8601d3b754e7394d570ccff3b54e7R177-R193)

* Improved the logic in the buddy list loader to handle cases where the connection is established before the buddy list is loaded, ensuring subscriptions are always restored (and making the process idempotent).

**Peer watching logic updates:**

* Modified `watchPeer` so that a `watchUser` request is sent for every peer (buddy or not), reflecting that the server now only pushes status updates for users watched in the current session—there is no automatic push for buddies.

* Updated `resubscribeWatchedPeers` to always send `watchUser` for all watched peers, regardless of buddy status, to align with the new server behavior.

* Clarified and updated documentation and logic around reference counting and unwatching peers, reflecting that buddy watches are now owned by `rewatchAllBuddies` and persist independently of transfer activity.


### Future work
- fix/optimistic UI for entire folder downloads
- fix file does not exist in upload history

### How to test

- Ensure all checks pass

### Author checklist

This PR:

- [x] Satisfies a goal that is specific & clearly motivated
- [x] Adds value in isolation (whether user-facing or sustainability-related)
- [x] Contains a concise & easy-to-understand title + description
- [x] Adheres to [SRP](https://en.wikipedia.org/wiki/Single-responsibility_principle) by default
- [x] Presents the best possible implementation to meet its goal, given constraints at hand
