### PR TITLE
fix downloading folder stall

### DIFF
--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Connections/PeerConnectionPool.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Connections/PeerConnectionPool.swift
@@ -99,9 +99,6 @@ public final class PeerConnectionPool {
     // MARK: - Configuration
 
     public let maxConnections = 50
-    /// Reserve for incoming connections, so a search burst that fills
-    /// the pool cannot block PierceFirewall connect-backs.
-    public let incomingHeadroom = 8
     public let maxConnectionsPerIP = 30  // Allow bulk transfers while preventing abuse
     public let connectionTimeout: TimeInterval = 60
 
@@ -447,8 +444,8 @@ public final class PeerConnectionPool {
     /// admission limits (per-IP, global, rate-limit).
     public func handleIncomingConnection(_ nwConnection: NWConnection, obfuscated: Bool = false) async {
         // Enforce connection limit to prevent resource exhaustion
-        if activeConnections >= maxConnections + incomingHeadroom {
-            logger.warning("Connection limit reached (\(self.maxConnections + self.incomingHeadroom)), rejecting connection from \(String(describing: nwConnection.endpoint))")
+        if activeConnections >= maxConnections {
+            logger.warning("Connection limit reached (\(self.maxConnections)), rejecting connection from \(String(describing: nwConnection.endpoint))")
             nwConnection.cancel()
             return
         }

--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Connections/PeerConnectionPool.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Connections/PeerConnectionPool.swift
@@ -99,6 +99,9 @@ public final class PeerConnectionPool {
     // MARK: - Configuration
 
     public let maxConnections = 50
+    /// Reserve for incoming connections, so a search burst that fills
+    /// the pool cannot block PierceFirewall connect-backs.
+    public let incomingHeadroom = 8
     public let maxConnectionsPerIP = 30  // Allow bulk transfers while preventing abuse
     public let connectionTimeout: TimeInterval = 60
 
@@ -444,9 +447,8 @@ public final class PeerConnectionPool {
     /// admission limits (per-IP, global, rate-limit).
     public func handleIncomingConnection(_ nwConnection: NWConnection, obfuscated: Bool = false) async {
         // Enforce connection limit to prevent resource exhaustion
-        if activeConnections >= maxConnections {
-            logger.warning("Connection limit reached (\(self.maxConnections)), rejecting connection from \(String(describing: nwConnection.endpoint))")
-            logger.warning("Connection limit reached, rejecting: \(String(describing: nwConnection.endpoint))")
+        if activeConnections >= maxConnections + incomingHeadroom {
+            logger.warning("Connection limit reached (\(self.maxConnections + self.incomingHeadroom)), rejecting connection from \(String(describing: nwConnection.endpoint))")
             nwConnection.cancel()
             return
         }
@@ -620,9 +622,12 @@ public final class PeerConnectionPool {
     /// ("incoming-*"), and a prefix-match on the outgoing form could also
     /// incorrectly match a different user whose name shares a dash-prefix
     /// (e.g. "bob" matching "bob-1-42").
+    ///
+    /// Only P-type connections match: an F-type socket has no receive
+    /// loop, so a message written to one gets no reply and no error.
     public func getConnectionForUser(_ username: String) async -> PeerConnection? {
         let matchingKeys = connections.compactMap { (key, info) -> String? in
-            info.username == username ? key : nil
+            info.username == username && info.connectionType == .peer ? key : nil
         }
 
         for key in matchingKeys {

--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Handlers/ServerMessageHandler.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Handlers/ServerMessageHandler.swift
@@ -542,35 +542,6 @@ public final class ServerMessageHandler {
         }
     }
 
-    /// Race `operation` against a `seconds` deadline. On timeout the task
-    /// group's cleanup signals cancellation to the operation child; for it
-    /// to actually unwind the operation must respect Task cancellation
-    /// (e.g. cancellable async APIs, or its own state checks). The
-    /// operation child here is `pool.connect`, which uses Network.framework
-    /// state handlers — not natively cancellation-aware — so a wedged peer
-    /// connection may continue dangling in the pool's bookkeeping until
-    /// the pool's own staleness sweep picks it up. The mitigation that
-    /// matters here is upstream: the queue processor no longer awaits this
-    /// call serially, so one stuck child can't block the entire queue.
-    private func withTimeout<T: Sendable>(seconds: TimeInterval, operation: @Sendable @escaping () async throws -> T) async throws -> T {
-        return try await withThrowingTaskGroup(of: T.self) { group in
-            group.addTask {
-                try await operation()
-            }
-
-            group.addTask {
-                try await Task.sleep(for: .seconds(seconds))
-                throw NetworkError.timeout
-            }
-
-            guard let result = try await group.next() else {
-                throw NetworkError.timeout
-            }
-            group.cancelAll()
-            return result
-        }
-    }
-
     // MARK: - Distributed Network Handlers
 
     private func handlePossibleParents(_ data: Data) {

--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/NetworkClient.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/NetworkClient.swift
@@ -2601,38 +2601,48 @@ public final class NetworkClient {
         let useObfuscated = obfuscatedPort > 0
         let dialPort = useObfuscated ? obfuscatedPort : port
 
-        var connection: PeerConnection
-        var isIndirect = false
-        do {
-            connection = try await withThrowingTaskGroup(of: PeerConnection.self) { group in
-                group.addTask {
-                    let conn = try await self.peerConnectionPool.connect(
-                        to: username, ip: ip, port: dialPort, token: token, obfuscated: useObfuscated
-                    )
-                    // PeerInit is a one-way direct-connection initializer in
-                    // the Soulseek protocol. `pool.connect` has already sent
-                    // our PeerInit successfully, so the P connection is ready
-                    // for peer messages now. Most clients (including
-                    // SoulseekQt) do not send a reciprocal PeerInit; waiting
-                    // for one here turns a healthy direct connection into an
-                    // artificial handshake timeout.
-                    return conn
+        // Both legs run together: a firewalled peer cannot accept the
+        // direct dial, and its pierce often arrives in under a second.
+        let (connection, isIndirect) = try await withThrowingTaskGroup(of: (PeerConnection, Bool).self) { group in
+            group.addTask {
+                // Cap the direct leg: a raw TCP dial can hang for 60 s.
+                let direct = try await withThrowingTaskGroup(of: PeerConnection.self) { inner in
+                    inner.addTask {
+                        // Most clients send no reciprocal PeerInit, and
+                        // pool.connect already sent ours. Do not wait.
+                        try await self.peerConnectionPool.connect(
+                            to: username, ip: ip, port: dialPort, token: token, obfuscated: useObfuscated
+                        )
+                    }
+                    inner.addTask {
+                        try await Task.sleep(for: .seconds(10))
+                        throw NetworkError.timeout
+                    }
+                    let result = try await inner.next()!
+                    inner.cancelAll()
+                    return result
                 }
-                group.addTask {
-                    try await Task.sleep(for: .seconds(10))
-                    throw NetworkError.timeout
-                }
-                let result = try await group.next()!
-                group.cancelAll()
-                return result
+                return (direct, false)
             }
+            group.addTask {
+                (try await self.waitForPendingBrowse(token: token), true)
+            }
+            // nextResult, not next: one leg's failure must not abort
+            // the other.
+            var lastError: Error = NetworkError.timeout
+            while let result = await group.nextResult() {
+                switch result {
+                case .success(let winner):
+                    group.cancelAll()
+                    return winner
+                case .failure(let error):
+                    if !(error is CancellationError) { lastError = error }
+                }
+            }
+            throw lastError
+        }
+        if !isIndirect {
             cancelPendingBrowse(token: token)
-        } catch {
-            // Direct timed out or handshake failed — the direct-dial child
-            // already tore down its own connection; wait for the peer's
-            // indirect PierceFirewall connection instead.
-            connection = try await waitForPendingBrowse(token: token)
-            isIndirect = true
         }
 
         if isIndirect {

--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/NetworkClient.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/NetworkClient.swift
@@ -2606,21 +2606,12 @@ public final class NetworkClient {
         let (connection, isIndirect) = try await withThrowingTaskGroup(of: (PeerConnection, Bool).self) { group in
             group.addTask {
                 // Cap the direct leg: a raw TCP dial can hang for 60 s.
-                let direct = try await withThrowingTaskGroup(of: PeerConnection.self) { inner in
-                    inner.addTask {
-                        // Most clients send no reciprocal PeerInit, and
-                        // pool.connect already sent ours. Do not wait.
-                        try await self.peerConnectionPool.connect(
-                            to: username, ip: ip, port: dialPort, token: token, obfuscated: useObfuscated
-                        )
-                    }
-                    inner.addTask {
-                        try await Task.sleep(for: .seconds(10))
-                        throw NetworkError.timeout
-                    }
-                    let result = try await inner.next()!
-                    inner.cancelAll()
-                    return result
+                // Most clients send no reciprocal PeerInit, and pool.connect
+                // already sent ours. Do not wait.
+                let direct = try await withTimeout(seconds: 10) {
+                    try await self.peerConnectionPool.connect(
+                        to: username, ip: ip, port: dialPort, token: token, obfuscated: useObfuscated
+                    )
                 }
                 return (direct, false)
             }
@@ -2628,23 +2619,32 @@ public final class NetworkClient {
                 (try await self.waitForPendingBrowse(token: token), true)
             }
             // nextResult, not next: one leg's failure must not abort
-            // the other.
+            // the other. Drain every child: a pierce that was consumed by
+            // the waiter but lost the race is not in the pool and not in
+            // `pendingBrowseStates`, so nothing else can close it. A losing
+            // direct connection stays pool-tracked and reusable.
+            var winner: (PeerConnection, Bool)?
             var lastError: Error = NetworkError.timeout
             while let result = await group.nextResult() {
                 switch result {
-                case .success(let winner):
-                    group.cancelAll()
-                    return winner
+                case .success(let value):
+                    if winner == nil {
+                        winner = value
+                        group.cancelAll()
+                    } else if value.1 {
+                        await value.0.disconnect()
+                    }
                 case .failure(let error):
                     if !(error is CancellationError) { lastError = error }
                 }
             }
+            if let winner { return winner }
+            // Both legs report CancellationError when the establishment
+            // itself was cancelled (disconnect) — do not dress that up as
+            // a timeout.
+            try Task.checkCancellation()
             throw lastError
         }
-        if !isIndirect {
-            cancelPendingBrowse(token: token)
-        }
-
         if isIndirect {
             // PierceFirewall stops the receive loop assuming file-transfer
             // mode. P connections need it resumed for peer messages.
@@ -2654,6 +2654,8 @@ public final class NetworkClient {
             // connection. Keep this validation scoped to that path; direct
             // connections are initialized by the PeerInit we send.
             try await connection.waitForPeerHandshake(timeout: .seconds(5))
+        } else {
+            cancelPendingBrowse(token: token)
         }
         return connection
     }

--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Utilities/WithTimeout.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Utilities/WithTimeout.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// Race `operation` against a `seconds` deadline.
+///
+/// The group awaits both children before returning, so this only bounds the
+/// caller's wait if `operation` responds to cancellation. An operation that
+/// ignores it silently un-bounds every caller of this function.
+func withTimeout<T: Sendable>(
+    seconds: TimeInterval,
+    operation: @Sendable @escaping () async throws -> T
+) async throws -> T {
+    try await withThrowingTaskGroup(of: T.self) { group in
+        group.addTask {
+            try await operation()
+        }
+        group.addTask {
+            try await Task.sleep(for: .seconds(seconds))
+            throw NetworkError.timeout
+        }
+        guard let result = try await group.next() else {
+            throw NetworkError.timeout
+        }
+        group.cancelAll()
+        return result
+    }
+}

--- a/seeleseek/App/AppState.swift
+++ b/seeleseek/App/AppState.swift
@@ -225,17 +225,18 @@ final class AppState {
                 return
             }
             let username = pending.username
-            self.folderRequestStates.removeValue(forKey: Self.folderKey(username: username, folder: pending.folder))
-            let queued = self.queueFolderDownload(files: files, from: username, folder: folder)
-            if !files.isEmpty {
-                ActivityLog.shared.log(.downloadStarted, title: "Queued \(queued) files from \(username)", detail: folder, username: username)
-                VoiceOverAnnouncer.shared.announce("Queued \(queued) files from \(username)")
-            }
-            self.logger.info("Folder download from \(username) in '\(folder)': queued \(queued)/\(files.count) files")
             if files.isEmpty {
-                ActivityLog.shared.log(.error, title: "Folder download from \(username) found no files", detail: folder, username: username)
-                VoiceOverAnnouncer.shared.announce("Folder download from \(username) found no files")
+                self.markFolderRequestFailed(pending, reason: "\(username) shared no files in this folder")
+                ActivityLog.shared.logFolderRequestFailed(
+                    username: username, folder: folder,
+                    reason: "\(username) shared no files in this folder"
+                )
+                return
             }
+            self.clearFolderRequestState(pending)
+            let queued = self.queueFolderDownload(files: files, from: username, folder: folder)
+            self.logger.info("Folder download from \(username) in '\(folder)': queued \(queued)/\(files.count) files")
+            ActivityLog.shared.logFolderQueued(count: queued, username: username, folder: folder)
         }
 
         client.searchResponseFilter = { [weak self] in
@@ -248,56 +249,55 @@ final class AppState {
                 maxResults: settings.maxSearchResponseResults
             )
         }
-
-        // ShareManager construction is side-effect-free; load + rescan
-        // are explicit so they happen after the countsChangesStream
-        // consumer above is wired.
-        // A preview must not scan the filesystem.
-        guard !SeeleSeekApp.isRunningInPreview else { return }
-        client.shareManager.loadPersistedFolders()
-        Task { await client.shareManager.rescanAll() }
     }
 
     // MARK: - Folder Download Coordinator
-    // Response events carry only `(token, folder, files)`.
-    private struct PendingFolderDownload {
+    struct FolderRequest: Hashable {
         let username: String
         let folder: String
     }
-    private var pendingFolderDownloads: [UInt32: PendingFolderDownload] = [:]
+    private var pendingFolderDownloads: [UInt32: FolderRequest] = [:]
 
     enum FolderRequestState: Equatable {
         case fetching
         case failed(String)
     }
 
-    /// Keyed by user and folder. Search rows read this.
-    private(set) var folderRequestStates: [String: FolderRequestState] = [:]
-
-    private static func folderKey(username: String, folder: String) -> String {
-        "\(username)\u{0000}\(folder)"
-    }
+    private(set) var folderRequestStates: [FolderRequest: FolderRequestState] = [:]
+    private var folderFailureClearTasks: [FolderRequest: Task<Void, Never>] = [:]
 
     func folderRequestState(for result: SearchResult) -> FolderRequestState? {
+        // Every visible row calls this on every render — skip the path parse.
+        guard !folderRequestStates.isEmpty else { return nil }
         let folder = Self.containingSoulseekFolder(of: result.filename)
         guard !folder.isEmpty else { return nil }
-        return folderRequestStates[Self.folderKey(username: result.username, folder: folder)]
+        return folderRequestStates[FolderRequest(username: result.username, folder: folder)]
     }
 
     #if DEBUG
-    /// Previews cannot write `folderRequestStates`: the setter is file private.
     func previewSeedFolderRequest(_ state: FolderRequestState, for result: SearchResult) {
         let folder = Self.containingSoulseekFolder(of: result.filename)
-        folderRequestStates[Self.folderKey(username: result.username, folder: folder)] = state
+        folderRequestStates[FolderRequest(username: result.username, folder: folder)] = state
     }
     #endif
 
-    private func markFolderRequestFailed(key: String, reason: String) {
-        folderRequestStates[key] = .failed(reason)
-        Task { [weak self] in
+    private func clearFolderRequestState(_ request: FolderRequest) {
+        folderFailureClearTasks.removeValue(forKey: request)?.cancel()
+        folderRequestStates.removeValue(forKey: request)
+    }
+
+    /// Cancel-and-replace: without it, an older failure's 30 s timer can
+    /// clear a newer failure for the same folder early.
+    private func markFolderRequestFailed(_ request: FolderRequest, reason: String) {
+        folderRequestStates[request] = .failed(reason)
+        folderFailureClearTasks[request]?.cancel()
+        folderFailureClearTasks[request] = Task { [weak self] in
             try? await Task.sleep(for: .seconds(30))
-            guard let self, case .failed = self.folderRequestStates[key] else { return }
-            self.folderRequestStates.removeValue(forKey: key)
+            guard let self, !Task.isCancelled else { return }
+            self.folderFailureClearTasks.removeValue(forKey: request)
+            if case .failed = self.folderRequestStates[request] {
+                self.folderRequestStates.removeValue(forKey: request)
+            }
         }
     }
 
@@ -311,46 +311,47 @@ final class AppState {
             logger.warning("Could not derive containing folder from filename: \(result.filename)")
             return
         }
-        let key = Self.folderKey(username: result.username, folder: folder)
-        folderRequestStates[key] = .fetching
-        // Everything below can take a minute inside the peer
-        // connection, so timestamp the click itself.
+        let request = FolderRequest(username: result.username, folder: folder)
+        guard folderRequestStates[request] != .fetching else { return }
+        folderRequestStates[request] = .fetching
         let started = Date()
         logger.info("Folder download clicked: \(result.username) '\(folder)'")
-        ActivityLog.shared.log(.info, title: "Getting folder contents from \(result.username)", detail: folder, username: result.username)
-        VoiceOverAnnouncer.shared.announce("Getting folder contents from \(result.username)")
+        ActivityLog.shared.logFolderRequestStarted(username: result.username, folder: folder)
         do {
             let token = try await networkClient.requestFolderContents(
                 from: result.username,
                 folder: folder
             )
-            pendingFolderDownloads[token] = PendingFolderDownload(username: result.username, folder: folder)
+            pendingFolderDownloads[token] = request
             logger.info("Requested folder contents '\(folder)' from \(result.username) (token=\(token)) after \(Int(Date().timeIntervalSince(started) * 1000)) ms")
-            scheduleFolderDownloadTimeout(token: token, username: result.username, folder: folder)
+            scheduleFolderDownloadTimeout(token: token, request: request)
         } catch {
             let elapsed = Int(Date().timeIntervalSince(started))
-            let reason = "Could not reach \(result.username) after \(elapsed) seconds"
-            markFolderRequestFailed(key: key, reason: reason)
+            let reason = networkClient.isConnected
+                ? "Could not reach \(result.username) after \(elapsed) seconds"
+                : "Not connected to the Soulseek server"
+            markFolderRequestFailed(request, reason: reason)
             logger.error("Failed to request folder contents after \(elapsed) s: \(error.localizedDescription)")
-            ActivityLog.shared.log(.error, title: "Folder download from \(result.username) failed", detail: reason, username: result.username)
-            VoiceOverAnnouncer.shared.announce(reason)
+            ActivityLog.shared.logFolderRequestFailed(
+                username: result.username, folder: folder, reason: reason
+            )
         }
     }
 
     /// Warn at 60 s but keep the entry for 5 more minutes: firewalled
     /// peers can need 45 s before the request is even sent, and those
     /// late replies must still queue.
-    private func scheduleFolderDownloadTimeout(token: UInt32, username: String, folder: String) {
+    private func scheduleFolderDownloadTimeout(token: UInt32, request: FolderRequest) {
         Task { [weak self] in
             try? await Task.sleep(for: .seconds(60))
             guard let self, self.pendingFolderDownloads[token] != nil else { return }
-            self.markFolderRequestFailed(
-                key: Self.folderKey(username: username, folder: folder),
-                reason: "\(username) did not answer within 60 seconds"
-            )
+            let (username, folder) = (request.username, request.folder)
+            let reason = "\(username) did not answer within 60 seconds"
+            self.markFolderRequestFailed(request, reason: reason)
             self.logger.info("Folder contents request slow: \(username) '\(folder)' (token=\(token))")
-            ActivityLog.shared.log(.error, title: "Folder download from \(username) did not start: no answer after 60 seconds", detail: folder, username: username)
-            VoiceOverAnnouncer.shared.announce("Folder download from \(username) did not start")
+            ActivityLog.shared.logFolderRequestFailed(
+                username: username, folder: folder, reason: reason
+            )
 
             try? await Task.sleep(for: .seconds(300))
             if self.pendingFolderDownloads.removeValue(forKey: token) != nil {
@@ -459,6 +460,12 @@ final class AppState {
         // Configure notifications
         NotificationService.shared.settings = settings
         NotificationService.shared.requestAuthorization()
+
+        // Not in wireNetworkClient: previews and the test host skip
+        // configure(), so neither scans the filesystem.
+        let client = networkClient
+        client.shareManager.loadPersistedFolders()
+        Task { await client.shareManager.rescanAll() }
 
         // Initialize database asynchronously
         Task {

--- a/seeleseek/App/AppState.swift
+++ b/seeleseek/App/AppState.swift
@@ -221,11 +221,21 @@ final class AppState {
         // we later send to them comes back `File not shared`.
         client.onFolderContentsResponse = { [weak self] token, folder, files in
             guard let self,
-                  let username = self.pendingFolderDownloads.removeValue(forKey: token) else {
+                  let pending = self.pendingFolderDownloads.removeValue(forKey: token) else {
                 return
             }
+            let username = pending.username
+            self.folderRequestStates.removeValue(forKey: Self.folderKey(username: username, folder: pending.folder))
             let queued = self.queueFolderDownload(files: files, from: username, folder: folder)
+            if !files.isEmpty {
+                ActivityLog.shared.log(.downloadStarted, title: "Queued \(queued) files from \(username)", detail: folder, username: username)
+                VoiceOverAnnouncer.shared.announce("Queued \(queued) files from \(username)")
+            }
             self.logger.info("Folder download from \(username) in '\(folder)': queued \(queued)/\(files.count) files")
+            if files.isEmpty {
+                ActivityLog.shared.log(.error, title: "Folder download from \(username) found no files", detail: folder, username: username)
+                VoiceOverAnnouncer.shared.announce("Folder download from \(username) found no files")
+            }
         }
 
         client.searchResponseFilter = { [weak self] in
@@ -242,58 +252,116 @@ final class AppState {
         // ShareManager construction is side-effect-free; load + rescan
         // are explicit so they happen after the countsChangesStream
         // consumer above is wired.
+        // A preview must not scan the filesystem.
+        guard !SeeleSeekApp.isRunningInPreview else { return }
         client.shareManager.loadPersistedFolders()
         Task { await client.shareManager.rescanAll() }
     }
 
     // MARK: - Folder Download Coordinator
-    // Maps the token returned by `requestFolderContents` to the username we
-    // asked — response events only carry `(token, folder, files)`, so we
-    // need this side-table to know where to queue the downloads.
-    private var pendingFolderDownloads: [UInt32: String] = [:]
+    // Response events carry only `(token, folder, files)`.
+    private struct PendingFolderDownload {
+        let username: String
+        let folder: String
+    }
+    private var pendingFolderDownloads: [UInt32: PendingFolderDownload] = [:]
+
+    enum FolderRequestState: Equatable {
+        case fetching
+        case failed(String)
+    }
+
+    /// Keyed by user and folder. Search rows read this.
+    private(set) var folderRequestStates: [String: FolderRequestState] = [:]
+
+    private static func folderKey(username: String, folder: String) -> String {
+        "\(username)\u{0000}\(folder)"
+    }
+
+    func folderRequestState(for result: SearchResult) -> FolderRequestState? {
+        let folder = Self.containingSoulseekFolder(of: result.filename)
+        guard !folder.isEmpty else { return nil }
+        return folderRequestStates[Self.folderKey(username: result.username, folder: folder)]
+    }
+
+    #if DEBUG
+    /// Previews cannot write `folderRequestStates`: the setter is file private.
+    func previewSeedFolderRequest(_ state: FolderRequestState, for result: SearchResult) {
+        let folder = Self.containingSoulseekFolder(of: result.filename)
+        folderRequestStates[Self.folderKey(username: result.username, folder: folder)] = state
+    }
+    #endif
+
+    private func markFolderRequestFailed(key: String, reason: String) {
+        folderRequestStates[key] = .failed(reason)
+        Task { [weak self] in
+            try? await Task.sleep(for: .seconds(30))
+            guard let self, case .failed = self.folderRequestStates[key] else { return }
+            self.folderRequestStates.removeValue(forKey: key)
+        }
+    }
 
     /// Right-click "Download entire folder" entrypoint for a search result.
     /// Derives the containing folder from the Soulseek path (backslash-
     /// separated), asks the peer for its contents, and queues every returned
-    /// file once the response arrives. Pending tokens are auto-cleaned after
-    /// 60 s if the peer never responds, so `pendingFolderDownloads` can't grow
-    /// unbounded. No ActivityLog entries — folder downloads surface through
-    /// the same Transfers-tab path as single-file downloads, matching the
-    /// app's "log on completion, not on intent" convention.
+    /// file once the response arrives.
     func downloadContainingFolder(of result: SearchResult) async {
         let folder = Self.containingSoulseekFolder(of: result.filename)
         guard !folder.isEmpty else {
             logger.warning("Could not derive containing folder from filename: \(result.filename)")
             return
         }
+        let key = Self.folderKey(username: result.username, folder: folder)
+        folderRequestStates[key] = .fetching
+        // Everything below can take a minute inside the peer
+        // connection, so timestamp the click itself.
+        let started = Date()
+        logger.info("Folder download clicked: \(result.username) '\(folder)'")
+        ActivityLog.shared.log(.info, title: "Getting folder contents from \(result.username)", detail: folder, username: result.username)
+        VoiceOverAnnouncer.shared.announce("Getting folder contents from \(result.username)")
         do {
             let token = try await networkClient.requestFolderContents(
                 from: result.username,
                 folder: folder
             )
-            pendingFolderDownloads[token] = result.username
-            logger.info("Requested folder contents '\(folder)' from \(result.username) (token=\(token))")
+            pendingFolderDownloads[token] = PendingFolderDownload(username: result.username, folder: folder)
+            logger.info("Requested folder contents '\(folder)' from \(result.username) (token=\(token)) after \(Int(Date().timeIntervalSince(started) * 1000)) ms")
             scheduleFolderDownloadTimeout(token: token, username: result.username, folder: folder)
         } catch {
-            logger.error("Failed to request folder contents: \(error.localizedDescription)")
+            let elapsed = Int(Date().timeIntervalSince(started))
+            let reason = "Could not reach \(result.username) after \(elapsed) seconds"
+            markFolderRequestFailed(key: key, reason: reason)
+            logger.error("Failed to request folder contents after \(elapsed) s: \(error.localizedDescription)")
+            ActivityLog.shared.log(.error, title: "Folder download from \(result.username) failed", detail: reason, username: result.username)
+            VoiceOverAnnouncer.shared.announce(reason)
         }
     }
 
-    /// Drop the pending entry after 60 s if the peer never replied. No-op
-    /// if the response already arrived and removed it.
+    /// Warn at 60 s but keep the entry for 5 more minutes: firewalled
+    /// peers can need 45 s before the request is even sent, and those
+    /// late replies must still queue.
     private func scheduleFolderDownloadTimeout(token: UInt32, username: String, folder: String) {
         Task { [weak self] in
             try? await Task.sleep(for: .seconds(60))
-            guard let self,
-                  self.pendingFolderDownloads.removeValue(forKey: token) != nil else {
-                return
+            guard let self, self.pendingFolderDownloads[token] != nil else { return }
+            self.markFolderRequestFailed(
+                key: Self.folderKey(username: username, folder: folder),
+                reason: "\(username) did not answer within 60 seconds"
+            )
+            self.logger.info("Folder contents request slow: \(username) '\(folder)' (token=\(token))")
+            ActivityLog.shared.log(.error, title: "Folder download from \(username) did not start: no answer after 60 seconds", detail: folder, username: username)
+            VoiceOverAnnouncer.shared.announce("Folder download from \(username) did not start")
+
+            try? await Task.sleep(for: .seconds(300))
+            if self.pendingFolderDownloads.removeValue(forKey: token) != nil {
+                self.logger.info("Folder contents request expired: \(username) '\(folder)' (token=\(token))")
             }
-            self.logger.info("Folder contents request timed out: \(username) '\(folder)' (token=\(token))")
         }
     }
 
-    /// Queue every file from a folder-contents response, skipping files
-    /// already queued for this user. Returns the number actually queued.
+    /// Queue every file from a folder-contents response. Returns the number
+    /// handed to the download manager. Do not pre-filter queued files here:
+    /// `queueDownload` skips active duplicates and re-drives failed rows.
     ///
     /// `folder` is the full Soulseek folder path the peer listed (as it
     /// appeared in `FolderContentsReply`). Some peers embed the full path
@@ -306,7 +374,6 @@ final class AppState {
         var queued = 0
         for file in files {
             let fullPath = Self.fullSoulseekPath(folder: folder, filename: file.filename)
-            if transferState.isFileQueued(filename: fullPath, username: username) { continue }
             let result = SearchResult(
                 username: username,
                 filename: fullPath,

--- a/seeleseek/Features/Search/Views/FolderRequestIndicator.swift
+++ b/seeleseek/Features/Search/Views/FolderRequestIndicator.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+/// Folder-contents request state, sized for a list row's action cluster.
+struct FolderRequestIndicator: View {
+    let state: AppState.FolderRequestState
+    let username: String
+
+    var body: some View {
+        switch state {
+        case .fetching:
+            ProgressView()
+                .progressViewStyle(.circular)
+                .scaleEffect(SeeleSpacing.scaleSmall)
+                .frame(width: SeeleSpacing.buttonHeight, height: SeeleSpacing.buttonHeight)
+                .help("Getting folder contents from \(username)...")
+                .accessibilityLabel("Getting folder contents from \(username)")
+        case .failed(let reason):
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: SeeleSpacing.iconSizeSmall))
+                .foregroundStyle(SeeleColors.warning)
+                .frame(width: SeeleSpacing.buttonHeight, height: SeeleSpacing.buttonHeight)
+                .help(reason)
+                .accessibilityLabel("Folder download failed. \(reason)")
+        }
+    }
+}
+
+#if DEBUG
+#Preview("Folder request indicator") {
+    HStack(spacing: SeeleSpacing.lg) {
+        FolderRequestIndicator(state: .fetching, username: "vinylcollector")
+        FolderRequestIndicator(
+            state: .failed("Could not reach jazzfan after 32 seconds"),
+            username: "jazzfan"
+        )
+    }
+    .padding(SeeleSpacing.lg)
+    .background(SeeleColors.background)
+    .preferredColorScheme(.dark)
+}
+#endif

--- a/seeleseek/Features/Search/Views/SearchResultRow.swift
+++ b/seeleseek/Features/Search/Views/SearchResultRow.swift
@@ -412,18 +412,18 @@ struct SearchResultRow: View {
     }
 
     private var secondaryActions: some View {
+        let folderRequestState = appState.folderRequestState(for: result)
         // Hit-testing stays on even at opacity 0 so Tab focus (and, via
         // `accessibilityAction` below, VoiceOver rotor) can reach these
         // actions. The invisible focus ring is an accepted tradeoff.
-        HStack(spacing: SeeleSpacing.xxs) {
-            folderSlot
+        return HStack(spacing: SeeleSpacing.xxs) {
+            folderSlot(folderRequestState)
             RowIconButton(
                 systemName: "person.crop.circle",
                 help: "Browse \(result.username)'s files",
                 action: browseUser
             )
         }
-        // Request state must show without a hover.
         .opacity(isHovered || folderRequestState != nil ? 1 : 0)
         .frame(width: secondaryActionsWidth, alignment: .trailing)
     }
@@ -431,9 +431,9 @@ struct SearchResultRow: View {
     /// Deliberately not on the download button: a request can run for a
     /// minute, and that button must stay usable for single files.
     @ViewBuilder
-    private var folderSlot: some View {
-        if let folderRequestState {
-            FolderRequestIndicator(state: folderRequestState, username: result.username)
+    private func folderSlot(_ state: AppState.FolderRequestState?) -> some View {
+        if let state {
+            FolderRequestIndicator(state: state, username: result.username)
         } else {
             RowIconButton(
                 systemName: "folder.badge.questionmark",
@@ -441,10 +441,6 @@ struct SearchResultRow: View {
                 action: browseFolder
             )
         }
-    }
-
-    private var folderRequestState: AppState.FolderRequestState? {
-        appState.folderRequestState(for: result)
     }
 
     private var primaryAction: some View {
@@ -537,6 +533,17 @@ struct SearchResultRow: View {
         }
         if downloadStatus != nil {
             parts.append(actionHelp)
+        }
+        // The row is a combined element with an explicit label, which
+        // overrides FolderRequestIndicator's own label — so the request
+        // state has to be surfaced here or VoiceOver never hears it.
+        switch appState.folderRequestState(for: result) {
+        case .fetching:
+            parts.append("getting folder contents")
+        case .failed(let reason):
+            parts.append("folder download failed, \(reason)")
+        case nil:
+            break
         }
         return parts.joined(separator: ", ")
     }

--- a/seeleseek/Features/Search/Views/SearchResultRow.swift
+++ b/seeleseek/Features/Search/Views/SearchResultRow.swift
@@ -416,19 +416,35 @@ struct SearchResultRow: View {
         // `accessibilityAction` below, VoiceOver rotor) can reach these
         // actions. The invisible focus ring is an accepted tradeoff.
         HStack(spacing: SeeleSpacing.xxs) {
-            RowIconButton(
-                systemName: "folder.badge.questionmark",
-                help: "Browse this folder",
-                action: browseFolder
-            )
+            folderSlot
             RowIconButton(
                 systemName: "person.crop.circle",
                 help: "Browse \(result.username)'s files",
                 action: browseUser
             )
         }
-        .opacity(isHovered ? 1 : 0)
+        // Request state must show without a hover.
+        .opacity(isHovered || folderRequestState != nil ? 1 : 0)
         .frame(width: secondaryActionsWidth, alignment: .trailing)
+    }
+
+    /// Deliberately not on the download button: a request can run for a
+    /// minute, and that button must stay usable for single files.
+    @ViewBuilder
+    private var folderSlot: some View {
+        if let folderRequestState {
+            FolderRequestIndicator(state: folderRequestState, username: result.username)
+        } else {
+            RowIconButton(
+                systemName: "folder.badge.questionmark",
+                help: "Browse this folder",
+                action: browseFolder
+            )
+        }
+    }
+
+    private var folderRequestState: AppState.FolderRequestState? {
+        appState.folderRequestState(for: result)
     }
 
     private var primaryAction: some View {
@@ -761,5 +777,55 @@ enum QualityScale {
     .frame(width: 900, height: 560)
     .background(SeeleColors.background)
     .previewAppState()
+}
+
+#Preview("Folder request states") {
+    let idle = SearchResult(
+        username: "musiclover42",
+        filename: "Music\\FLAC\\Underscores\\01 - Hollywood Forever.flac",
+        size: 45_000_000, bitrate: 1411, duration: 413,
+        freeSlots: true, uploadSpeed: 1_500_000
+    )
+    let fetching = SearchResult(
+        username: "vinylcollector",
+        filename: "Music\\MP3\\Underscores\\02 - Hollywood Forever.mp3",
+        size: 8_500_000, bitrate: 320, duration: 413,
+        freeSlots: true, uploadSpeed: 300_000
+    )
+    let failed = SearchResult(
+        username: "jazzfan",
+        filename: "Audio\\Live\\Underscores\\03 - Hollywood Forever.mp3",
+        size: 4_200_000, bitrate: 128, duration: 413,
+        freeSlots: true, uploadSpeed: 80_000
+    )
+
+    let state = PreviewData.connectedAppState
+    state.previewSeedFolderRequest(.fetching, for: fetching)
+    state.previewSeedFolderRequest(
+        .failed("Could not reach jazzfan after 32 seconds"),
+        for: failed
+    )
+
+    return VStack(alignment: .leading, spacing: SeeleSpacing.md) {
+        previewStateLabel("Idle — folder button appears on hover")
+        SearchResultRow(result: idle)
+
+        previewStateLabel("Fetching — spinner in the folder slot")
+        SearchResultRow(result: fetching)
+
+        previewStateLabel("Failed — reason on hover, clears after 30 s")
+        SearchResultRow(result: failed)
+    }
+    .padding(SeeleSpacing.lg)
+    .frame(width: 900)
+    .background(SeeleColors.background)
+    .previewAppState(state)
+}
+
+@ViewBuilder
+private func previewStateLabel(_ text: String) -> some View {
+    Text(text)
+        .font(SeeleTypography.caption)
+        .foregroundStyle(SeeleColors.textTertiary)
 }
 #endif

--- a/seeleseek/Features/Statistics/ActivityLog.swift
+++ b/seeleseek/Features/Statistics/ActivityLog.swift
@@ -206,6 +206,21 @@ final class ActivityLog: ActivityLogging {
         }
     }
 
+    func logFolderRequestStarted(username: String, folder: String) {
+        log(.info, title: "Getting folder contents from \(username)", detail: folder, username: username)
+        VoiceOverAnnouncer.shared.announce("Getting folder contents from \(username)")
+    }
+
+    func logFolderQueued(count: Int, username: String, folder: String) {
+        log(.downloadStarted, title: "Queued \(count) files from \(username)", detail: folder, username: username)
+        VoiceOverAnnouncer.shared.announce("Queued \(count) files from \(username)")
+    }
+
+    func logFolderRequestFailed(username: String, folder: String, reason: String) {
+        log(.error, title: "Folder download from \(username) failed: \(reason)", detail: folder, username: username)
+        VoiceOverAnnouncer.shared.announce(reason)
+    }
+
     func logError(_ message: String, detail: String? = nil) {
         log(.error, title: message, detail: detail)
     }

--- a/seeleseek/seeleseekApp.swift
+++ b/seeleseek/seeleseekApp.swift
@@ -14,7 +14,7 @@ struct SeeleSeekApp: App {
         }
     }
 
-    private static var isRunningInPreview: Bool {
+    static var isRunningInPreview: Bool {
         let env = ProcessInfo.processInfo.environment
         return env["XCODE_RUNNING_FOR_PREVIEWS"] == "1"
             || env["XCODE_RUNNING_FOR_PLAYGROUNDS"] == "1"

--- a/seeleseek/seeleseekApp.swift
+++ b/seeleseek/seeleseekApp.swift
@@ -14,7 +14,7 @@ struct SeeleSeekApp: App {
         }
     }
 
-    static var isRunningInPreview: Bool {
+    private static var isRunningInPreview: Bool {
         let env = ProcessInfo.processInfo.environment
         return env["XCODE_RUNNING_FOR_PREVIEWS"] == "1"
             || env["XCODE_RUNNING_FOR_PLAYGROUNDS"] == "1"


### PR DESCRIPTION
### Description

This PR introduces folder download request state tracking and user feedback in the UI, improves network connection handling, and refactors timeout logic. The main changes are grouped below.

---

**Folder Download Request State Tracking and User Feedback:**

* Added a `FolderRequest` model and related state management to `AppState`, allowing the app to track the state (`fetching`, `failed`) of folder download requests, automatically clear failures after a timeout, and expose this state for UI consumption.
* Updated the folder download workflow to log ActivityLog events, handle empty-folder responses as failures, and provide detailed error messages and timeouts to the user. [[1]](diffhunk://#diff-86c2cb35156f4fc4c3307607e46b123d081085dcc461222e54a9073c37d144f3L224-R239) [[2]](diffhunk://#diff-86c2cb35156f4fc4c3307607e46b123d081085dcc461222e54a9073c37d144f3L241-R365)
* Added a new `FolderRequestIndicator` SwiftUI view to visually represent the folder request state in the search results row, showing a progress spinner or a warning icon as appropriate.
* Updated `SearchResultRow` to display the folder request indicator and to surface folder request state in accessibility labels, improving user and accessibility feedback. [[1]](diffhunk://#diff-07d9a48c9fc122cccbe98bfe2d605aefc2f397e9b4ab4bfb63c35ac6253d7b7cR415-R445) [[2]](diffhunk://#diff-07d9a48c9fc122cccbe98bfe2d605aefc2f397e9b4ab4bfb63c35ac6253d7b7cR537-R547)

**Network Connection Handling and Timeout Improvements:**

* Refactored the logic for establishing peer connections to race direct and indirect (firewall-piercing) connection attempts, using a new `withTimeout` utility to bound direct connection attempts and ensure both legs are properly handled and cleaned up. [[1]](diffhunk://#diff-f3aa9a82ee1ce3b938a3e39e5b875ff339f1ffad68029fbf374f19ebeaa6c60cL2604-L2637) [[2]](diffhunk://#diff-f3aa9a82ee1ce3b938a3e39e5b875ff339f1ffad68029fbf374f19ebeaa6c60cR2657-R2658) [[3]](diffhunk://#diff-67e3a2f54b7234393875d656bfc9c5674359e8139d3045f8c86487fc737dc7a6R1-R26)
* Improved connection pool logic to only match peer connections of the correct type and clarified documentation.
* Improved logging when the connection limit is reached.

**Codebase Cleanup and Refactoring:**

* Moved the `withTimeout` implementation to a new utility file for reuse and removed the previous duplicate in `ServerMessageHandler`. [[1]](diffhunk://#diff-67e3a2f54b7234393875d656bfc9c5674359e8139d3045f8c86487fc737dc7a6R1-R26) [[2]](diffhunk://#diff-af1a120c8853931a0f416baef1b56dc753f4b91e163a75740f3065a4ae9f707fL545-L573)
* Deferred share folder scanning to the correct place in `AppState` initialization, ensuring test hosts and previews do not trigger filesystem scans unnecessarily. [[1]](diffhunk://#diff-86c2cb35156f4fc4c3307607e46b123d081085dcc461222e54a9073c37d144f3R464-R469) [[2]](diffhunk://#diff-86c2cb35156f4fc4c3307607e46b123d081085dcc461222e54a9073c37d144f3L241-R365)

---

These changes collectively improve the robustness, user feedback, and maintainability of folder downloads and peer networking.

<!--
### Future work
A place to describe changes that can or will be done in follow-up PRs
-->

### How to test

- Ensure all checks pass

### Author checklist

This PR:

- [x] Satisfies a goal that is specific & clearly motivated
- [x] Adds value in isolation (whether user-facing or sustainability-related)
- [x] Contains a concise & easy-to-understand title + description
- [x] Adheres to [SRP](https://en.wikipedia.org/wiki/Single-responsibility_principle) by default
- [x] Presents the best possible implementation to meet its goal, given constraints at hand
