### PR TITLE
fix settings nav button shape content area

### DIFF
--- a/seeleseek/Features/Settings/Views/SettingsView.swift
+++ b/seeleseek/Features/Settings/Views/SettingsView.swift
@@ -134,6 +134,7 @@ struct SettingsView: View {
                         .stroke(Color(nsColor: .keyboardFocusIndicatorColor), lineWidth: 2)
                 }
             }
+            .contentShape(RoundedRectangle(cornerRadius: SeeleSpacing.radiusMD, style: .continuous))
         }
         .buttonStyle(.plain)
         .padding(.horizontal, SeeleSpacing.xs)


### PR DESCRIPTION
### Description

This PR makes a small UI improvement to the `SettingsView` by adjusting the clickable area of a button. The change ensures that the button's interactive region matches its visual shape, improving usability.

* UI improvement:
  * [`SettingsView.swift`](diffhunk://#diff-297fdc05bc96f737e3d3115327b88cade4dedee2344beeeafdf3ff59d5c23227R137): Added a `.contentShape` modifier with a rounded rectangle to the button, ensuring the clickable area aligns with the button's visual appearance.

<!--
### Future work
A place to describe changes that can or will be done in follow-up PRs
-->

### How to test

- Ensure all checks pass

### Author checklist

This PR:

- [x] Satisfies a goal that is specific & clearly motivated
- [x] Adds value in isolation (whether user-facing or sustainability-related)
- [x] Contains a concise & easy-to-understand title + description
- [x] Adheres to [SRP](https://en.wikipedia.org/wiki/Single-responsibility_principle) by default
- [x] Presents the best possible implementation to meet its goal, given constraints at hand
