### PR TITLE
optimize download retries

### DIFF
--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Models/Transfer.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Models/Transfer.swift
@@ -137,6 +137,10 @@ public struct Transfer: Identifiable, Hashable, Sendable {
         switch status {
         case .failed, .cancelled:
             return true
+        case .waiting:
+            // The peer may have dropped our queue slot (peer restarts lose
+            // it). Uploads in .waiting are the peer's queue, not ours.
+            return direction == .download
         default:
             return false
         }

--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Storage/DownloadManager.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Storage/DownloadManager.swift
@@ -2346,17 +2346,7 @@ public final class DownloadManager {
 
         for (username, transfers) in byUser {
             if let connection = await networkClient.peerConnectionPool.getConnectionForUser(username) {
-                for transfer in transfers {
-                    do {
-                        // Re-send QueueDownload to keep our spot in the remote queue
-                        try await connection.queueDownload(filename: transfer.filename)
-                        // Ask for our queue position so the UI shows it
-                        try await connection.sendPlaceInQueueRequest(filename: transfer.filename)
-                        logger.debug("Re-queued + requested position: \(transfer.filename)")
-                    } catch {
-                        logger.debug("Failed to re-queue \(transfer.filename): \(error.localizedDescription)")
-                    }
-                }
+                await refreshQueueSlots(for: transfers, over: connection)
             } else {
                 // No connection exists. Skip peers the server says are
                 // offline — a UserStatus push re-drives them on return.
@@ -2369,9 +2359,13 @@ public final class DownloadManager {
                 // them all on the same tick.
                 logger.info("No connection to \(username), re-initiating downloads")
                 var staggerIndex = 0
+                var pendingToRefresh: [Transfer] = []
                 for transfer in transfers {
                     let alreadyPending = pendingDownloads.values.contains { $0.transferId == transfer.id }
-                    if alreadyPending { continue }
+                    if alreadyPending {
+                        pendingToRefresh.append(transfer)
+                        continue
+                    }
                     guard dialBudget > 0 else { break }
                     dialBudget -= 1
                     let delay = Double(staggerIndex) * 0.5
@@ -2383,6 +2377,35 @@ public final class DownloadManager {
                     }
                     staggerIndex += 1
                 }
+                // Re-dial once and refresh every pending row's queue slot
+                // (a restarted peer has dropped its queue). Do not touch
+                // the pending entries or tokens — the peer's eventual
+                // TransferRequest must still match them.
+                if !pendingToRefresh.isEmpty, dialBudget > 0 {
+                    dialBudget -= 1
+                    Task { [weak self, pendingToRefresh] in
+                        guard let self, let networkClient = self.networkClient else { return }
+                        guard let connection = try? await networkClient.establishPeerConnection(for: username) else {
+                            self.logger.debug("Re-queue dial to \(username) failed; next tick retries")
+                            return
+                        }
+                        await self.refreshQueueSlots(for: pendingToRefresh, over: connection)
+                    }
+                }
+            }
+        }
+    }
+
+    /// Re-send QueueDownload (keeps our spot in the remote queue) and
+    /// PlaceInQueueRequest (position for the UI) for each transfer.
+    private func refreshQueueSlots(for transfers: [Transfer], over connection: PeerConnection) async {
+        for transfer in transfers {
+            do {
+                try await connection.queueDownload(filename: transfer.filename)
+                try await connection.sendPlaceInQueueRequest(filename: transfer.filename)
+                logger.debug("Re-queued + requested position: \(transfer.filename)")
+            } catch {
+                logger.debug("Failed to re-queue \(transfer.filename): \(error.localizedDescription)")
             }
         }
     }

--- a/seeleseek/Features/Transfers/Views/TransferRow.swift
+++ b/seeleseek/Features/Transfers/Views/TransferRow.swift
@@ -252,6 +252,13 @@ struct TransferRow: View {
             Divider()
         }
 
+        if transfer.canRetry {
+            Button(action: onRetry) {
+                Label("Retry Now", systemImage: "arrow.clockwise")
+            }
+            Divider()
+        }
+
         if transfer.status == .completed, transfer.isAudioFile, transfer.localPath != nil {
             Button(action: toggleAudioPreview) {
                 Label(


### PR DESCRIPTION
### Description

This PR improves the reliability and user experience of the transfer retry and queue management system. It adds logic to ensure downloads in a `.waiting` state are properly handled, refactors queue slot refresh logic for better maintainability, and introduces a "Retry Now" button in the UI for eligible transfers.

**Queue Management Improvements:**

* Transfers in the `.waiting` state are now considered retryable only if their direction is `.download`, addressing cases where a peer may have dropped the queue slot.
* The logic for refreshing queue slots has been refactored into a new `refreshQueueSlots` method, reducing code duplication and improving clarity [[1]](diffhunk://#diff-473413f7f7c0b9edac4781f0bf57f99ae1309950eb2d67ce1c095e6485308d58L2349-R2349) [[2]](diffhunk://#diff-473413f7f7c0b9edac4781f0bf57f99ae1309950eb2d67ce1c095e6485308d58R2380-R2408).
* When re-initiating downloads, transfers already pending are now collected and have their queue slots refreshed in bulk, ensuring that queue positions are maintained without unnecessary re-dials [[1]](diffhunk://#diff-473413f7f7c0b9edac4781f0bf57f99ae1309950eb2d67ce1c095e6485308d58R2362-R2368) [[2]](diffhunk://#diff-473413f7f7c0b9edac4781f0bf57f99ae1309950eb2d67ce1c095e6485308d58R2380-R2408).

**User Interface Enhancement:**

* A "Retry Now" button is now displayed in the transfer row UI for transfers that can be retried, allowing users to manually trigger a retry when appropriate.

<!--
### Future work
A place to describe changes that can or will be done in follow-up PRs
-->

### How to test

- Ensure all checks pass

### Author checklist

This PR:

- [x] Satisfies a goal that is specific & clearly motivated
- [x] Adds value in isolation (whether user-facing or sustainability-related)
- [x] Contains a concise & easy-to-understand title + description
- [x] Adheres to [SRP](https://en.wikipedia.org/wiki/Single-responsibility_principle) by default
- [x] Presents the best possible implementation to meet its goal, given constraints at hand
