### PR TITLE
fix launch data

### DIFF
--- a/seeleseek/App/AppState.swift
+++ b/seeleseek/App/AppState.swift
@@ -461,15 +461,15 @@ final class AppState {
         NotificationService.shared.settings = settings
         NotificationService.shared.requestAuthorization()
 
-        // Not in wireNetworkClient: previews and the test host skip
-        // configure(), so neither scans the filesystem.
-        let client = networkClient
-        client.shareManager.loadPersistedFolders()
-        Task { await client.shareManager.rescanAll() }
-
-        // Initialize database asynchronously
         Task {
             await initializeDatabase()
+            // Wiring is not inert: setupCallbacks loads each feature
+            // state's persisted data, so the database must be ready first.
+            // Previews and the test host skip configure(), so neither
+            // scans the filesystem.
+            let client = networkClient
+            client.shareManager.loadPersistedFolders()
+            await client.shareManager.rescanAll()
         }
     }
 


### PR DESCRIPTION
### Description

This PR updates the initialization order in the `AppState` class to ensure that the database is ready before loading persisted folders and rescanning shares. This change improves reliability by preventing feature state loading before the database is initialized.

Initialization order improvements:

* Moved the calls to `networkClient.shareManager.loadPersistedFolders()` and `rescanAll()` to occur after `initializeDatabase()` completes, ensuring the database is ready before loading persisted data.
<!--
### Future work
A place to describe changes that can or will be done in follow-up PRs
-->

### How to test
- Ensure all checks pass

### Author checklist

This PR:

- [x] Satisfies a goal that is specific & clearly motivated
- [x] Adds value in isolation (whether user-facing or sustainability-related)
- [x] Contains a concise & easy-to-understand title + description
- [x] Adheres to [SRP](https://en.wikipedia.org/wiki/Single-responsibility_principle) by default
- [x] Presents the best possible implementation to meet its goal, given constraints at hand
