### PR TITLE
implement extendedclientinfo

### DIFF
--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Models/ExtendedClientInfo.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Models/ExtendedClientInfo.swift
@@ -1,12 +1,41 @@
 import Foundation
 
+/// A peer's advertised protocol extensions, from ExtendedClientInfo (code 10000).
+///
+/// Presence means "this peer speaks extensions", not "this peer is SeeleSeek" —
+/// any client may implement the handshake. Never infer identity from it.
 public struct ExtendedClientInfo: Sendable, Equatable {
     public let revision: UInt32
+    /// Free-form and optional; peers may send an empty string. Display only.
     public let clientInfo: String
-    
+
+    /// Wire name → the code this peer binds it to.
     public let capabilities: [String: UInt32]
-    
+
+    public init(revision: UInt32, clientInfo: String, capabilities: [String: UInt32]) {
+        self.revision = revision
+        self.clientInfo = clientInfo
+        self.capabilities = capabilities
+    }
+
+    /// Exact (name, code) match, per the spec's rule that a mismatched code
+    /// means we must not send that message.
     public func supports(_ code: SeeleSeekExtendedClientInfoCode) -> Bool {
         capabilities[code.wireName] == code.rawValue
+    }
+
+    /// Synthesised for SeeleSeek 1.x peers, which predate this handshake and
+    /// send a bare uint8 version at code 10000. They support the same three
+    /// codes implicitly. Remove once 1.x is no longer in the wild.
+    public static func legacySeeleSeek(version: UInt8) -> ExtendedClientInfo {
+        ExtendedClientInfo(
+            revision: 0,
+            clientInfo: "SeeleSeek/\(version).x",
+            capabilities: Dictionary(
+                uniqueKeysWithValues: SeeleSeekExtendedClientInfoCode.allCases.map {
+                    ($0.wireName, $0.rawValue)
+                }
+            )
+        )
     }
 }

--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Models/ExtendedClientInfo.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Models/ExtendedClientInfo.swift
@@ -23,19 +23,4 @@ public struct ExtendedClientInfo: Sendable, Equatable {
     public func supports(_ code: SeeleSeekExtendedClientInfoCode) -> Bool {
         capabilities[code.wireName] == code.rawValue
     }
-
-    /// Synthesised for SeeleSeek 1.x peers, which predate this handshake and
-    /// send a bare uint8 version at code 10000. They support the same three
-    /// codes implicitly. Remove once 1.x is no longer in the wild.
-    public static func legacySeeleSeek(version: UInt8) -> ExtendedClientInfo {
-        ExtendedClientInfo(
-            revision: 0,
-            clientInfo: "SeeleSeek/\(version).x",
-            capabilities: Dictionary(
-                uniqueKeysWithValues: SeeleSeekExtendedClientInfoCode.allCases.map {
-                    ($0.wireName, $0.rawValue)
-                }
-            )
-        )
-    }
 }

--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Models/ExtendedClientInfo.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Models/ExtendedClientInfo.swift
@@ -10,8 +10,19 @@ public struct ExtendedClientInfo: Sendable, Equatable {
     /// both sides validate against it.
     public static let currentRevision: UInt32 = 1
 
+    /// What we advertise about ourselves. The spec makes this optional, but a
+    /// field every implementer leaves empty is a dead field, and knowing what
+    /// is actually deployed is the point of publishing the handshake. It adds
+    /// nothing to our fingerprint that the capability list does not already
+    /// give away. Version comes from the host bundle so it cannot go stale.
+    public static let localClientInfo: String = {
+        let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0"
+        return "SeeleSeek/\(version) (https://seeleseek.net)"
+    }()
+
     public let revision: UInt32
-    /// Free-form and optional; peers may send an empty string. Display only.
+    /// Free-form and optional; peers may send an empty string. Display only —
+    /// it is self-reported and trivially spoofed, so never branch on it.
     public let clientInfo: String
 
     /// Wire name → the code this peer binds it to.

--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Models/ExtendedClientInfo.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Models/ExtendedClientInfo.swift
@@ -5,6 +5,11 @@ import Foundation
 /// Presence means "this peer speaks extensions", not "this peer is SeeleSeek" —
 /// any client may implement the handshake. Never infer identity from it.
 public struct ExtendedClientInfo: Sendable, Equatable {
+    /// Revision of the ExtendedClientInfo format itself, not of any individual
+    /// capability. Owned here rather than on the builder or the parser, since
+    /// both sides validate against it.
+    public static let currentRevision: UInt32 = 1
+
     public let revision: UInt32
     /// Free-form and optional; peers may send an empty string. Display only.
     public let clientInfo: String
@@ -20,7 +25,7 @@ public struct ExtendedClientInfo: Sendable, Equatable {
 
     /// Exact (name, code) match, per the spec's rule that a mismatched code
     /// means we must not send that message.
-    public func supports(_ code: SeeleSeekExtendedClientInfoCode) -> Bool {
+    public func supports(_ code: ExtendedClientInfoCode) -> Bool {
         capabilities[code.wireName] == code.rawValue
     }
 }

--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Models/ExtendedClientInfo.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Models/ExtendedClientInfo.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+public struct ExtendedClientInfo: Sendable, Equatable {
+    public let revision: UInt32
+    public let clientInfo: String
+    
+    public let capabilities: [String: UInt32]
+    
+    public func supports(_ code: SeeleSeekExtendedClientInfoCode) -> Bool {
+        capabilities[code.wireName] == code.rawValue
+    }
+}

--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Models/PeerConnectionEvent.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Models/PeerConnectionEvent.swift
@@ -22,7 +22,6 @@ public enum PeerConnectionEvent: Sendable {
     case sharesRequest
     case userInfoRequest
     case userInfoReply(MessageParser.UserInfoReplyInfo)
-    case seeleSeekVersionDiscovered(UInt8)
     case extendedClientInfoDiscovered(ExtendedClientInfo)
     case artworkRequest(token: UInt32, filePath: String)
     case artworkReply(token: UInt32, imageData: Data)

--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Models/PeerConnectionEvent.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Models/PeerConnectionEvent.swift
@@ -23,6 +23,7 @@ public enum PeerConnectionEvent: Sendable {
     case userInfoRequest
     case userInfoReply(MessageParser.UserInfoReplyInfo)
     case seeleSeekVersionDiscovered(UInt8)
+    case extendedClientInfoDiscovered(ExtendedClientInfo)
     case artworkRequest(token: UInt32, filePath: String)
     case artworkReply(token: UInt32, imageData: Data)
 }

--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Connections/PeerConnection.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Connections/PeerConnection.swift
@@ -92,15 +92,10 @@ public actor PeerConnection {
     // SeeleSeek extension state
     private(set) var extendedClientInfo: ExtendedClientInfo?
 
-    /// Whether this peer advertised any protocol extensions. Deliberately not
-    /// "is this SeeleSeek" — code 10000 is open to any client, so identity is
-    /// not inferable and nothing should branch on it.
-    public var supportsExtensions: Bool { extendedClientInfo != nil }
-
     /// Authoritative capability gate. Per-socket and always current, unlike
     /// the pool's sticky per-username cache, which peers may invalidate at any
     /// time by re-advertising a different set.
-    public func supports(_ code: SeeleSeekExtendedClientInfoCode) -> Bool {
+    public func supports(_ code: ExtendedClientInfoCode) -> Bool {
         extendedClientInfo?.supports(code) ?? false
     }
 
@@ -462,8 +457,20 @@ public actor PeerConnection {
     /// it drop it as an unknown code. Only safe on P-type sockets — F-type
     /// connections switch to raw file-transfer bytes after init and would
     /// misinterpret this message as file data.
+    ///
+    /// Deliberately uses plain `send` rather than `send(extension:_:)` — this
+    /// is the bootstrap, sent before either side has advertised anything.
     public func sendExtendedClientInfo() async throws {
         try await send(MessageBuilder.extendedClientInfoMessage())
+    }
+
+    /// Send an extension message, refusing if the peer never advertised the
+    /// code. Every extension send must go through here: the spec forbids
+    /// sending a code a peer did not advertise, and expressing that per call
+    /// site is how the first three of four sites came to omit it.
+    public func send(extension code: ExtendedClientInfoCode, _ message: Data) async throws {
+        guard supports(code) else { throw PeerError.capabilityNotAdvertised(code) }
+        try await send(message)
     }
 
     public func sendPierceFirewall() async throws {
@@ -1591,13 +1598,13 @@ public actor PeerConnection {
             handleUserInfoRequest()
 
         // SeeleSeek extension codes
-        case SeeleSeekExtendedClientInfoCode.extendedClientInfo.rawValue:
+        case ExtendedClientInfoCode.extendedClientInfo.rawValue:
             handleExtendedClientInfo(payload)
 
-        case SeeleSeekExtendedClientInfoCode.artworkRequest.rawValue:
+        case ExtendedClientInfoCode.artworkRequest.rawValue:
             handleArtworkRequest(payload)
 
-        case SeeleSeekExtendedClientInfoCode.artworkReply.rawValue:
+        case ExtendedClientInfoCode.artworkReply.rawValue:
             handleArtworkReply(payload)
 
         default:
@@ -2054,6 +2061,7 @@ public enum PeerError: Error, LocalizedError {
     case timeout
     case invalidPort
     case malformedOutboundMessage
+    case capabilityNotAdvertised(ExtendedClientInfoCode)
 
     public var errorDescription: String? {
         switch self {
@@ -2064,6 +2072,7 @@ public enum PeerError: Error, LocalizedError {
         case .timeout: return "Connection timed out"
         case .invalidPort: return "Invalid port number"
         case .malformedOutboundMessage: return "Outbound message is malformed"
+        case .capabilityNotAdvertised(let code): return "Peer has not advertised \(code.wireName)"
         }
     }
 }

--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Connections/PeerConnection.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Connections/PeerConnection.swift
@@ -1623,8 +1623,14 @@ public actor PeerConnection {
     // MARK: - SeeleSeek Extension Handlers
 
     /// Handle ExtendedClientInfo (code 10000) — record what this peer speaks.
+    ///
+    /// SeeleSeek 1.x sent a bare uint8 version at this code. That does not
+    /// parse and is deliberately not special-cased: the spec treats a peer
+    /// that has not sent a valid advertisement as supporting nothing, and
+    /// inferring capabilities from a version byte is the exact practice this
+    /// handshake replaces.
     private func handleExtendedClientInfo(_ payload: Data) {
-        guard let info = MessageParser.parseExtendedClientInfo(payload) ?? legacyHandshake(payload) else {
+        guard let info = MessageParser.parseExtendedClientInfo(payload) else {
             logger.warning("[\(self.peerUsername)] ExtendedClientInfo malformed or unknown revision, ignoring")
             return
         }
@@ -1632,16 +1638,6 @@ public actor PeerConnection {
         extendedClientInfo = info
         logger.info("[\(self.peerUsername)] Extensions: \(info.capabilities.keys.sorted().joined(separator: ", "))")
         eventContinuation.yield(.extendedClientInfoDiscovered(info))
-    }
-
-    /// SeeleSeek 1.x sent a bare uint8 version at this code. A one-byte
-    /// payload can only be that, since the current format needs 12 bytes
-    /// minimum. Drop this once 1.x is gone.
-    private func legacyHandshake(_ payload: Data) -> ExtendedClientInfo? {
-        guard payload.count == 1 else { return nil }
-        let version = payload[payload.startIndex]
-        logger.info("[\(self.peerUsername)] Legacy SeeleSeek handshake (version \(version))")
-        return .legacySeeleSeek(version: version)
     }
 
     /// Handle artwork request (code 10001) — peer wants album art for a file.

--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Connections/PeerConnection.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Connections/PeerConnection.swift
@@ -91,8 +91,15 @@ public actor PeerConnection {
 
     // SeeleSeek extension state
     private(set) var extendedClientInfo: ExtendedClientInfo?
-    /// TODO: not correct since any client could use extendo, check on string
-    public var isSeeleSeekPeer: Bool { extendedClientInfo != nil }
+
+    /// Whether this peer advertised any protocol extensions. Deliberately not
+    /// "is this SeeleSeek" — code 10000 is open to any client, so identity is
+    /// not inferable and nothing should branch on it.
+    public var supportsExtensions: Bool { extendedClientInfo != nil }
+
+    /// Authoritative capability gate. Per-socket and always current, unlike
+    /// the pool's sticky per-username cache, which peers may invalidate at any
+    /// time by re-advertising a different set.
     public func supports(_ code: SeeleSeekExtendedClientInfoCode) -> Bool {
         extendedClientInfo?.supports(code) ?? false
     }
@@ -448,15 +455,15 @@ public actor PeerConnection {
         logger.debug("PeerInit sent, handshake marked complete")
 
         // Send SeeleSeek handshake so the peer knows we support extensions
-        try? await sendSeeleSeekHandshake()
+        try? await sendExtendedClientInfo()
     }
 
-    /// Send the SeeleSeek capability handshake (code 10000). Non-SeeleSeek
-    /// peers drop it as an unknown code. Only safe on P-type sockets — F-type
+    /// Advertise our extension codes (code 10000). Peers that do not implement
+    /// it drop it as an unknown code. Only safe on P-type sockets — F-type
     /// connections switch to raw file-transfer bytes after init and would
     /// misinterpret this message as file data.
-    public func sendSeeleSeekHandshake() async throws {
-        try await send(MessageBuilder.extendedClientInfoMessage( clientInfo: ""))
+    public func sendExtendedClientInfo() async throws {
+        try await send(MessageBuilder.extendedClientInfoMessage())
     }
 
     public func sendPierceFirewall() async throws {
@@ -1516,7 +1523,7 @@ public actor PeerConnection {
                     // Reciprocate the SeeleSeek handshake so the initiator learns
                     // we're also a SeeleSeek client. Only on P-type sockets —
                     // F-type is handled above and returns before this point.
-                    try? await sendSeeleSeekHandshake()
+                    try? await sendExtendedClientInfo()
                 }
             }
             handshakeComplete = true
@@ -1615,15 +1622,26 @@ public actor PeerConnection {
 
     // MARK: - SeeleSeek Extension Handlers
 
-    
+    /// Handle ExtendedClientInfo (code 10000) — record what this peer speaks.
     private func handleExtendedClientInfo(_ payload: Data) {
-        guard let info = MessageParser.parseExtendedClientInfo(payload) else {
+        guard let info = MessageParser.parseExtendedClientInfo(payload) ?? legacyHandshake(payload) else {
             logger.warning("[\(self.peerUsername)] ExtendedClientInfo malformed or unknown revision, ignoring")
             return
         }
-        
+
         extendedClientInfo = info
+        logger.info("[\(self.peerUsername)] Extensions: \(info.capabilities.keys.sorted().joined(separator: ", "))")
         eventContinuation.yield(.extendedClientInfoDiscovered(info))
+    }
+
+    /// SeeleSeek 1.x sent a bare uint8 version at this code. A one-byte
+    /// payload can only be that, since the current format needs 12 bytes
+    /// minimum. Drop this once 1.x is gone.
+    private func legacyHandshake(_ payload: Data) -> ExtendedClientInfo? {
+        guard payload.count == 1 else { return nil }
+        let version = payload[payload.startIndex]
+        logger.info("[\(self.peerUsername)] Legacy SeeleSeek handshake (version \(version))")
+        return .legacySeeleSeek(version: version)
     }
 
     /// Handle artwork request (code 10001) — peer wants album art for a file.

--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Connections/PeerConnection.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Connections/PeerConnection.swift
@@ -90,7 +90,12 @@ public actor PeerConnection {
     private let eventContinuation: AsyncStream<PeerConnectionEvent>.Continuation
 
     // SeeleSeek extension state
-    private(set) var isSeeleSeekPeer = false
+    private(set) var extendedClientInfo: ExtendedClientInfo?
+    /// TODO: not correct since any client could use extendo, check on string
+    public var isSeeleSeekPeer: Bool { extendedClientInfo != nil }
+    public func supports(_ code: SeeleSeekExtendedClientInfoCode) -> Bool {
+        extendedClientInfo?.supports(code) ?? false
+    }
 
     /// Get the discovered peer username (from PeerInit message)
     public func getPeerUsername() -> String {
@@ -451,7 +456,7 @@ public actor PeerConnection {
     /// connections switch to raw file-transfer bytes after init and would
     /// misinterpret this message as file data.
     public func sendSeeleSeekHandshake() async throws {
-        try await send(MessageBuilder.seeleseekHandshakeMessage())
+        try await send(MessageBuilder.extendedClientInfoMessage( clientInfo: ""))
     }
 
     public func sendPierceFirewall() async throws {
@@ -1579,13 +1584,13 @@ public actor PeerConnection {
             handleUserInfoRequest()
 
         // SeeleSeek extension codes
-        case SeeleSeekPeerCode.handshake.rawValue:
-            handleSeeleSeekHandshake(payload)
+        case SeeleSeekExtendedClientInfoCode.extendedClientInfo.rawValue:
+            handleExtendedClientInfo(payload)
 
-        case SeeleSeekPeerCode.artworkRequest.rawValue:
+        case SeeleSeekExtendedClientInfoCode.artworkRequest.rawValue:
             handleArtworkRequest(payload)
 
-        case SeeleSeekPeerCode.artworkReply.rawValue:
+        case SeeleSeekExtendedClientInfoCode.artworkReply.rawValue:
             handleArtworkReply(payload)
 
         default:
@@ -1610,12 +1615,15 @@ public actor PeerConnection {
 
     // MARK: - SeeleSeek Extension Handlers
 
-    /// Handle SeeleSeek handshake (code 10000) — marks this peer as a SeeleSeek client.
-    private func handleSeeleSeekHandshake(_ payload: Data) {
-        let version = payload.count > 0 ? payload[payload.startIndex] : 0
-        isSeeleSeekPeer = true
-        logger.info("[\(self.peerUsername)] SeeleSeek peer detected (version \(version))")
-        eventContinuation.yield(.seeleSeekVersionDiscovered(version))
+    
+    private func handleExtendedClientInfo(_ payload: Data) {
+        guard let info = MessageParser.parseExtendedClientInfo(payload) else {
+            logger.warning("[\(self.peerUsername)] ExtendedClientInfo malformed or unknown revision, ignoring")
+            return
+        }
+        
+        extendedClientInfo = info
+        eventContinuation.yield(.extendedClientInfoDiscovered(info))
     }
 
     /// Handle artwork request (code 10001) — peer wants album art for a file.

--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Connections/PeerConnectionPool.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Connections/PeerConnectionPool.swift
@@ -40,6 +40,8 @@ public final class PeerConnectionPool {
     /// connection state/bytes mutation. Written once per SeeleSeek peer
     /// per session; never cleared while the app is running.
     public private(set) var seeleSeekVersions: [String: UInt8] = [:]
+    
+    public private(set) var extendedClientInfoByUser: [String: ExtendedClientInfo] = [:]
 
     // CRITICAL: Store actual PeerConnection objects to keep them alive!
     // Without this, connections get deallocated immediately after creation.
@@ -162,9 +164,11 @@ public final class PeerConnectionPool {
         /// Please note this obviously could break in the future due
         /// to other clients using the extension code.
         public var seeleSeekVersion: UInt8?
+        
+        public var extendedClientInfo: ExtendedClientInfo?
 
-        public init(id: String, username: String, ip: String, port: Int, state: PeerConnection.State, connectionType: PeerConnection.ConnectionType, bytesReceived: UInt64 = 0, bytesSent: UInt64 = 0, connectedAt: Date? = nil, currentSpeed: Double = 0, seeleSeekVersion: UInt8? = nil) {
-            self.id = id; self.username = username; self.ip = ip; self.port = port; self.state = state; self.connectionType = connectionType; self.bytesReceived = bytesReceived; self.bytesSent = bytesSent; self.connectedAt = connectedAt; self.currentSpeed = currentSpeed; self.seeleSeekVersion = seeleSeekVersion
+        public init(id: String, username: String, ip: String, port: Int, state: PeerConnection.State, connectionType: PeerConnection.ConnectionType, bytesReceived: UInt64 = 0, bytesSent: UInt64 = 0, connectedAt: Date? = nil, currentSpeed: Double = 0, seeleSeekVersion: UInt8? = nil, extendedClientInfo: ExtendedClientInfo? = nil) {
+            self.id = id; self.username = username; self.ip = ip; self.port = port; self.state = state; self.connectionType = connectionType; self.bytesReceived = bytesReceived; self.bytesSent = bytesSent; self.connectedAt = connectedAt; self.currentSpeed = currentSpeed; self.seeleSeekVersion = seeleSeekVersion; self.extendedClientInfo = extendedClientInfo;
         }
     }
 
@@ -1114,6 +1118,14 @@ public final class PeerConnectionPool {
             connections[connectionId]?.seeleSeekVersion = version
             if !peerUsername.isEmpty {
                 seeleSeekVersions[peerUsername] = version
+            }
+            
+        case .extendedClientInfoDiscovered(let info):
+            let peerUsername = connection.peerInfo.username.isEmpty ? username : connection.peerInfo.username
+            connections[connectionId]?.extendedClientInfo = info
+            // seems inneficient to store twice?
+            if !peerUsername.isEmpty {
+                extendedClientInfoByUser[peerUsername] = info
             }
 
         case .artworkRequest(let token, let filePath):

--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Connections/PeerConnectionPool.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Connections/PeerConnectionPool.swift
@@ -33,15 +33,23 @@ public final class PeerConnectionPool {
 
     public private(set) var connections: [String: PeerConnectionInfo] = [:]
 
-    /// SeeleSeek client versions discovered via the capability handshake,
-    /// keyed by peer username. Separate from `connections` because the
-    /// version is a sticky, per-user fact — views that care (profile sheet,
-    /// peer info popover) want to observe it without also observing every
-    /// connection state/bytes mutation. Written once per SeeleSeek peer
-    /// per session; never cleared while the app is running.
-    public private(set) var seeleSeekVersions: [String: UInt8] = [:]
-    
+    /// Extension capabilities discovered via ExtendedClientInfo, keyed by peer
+    /// username. Stored here *as well as* on the `PeerConnectionInfo` row
+    /// because the two have different observers: the activity-tab popover
+    /// already binds to a connection row, while views like `UserProfileSheet`
+    /// have only a username. Reading this dict invalidates them on discovery
+    /// alone, not on every connection-state or bytes mutation.
+    ///
+    /// DISPLAY ONLY, and never cleared while the app runs. Peers may change
+    /// what they advertise at any time, so anything gating a *send* must ask
+    /// `PeerConnection.supports(_:)` on the live socket instead.
     public private(set) var extendedClientInfoByUser: [String: ExtendedClientInfo] = [:]
+
+    /// Whether `username` has advertised `code`, for building UI synchronously.
+    /// An affordance only — the send path re-checks the live socket.
+    public func hasAdvertised(_ code: SeeleSeekExtendedClientInfoCode, by username: String) -> Bool {
+        extendedClientInfoByUser[username]?.supports(code) ?? false
+    }
 
     // CRITICAL: Store actual PeerConnection objects to keep them alive!
     // Without this, connections get deallocated immediately after creation.
@@ -157,18 +165,13 @@ public final class PeerConnectionPool {
         public var bytesSent: UInt64 = 0
         public var connectedAt: Date?
         public var currentSpeed: Double = 0
-        /// Non-nil only when the peer is a SeeleSeek client and sent our
-        /// capability handshake (extension code 10000). Standard Soulseek
-        /// peers (Nicotine+, qtoolsoulsync, etc.) never expose client
-        /// version peer-to-peer, so this stays nil for them by design.
-        /// Please note this obviously could break in the future due
-        /// to other clients using the extension code.
-        public var seeleSeekVersion: UInt8?
-        
+        /// Non-nil once the peer advertised extensions (code 10000). Peers
+        /// that do not implement the handshake stay nil, which is most of
+        /// them. Presence says nothing about *which* client this is.
         public var extendedClientInfo: ExtendedClientInfo?
 
-        public init(id: String, username: String, ip: String, port: Int, state: PeerConnection.State, connectionType: PeerConnection.ConnectionType, bytesReceived: UInt64 = 0, bytesSent: UInt64 = 0, connectedAt: Date? = nil, currentSpeed: Double = 0, seeleSeekVersion: UInt8? = nil, extendedClientInfo: ExtendedClientInfo? = nil) {
-            self.id = id; self.username = username; self.ip = ip; self.port = port; self.state = state; self.connectionType = connectionType; self.bytesReceived = bytesReceived; self.bytesSent = bytesSent; self.connectedAt = connectedAt; self.currentSpeed = currentSpeed; self.seeleSeekVersion = seeleSeekVersion; self.extendedClientInfo = extendedClientInfo;
+        public init(id: String, username: String, ip: String, port: Int, state: PeerConnection.State, connectionType: PeerConnection.ConnectionType, bytesReceived: UInt64 = 0, bytesSent: UInt64 = 0, connectedAt: Date? = nil, currentSpeed: Double = 0, extendedClientInfo: ExtendedClientInfo? = nil) {
+            self.id = id; self.username = username; self.ip = ip; self.port = port; self.state = state; self.connectionType = connectionType; self.bytesReceived = bytesReceived; self.bytesSent = bytesSent; self.connectedAt = connectedAt; self.currentSpeed = currentSpeed; self.extendedClientInfo = extendedClientInfo;
         }
     }
 
@@ -1104,26 +1107,12 @@ public final class PeerConnectionPool {
             let peerUsername = connection.peerInfo.username.isEmpty ? username : connection.peerInfo.username
             eventContinuation.yield(.userInfoReply(username: peerUsername, info: info))
 
-        case .seeleSeekVersionDiscovered(let version):
-            // Stamp the version onto the live PeerConnectionInfo (for the
-            // activity-tab popover, which is already binding to the
-            // connection row) AND into the per-username `seeleSeekVersions`
-            // dict. The separate dict is what views like UserProfileSheet
-            // read: observing it only invalidates on discovery, not on
-            // every connection-state or bytes update.
-            let peerUsername = connection.peerInfo.username.isEmpty ? username : connection.peerInfo.username
-            // Stamp onto the exact PeerConnectionInfo for this socket.
-            // Prefix scans on username can hit the wrong row when a user
-            // has multiple concurrent connections.
-            connections[connectionId]?.seeleSeekVersion = version
-            if !peerUsername.isEmpty {
-                seeleSeekVersions[peerUsername] = version
-            }
-            
         case .extendedClientInfoDiscovered(let info):
             let peerUsername = connection.peerInfo.username.isEmpty ? username : connection.peerInfo.username
+            // Stamp onto the exact PeerConnectionInfo for this socket. Prefix
+            // scans on username can hit the wrong row when a user has
+            // multiple concurrent connections.
             connections[connectionId]?.extendedClientInfo = info
-            // seems inneficient to store twice?
             if !peerUsername.isEmpty {
                 extendedClientInfoByUser[peerUsername] = info
             }

--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Connections/PeerConnectionPool.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Connections/PeerConnectionPool.swift
@@ -47,7 +47,7 @@ public final class PeerConnectionPool {
 
     /// Whether `username` has advertised `code`, for building UI synchronously.
     /// An affordance only — the send path re-checks the live socket.
-    public func hasAdvertised(_ code: SeeleSeekExtendedClientInfoCode, by username: String) -> Bool {
+    public func hasAdvertised(_ code: ExtendedClientInfoCode, by username: String) -> Bool {
         extendedClientInfoByUser[username]?.supports(code) ?? false
     }
 
@@ -165,13 +165,8 @@ public final class PeerConnectionPool {
         public var bytesSent: UInt64 = 0
         public var connectedAt: Date?
         public var currentSpeed: Double = 0
-        /// Non-nil once the peer advertised extensions (code 10000). Peers
-        /// that do not implement the handshake stay nil, which is most of
-        /// them. Presence says nothing about *which* client this is.
-        public var extendedClientInfo: ExtendedClientInfo?
-
-        public init(id: String, username: String, ip: String, port: Int, state: PeerConnection.State, connectionType: PeerConnection.ConnectionType, bytesReceived: UInt64 = 0, bytesSent: UInt64 = 0, connectedAt: Date? = nil, currentSpeed: Double = 0, extendedClientInfo: ExtendedClientInfo? = nil) {
-            self.id = id; self.username = username; self.ip = ip; self.port = port; self.state = state; self.connectionType = connectionType; self.bytesReceived = bytesReceived; self.bytesSent = bytesSent; self.connectedAt = connectedAt; self.currentSpeed = currentSpeed; self.extendedClientInfo = extendedClientInfo;
+        public init(id: String, username: String, ip: String, port: Int, state: PeerConnection.State, connectionType: PeerConnection.ConnectionType, bytesReceived: UInt64 = 0, bytesSent: UInt64 = 0, connectedAt: Date? = nil, currentSpeed: Double = 0) {
+            self.id = id; self.username = username; self.ip = ip; self.port = port; self.state = state; self.connectionType = connectionType; self.bytesReceived = bytesReceived; self.bytesSent = bytesSent; self.connectedAt = connectedAt; self.currentSpeed = currentSpeed;
         }
     }
 
@@ -1109,11 +1104,10 @@ public final class PeerConnectionPool {
 
         case .extendedClientInfoDiscovered(let info):
             let peerUsername = connection.peerInfo.username.isEmpty ? username : connection.peerInfo.username
-            // Stamp onto the exact PeerConnectionInfo for this socket. Prefix
-            // scans on username can hit the wrong row when a user has
-            // multiple concurrent connections.
-            connections[connectionId]?.extendedClientInfo = info
-            if !peerUsername.isEmpty {
+            // Equality-guarded: peers re-advertise on every new P socket, and
+            // browse rows observe this dict. An unguarded write would repaint
+            // the visible file tree on each reconnect for no visual change.
+            if !peerUsername.isEmpty, extendedClientInfoByUser[peerUsername] != info {
                 extendedClientInfoByUser[peerUsername] = info
             }
 

--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Handlers/ServerMessageHandler.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Handlers/ServerMessageHandler.swift
@@ -522,7 +522,7 @@ public final class ServerMessageHandler {
             // F-type flips to raw file-transfer bytes after PierceFirewall and
             // would misinterpret an extra 13-byte message as file data.
             if connectionType == "P" {
-                try? await connection.sendSeeleSeekHandshake()
+                try? await connection.sendExtendedClientInfo()
             } else if connectionType == "F" {
                 // This is the downloader side of an indirect F connection.
                 // The uploader will now send the raw 4-byte FileTransferInit

--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/NetworkClient.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/NetworkClient.swift
@@ -2756,6 +2756,15 @@ public final class NetworkClient {
                 return
             }
 
+            // Only peers that advertised ArtworkRequest get one. Asked on the
+            // live socket rather than the pool's sticky cache, since peers may
+            // change what they advertise.
+            guard await connection.supports(.artworkRequest) else {
+                logger.debug("\(username) has not advertised ArtworkRequest, skipping")
+                deliverArtwork(key: key, data: nil)
+                return
+            }
+
             let request = MessageBuilder.artworkRequestMessage(token: token, filePath: filePath)
             do {
                 try await connection.send(request)

--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/NetworkClient.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/NetworkClient.swift
@@ -2665,8 +2665,18 @@ public final class NetworkClient {
 
     // MARK: - SeeleSeek Artwork Request Handling
 
-    /// Handle artwork request from a SeeleSeek peer — look up the file and send back embedded artwork.
+    /// Handle artwork request from an extension peer — look up the file and send back embedded artwork.
     private func handleArtworkRequest(username: String, token: UInt32, filePath: String, connection: PeerConnection) async {
+        // Gate on the code we are about to *send*, same rule as the outbound
+        // side. Placed before the index scan rather than beside the reply:
+        // servicing this means an O(N) walk of the share index plus a disk
+        // read and image parse, which no peer gets to trigger on demand
+        // without having advertised the exchange.
+        guard await connection.supports(.artworkReply) else {
+            logger.debug("ArtworkRequest from \(username) ignored — peer has not advertised the artwork extension")
+            return
+        }
+
         // Find the file in our share index by SoulSeek path. Snapshot on
         // the main actor, scan off-main — O(N) over a large index per
         // incoming request otherwise hitches the UI.
@@ -2678,7 +2688,7 @@ public final class NetworkClient {
             logger.warning("ArtworkRequest: file not found in shares: \(filePath)")
             // Send empty reply
             let reply = MessageBuilder.artworkReplyMessage(token: token, imageData: Data())
-            try? await connection.send(reply)
+            try? await connection.send(extension: .artworkReply, reply)
             return
         }
 
@@ -2691,7 +2701,7 @@ public final class NetworkClient {
             if !isBuddy {
                 logger.info("ArtworkRequest denied (buddy-only file, non-buddy requester): \(filePath)")
                 let reply = MessageBuilder.artworkReplyMessage(token: token, imageData: Data())
-                try? await connection.send(reply)
+                try? await connection.send(extension: .artworkReply, reply)
                 return
             }
         }
@@ -2703,7 +2713,7 @@ public final class NetworkClient {
 
         logger.info("ArtworkRequest: sending \(imageData.count) bytes for \(filePath)")
         let reply = MessageBuilder.artworkReplyMessage(token: token, imageData: imageData)
-        try? await connection.send(reply)
+        try? await connection.send(extension: .artworkReply, reply)
     }
 
     /// Pending artwork request callbacks keyed by token.
@@ -2756,19 +2766,13 @@ public final class NetworkClient {
                 return
             }
 
-            // Only peers that advertised ArtworkRequest get one. Asked on the
-            // live socket rather than the pool's sticky cache, since peers may
-            // change what they advertise.
-            guard await connection.supports(.artworkRequest) else {
-                logger.debug("\(username) has not advertised ArtworkRequest, skipping")
-                deliverArtwork(key: key, data: nil)
-                return
-            }
-
+            // Throws `capabilityNotAdvertised` for peers that never advertised
+            // it, which lands in the same nil delivery as a send failure.
             let request = MessageBuilder.artworkRequestMessage(token: token, filePath: filePath)
             do {
-                try await connection.send(request)
+                try await connection.send(extension: .artworkRequest, request)
             } catch {
+                logger.debug("Artwork request to \(username) not sent: \(error.localizedDescription)")
                 deliverArtwork(key: key, data: nil)
                 return
             }

--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Protocol/MessageBuilder.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Protocol/MessageBuilder.swift
@@ -856,21 +856,12 @@ public enum MessageBuilder {
 
     // MARK: - SeeleSeek Extension Messages
 
-//    /// SeeleSeek handshake (code 10000) — identify ourselves as a SeeleSeek client.
-//    /// Sent right after PeerInit. Payload: uint8 version (currently 1).
-//    public nonisolated static func seeleseekHandshakeMessage() -> Data {
-//        var payload = Data()
-//        payload.appendUInt32(SeeleSeekPeerCode.handshake.rawValue)
-//        payload.appendUInt8(1) // protocol version
-//        return wrapMessage(payload)
-//    }
-    
-    
-    static let extendedClientInfoRevision: UInt32 = 1
-    
-    /// ExtendedClientInfo (code 10000)
+    public static let extendedClientInfoRevision: UInt32 = 1
+
+    /// ExtendedClientInfo (code 10000) — advertise which extension codes we speak.
     ///
-    /// `clientInfo`
+    /// `clientInfo` goes on the wire verbatim and is a durable fingerprint, so
+    /// it defaults to empty. Nothing in our own logic may depend on its value.
     public nonisolated static func extendedClientInfoMessage(
         advertising codes: [SeeleSeekExtendedClientInfoCode] = SeeleSeekExtendedClientInfoCode.allCases,
         clientInfo: String = ""

--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Protocol/MessageBuilder.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Protocol/MessageBuilder.swift
@@ -856,19 +856,46 @@ public enum MessageBuilder {
 
     // MARK: - SeeleSeek Extension Messages
 
-    /// SeeleSeek handshake (code 10000) — identify ourselves as a SeeleSeek client.
-    /// Sent right after PeerInit. Payload: uint8 version (currently 1).
-    public nonisolated static func seeleseekHandshakeMessage() -> Data {
+//    /// SeeleSeek handshake (code 10000) — identify ourselves as a SeeleSeek client.
+//    /// Sent right after PeerInit. Payload: uint8 version (currently 1).
+//    public nonisolated static func seeleseekHandshakeMessage() -> Data {
+//        var payload = Data()
+//        payload.appendUInt32(SeeleSeekPeerCode.handshake.rawValue)
+//        payload.appendUInt8(1) // protocol version
+//        return wrapMessage(payload)
+//    }
+    
+    
+    static let extendedClientInfoRevision: UInt32 = 1
+    
+    /// ExtendedClientInfo (code 10000)
+    ///
+    /// `clientInfo`
+    public nonisolated static func extendedClientInfoMessage(
+        advertising codes: [SeeleSeekExtendedClientInfoCode] = SeeleSeekExtendedClientInfoCode.allCases,
+        clientInfo: String = ""
+    ) -> Data {
         var payload = Data()
-        payload.appendUInt32(SeeleSeekPeerCode.handshake.rawValue)
-        payload.appendUInt8(1) // protocol version
+        // 0. send extendedClient code
+        payload.appendUInt32(SeeleSeekExtendedClientInfoCode.extendedClientInfo.rawValue)
+        // 1. send revision identifier (value is always 1)
+        payload.appendUInt32(extendedClientInfoRevision)
+        // 2. send string with optional client info (may identify software or any custom signals)
+        payload.appendString(clientInfo)
+        
+        payload.appendUInt32(UInt32(codes.count))
+        for code in codes {
+            payload.appendUInt32(code.rawValue)
+            payload.appendString(code.wireName)
+            payload.appendUInt32(0) // reserved
+        }
         return wrapMessage(payload)
     }
 
     /// Artwork request (code 10001) — ask peer for album art embedded in a file.
     public nonisolated static func artworkRequestMessage(token: UInt32, filePath: String) -> Data {
         var payload = Data()
-        payload.appendUInt32(SeeleSeekPeerCode.artworkRequest.rawValue)
+        payload.appendUInt32(SeeleSeekExtendedClientInfoCode.artworkRequest.rawValue)
         payload.appendUInt32(token)
         payload.appendString(filePath)
         return wrapMessage(payload)
@@ -877,7 +904,7 @@ public enum MessageBuilder {
     /// Artwork reply (code 10002) — respond with image data (or empty if none found).
     public nonisolated static func artworkReplyMessage(token: UInt32, imageData: Data) -> Data {
         var payload = Data()
-        payload.appendUInt32(SeeleSeekPeerCode.artworkReply.rawValue)
+        payload.appendUInt32(SeeleSeekExtendedClientInfoCode.artworkReply.rawValue)
         payload.appendUInt32(token)
         // Write raw image bytes (length is implicit from message frame)
         payload.append(imageData)

--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Protocol/MessageBuilder.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Protocol/MessageBuilder.swift
@@ -858,11 +858,11 @@ public enum MessageBuilder {
 
     /// ExtendedClientInfo (code 10000) — advertise which extension codes we speak.
     ///
-    /// `clientInfo` goes on the wire verbatim and is a durable fingerprint, so
-    /// it defaults to empty. Nothing in our own logic may depend on its value.
+    /// `clientInfo` goes on the wire verbatim. Nothing in our own logic may
+    /// depend on its value: peers choose it freely and can lie.
     public nonisolated static func extendedClientInfoMessage(
         advertising codes: [ExtendedClientInfoCode] = ExtendedClientInfoCode.advertised,
-        clientInfo: String = ""
+        clientInfo: String = ExtendedClientInfo.localClientInfo
     ) -> Data {
         var payload = Data()
         // 0. send extendedClient code

--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Protocol/MessageBuilder.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Protocol/MessageBuilder.swift
@@ -856,21 +856,19 @@ public enum MessageBuilder {
 
     // MARK: - SeeleSeek Extension Messages
 
-    public static let extendedClientInfoRevision: UInt32 = 1
-
     /// ExtendedClientInfo (code 10000) — advertise which extension codes we speak.
     ///
     /// `clientInfo` goes on the wire verbatim and is a durable fingerprint, so
     /// it defaults to empty. Nothing in our own logic may depend on its value.
     public nonisolated static func extendedClientInfoMessage(
-        advertising codes: [SeeleSeekExtendedClientInfoCode] = SeeleSeekExtendedClientInfoCode.allCases,
+        advertising codes: [ExtendedClientInfoCode] = ExtendedClientInfoCode.advertised,
         clientInfo: String = ""
     ) -> Data {
         var payload = Data()
         // 0. send extendedClient code
-        payload.appendUInt32(SeeleSeekExtendedClientInfoCode.extendedClientInfo.rawValue)
+        payload.appendUInt32(ExtendedClientInfoCode.extendedClientInfo.rawValue)
         // 1. send revision identifier (value is always 1)
-        payload.appendUInt32(extendedClientInfoRevision)
+        payload.appendUInt32(ExtendedClientInfo.currentRevision)
         // 2. send string with optional client info (may identify software or any custom signals)
         payload.appendString(clientInfo)
         
@@ -886,7 +884,7 @@ public enum MessageBuilder {
     /// Artwork request (code 10001) — ask peer for album art embedded in a file.
     public nonisolated static func artworkRequestMessage(token: UInt32, filePath: String) -> Data {
         var payload = Data()
-        payload.appendUInt32(SeeleSeekExtendedClientInfoCode.artworkRequest.rawValue)
+        payload.appendUInt32(ExtendedClientInfoCode.artworkRequest.rawValue)
         payload.appendUInt32(token)
         payload.appendString(filePath)
         return wrapMessage(payload)
@@ -895,7 +893,7 @@ public enum MessageBuilder {
     /// Artwork reply (code 10002) — respond with image data (or empty if none found).
     public nonisolated static func artworkReplyMessage(token: UInt32, imageData: Data) -> Data {
         var payload = Data()
-        payload.appendUInt32(SeeleSeekExtendedClientInfoCode.artworkReply.rawValue)
+        payload.appendUInt32(ExtendedClientInfoCode.artworkReply.rawValue)
         payload.appendUInt32(token)
         // Write raw image bytes (length is implicit from message frame)
         payload.append(imageData)

--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Protocol/MessageCode.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Protocol/MessageCode.swift
@@ -248,24 +248,24 @@ public enum PeerMessageCode: UInt8 {
 }
 
 // MARK: - SeeleSeek Extension Codes (client-specific, UInt32 range 10000+)
-// These codes are only understood by other SeeleSeek clients.
-// Non-SeeleSeek peers will silently ignore them (unknown code path).
-public enum SeeleSeekPeerCode: UInt32, CaseIterable {
-    /// Capability handshake — sent after PeerInit to identify SeeleSeek peers.
-    /// Payload: uint8 version
-    case handshake = 10000
-
+// These codes are only understood by other clients supporting ExtendedClientInfo.
+// Non-supporting peers will silently ignore them (unknown code path).
+public enum SeeleSeekExtendedClientInfoCode: UInt32, CaseIterable {
+    
+    /// Extended client info handshake — sent after PeerInit to identify client extended capabilities peers.
+    case extendedClientInfo = 10000
+    
     /// Request album artwork embedded in a file.
     /// Payload: uint32 token + string filePath
     case artworkRequest = 10001
-
-    /// Response with artwork image data (or empty if none found).
-    /// Payload: uint32 token + bytes imageData (may be empty)
+    
+    /// Request album artwork embedded in a file.
+    /// Payload: uint32 token + string filePath
     case artworkReply = 10002
-
-    nonisolated var description: String {
+    
+    public nonisolated var wireName: String {
         switch self {
-        case .handshake: "SeeleSeekHandshake"
+        case .extendedClientInfo: "ExtendedClientInfo"
         case .artworkRequest: "ArtworkRequest"
         case .artworkReply: "ArtworkReply"
         }

--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Protocol/MessageCode.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Protocol/MessageCode.swift
@@ -247,10 +247,10 @@ public enum PeerMessageCode: UInt8 {
     }
 }
 
-// MARK: - SeeleSeek Extension Codes (client-specific, UInt32 range 10000+)
+// MARK: - Extension Codes (client-specific, UInt32 range 10000+)
 // These codes are only understood by other clients supporting ExtendedClientInfo.
 // Non-supporting peers will silently ignore them (unknown code path).
-public enum SeeleSeekExtendedClientInfoCode: UInt32, CaseIterable {
+public enum ExtendedClientInfoCode: UInt32, CaseIterable, Sendable {
     
     /// Extended client info handshake — sent after PeerInit to identify client extended capabilities peers.
     case extendedClientInfo = 10000
@@ -270,6 +270,13 @@ public enum SeeleSeekExtendedClientInfoCode: UInt32, CaseIterable {
         case .artworkReply: "ArtworkReply"
         }
     }
+
+    /// What we actually implement, and therefore promise to peers.
+    /// Deliberately not `allCases` — this enum is the code table, and a case
+    /// may be added to describe or receive a code before we implement it.
+    public nonisolated static let advertised: [ExtendedClientInfoCode] = [
+        .extendedClientInfo, .artworkRequest, .artworkReply
+    ]
 }
 
 // MARK: - Distributed Message Codes

--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Protocol/MessageCode.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Protocol/MessageCode.swift
@@ -259,8 +259,8 @@ public enum SeeleSeekExtendedClientInfoCode: UInt32, CaseIterable {
     /// Payload: uint32 token + string filePath
     case artworkRequest = 10001
     
-    /// Request album artwork embedded in a file.
-    /// Payload: uint32 token + string filePath
+    /// Response with artwork image data (or empty if none found).
+    /// Payload: uint32 token + bytes imageData (may be empty)
     case artworkReply = 10002
     
     public nonisolated var wireName: String {

--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Protocol/MessageParser.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Protocol/MessageParser.swift
@@ -1176,7 +1176,7 @@ public enum MessageParser {
         offset += 4
 
         // Fail closed on an unknown revision rather than guessing at the layout.
-        guard revision == MessageBuilder.extendedClientInfoRevision else { return nil }
+        guard revision == ExtendedClientInfo.currentRevision else { return nil }
 
         guard let (clientInfo, infoBytes) = payload.readString(at: offset) else { return nil }
         offset += infoBytes

--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Protocol/MessageParser.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Protocol/MessageParser.swift
@@ -1162,4 +1162,37 @@ public enum MessageParser {
 
         return DistributedSearchInfo(unknown: unknown, username: username, token: token, query: query)
     }
+    
+    
+    private static let maxAdvertisedCapabilities = 64
+    
+    public nonisolated static func parseExtendedClientInfo(_ payload: Data) -> ExtendedClientInfo? {
+        var offset = 0
+        
+        guard let revision = payload.readUInt32(at: offset) else { return nil }
+        offset += 4
+        
+        // fail closed on uknown revision
+        guard revision == MessageBuilder.extendedClientInfoRevision else { return nil }
+        
+        guard let (clientInfo, infoBytes) = payload.readString(at: offset) else { return nil }
+        offset += infoBytes
+        
+        guard let count = payload.readUInt32(at: offset) else { return nil }
+        offset += 4
+        guard count <= maxAdvertisedCapabilities else { return nil }
+        
+        var capabilites: [String: UInt32] = [:]
+        for _ in 0..<count {
+            guard let code = payload.readUInt32(at: offset) else { return nil }
+            offset += 4
+            guard let (name, nameBytes) = payload.readString(at: offset) else { return nil }
+            offset += nameBytes
+            guard payload.readUInt32(at: offset) != nil else { return nil }
+            offset += 4
+            capabilites[name] = code
+        }
+        
+        return ExtendedClientInfo(revision: revision, clientInfo: clientInfo, capabilities: capabilites)
+    }
 }

--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Protocol/MessageParser.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Protocol/MessageParser.swift
@@ -1162,37 +1162,40 @@ public enum MessageParser {
 
         return DistributedSearchInfo(unknown: unknown, username: username, token: token, query: query)
     }
-    
-    
+
+    /// Entries are 12 bytes minimum (code + empty-string length prefix +
+    /// reserved), so a count above `remaining / 12` is provably a lie. The
+    /// cap is a second belt: `readUInt32`/`readString` bounds-check every
+    /// field, so an oversized count fails on the first read anyway.
     private static let maxAdvertisedCapabilities = 64
-    
+
     public nonisolated static func parseExtendedClientInfo(_ payload: Data) -> ExtendedClientInfo? {
         var offset = 0
-        
+
         guard let revision = payload.readUInt32(at: offset) else { return nil }
         offset += 4
-        
-        // fail closed on uknown revision
+
+        // Fail closed on an unknown revision rather than guessing at the layout.
         guard revision == MessageBuilder.extendedClientInfoRevision else { return nil }
-        
+
         guard let (clientInfo, infoBytes) = payload.readString(at: offset) else { return nil }
         offset += infoBytes
-        
+
         guard let count = payload.readUInt32(at: offset) else { return nil }
         offset += 4
         guard count <= maxAdvertisedCapabilities else { return nil }
-        
-        var capabilites: [String: UInt32] = [:]
+
+        var capabilities: [String: UInt32] = [:]
         for _ in 0..<count {
             guard let code = payload.readUInt32(at: offset) else { return nil }
             offset += 4
             guard let (name, nameBytes) = payload.readString(at: offset) else { return nil }
             offset += nameBytes
-            guard payload.readUInt32(at: offset) != nil else { return nil }
+            guard payload.readUInt32(at: offset) != nil else { return nil }  // reserved
             offset += 4
-            capabilites[name] = code
+            capabilities[name] = code
         }
-        
-        return ExtendedClientInfo(revision: revision, clientInfo: clientInfo, capabilities: capabilites)
+
+        return ExtendedClientInfo(revision: revision, clientInfo: clientInfo, capabilities: capabilities)
     }
 }

--- a/seeleseek.xcodeproj/project.xcworkspace/xcuserdata/brettwork.xcuserdatad/IDEFindNavigatorScopes.plist
+++ b/seeleseek.xcodeproj/project.xcworkspace/xcuserdata/brettwork.xcuserdatad/IDEFindNavigatorScopes.plist
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<array/>
-</plist>

--- a/seeleseek.xcodeproj/project.xcworkspace/xcuserdata/brettwork.xcuserdatad/IDEFindNavigatorScopes.plist
+++ b/seeleseek.xcodeproj/project.xcworkspace/xcuserdata/brettwork.xcuserdatad/IDEFindNavigatorScopes.plist
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<array/>
+</plist>

--- a/seeleseek/Core/Extensions/ExtendedClientInfo+UI.swift
+++ b/seeleseek/Core/Extensions/ExtendedClientInfo+UI.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+import SeeleseekCore
+
+extension ExtendedClientInfo {
+    /// Badge text for a peer that advertised extensions.
+    ///
+    /// Falls back to a generic label because `clientInfo` is optional on the
+    /// wire and we send it empty ourselves, so most advertising peers have no
+    /// string to show. Naming a client here would also claim an identity the
+    /// handshake cannot establish.
+    var displayLabel: String {
+        clientInfo.isEmpty ? "extended client" : clientInfo
+    }
+}

--- a/seeleseek/Features/Browse/Views/FileTreeRow.swift
+++ b/seeleseek/Features/Browse/Views/FileTreeRow.swift
@@ -15,6 +15,13 @@ struct FileTreeRow: View {
     @State private var isLoadingArtwork = false
     @State private var showArtworkPopover = false
 
+    /// Artwork is an extension, so only offer it to peers that advertised it.
+    /// The send path re-checks the live socket; this just avoids showing a
+    /// menu item that could only ever fail.
+    private var peerServesArtwork: Bool {
+        appState.networkClient.peerConnectionPool.hasAdvertised(.artworkRequest, by: username)
+    }
+
     private var isExpanded: Bool {
         // While a filter is active the tree renders matches with their
         // ancestor chain regardless of expansion state, so show every
@@ -179,7 +186,7 @@ struct FileTreeRow: View {
                     Label("Download Containing Folder", systemImage: "arrow.down.circle.fill")
                 }
 
-                if file.isAudioFile {
+                if file.isAudioFile, peerServesArtwork {
                     Button {
                         fetchArtwork()
                     } label: {
@@ -234,7 +241,7 @@ struct FileTreeRow: View {
                     Button("Download file") { downloadFile() }
                 }
                 Button("Download containing folder") { downloadContainingFolder() }
-                if file.isAudioFile {
+                if file.isAudioFile, peerServesArtwork {
                     Button("Show album art") { fetchArtwork() }
                 }
                 Button("Copy filename") { copyFilename() }

--- a/seeleseek/Features/Social/Views/UserProfileSheet.swift
+++ b/seeleseek/Features/Social/Views/UserProfileSheet.swift
@@ -95,8 +95,8 @@ struct UserProfileSheet: View {
                         .font(SeeleTypography.caption)
                         .foregroundStyle(SeeleColors.textSecondary)
 
-                    if let version = liveSeeleSeekVersion {
-                        Text("seeleseek v\(version)")
+                    if let info = liveExtendedClientInfo {
+                        Text(info.clientInfo.isEmpty ? "extended client" : info.clientInfo)
                             .font(SeeleTypography.caption2)
                             .foregroundStyle(SeeleColors.accent)
                             .padding(.horizontal, SeeleSpacing.xs)
@@ -348,13 +348,13 @@ struct UserProfileSheet: View {
         return profile.countryCode.map { CountryFormatter.flag(for: $0) }
     }
 
-    /// SeeleSeek version for this user, looked up in the dedicated
+    /// Advertised extensions for this user, looked up in the dedicated
     /// per-username dict on the pool. Reading the dict invalidates this
-    /// view only when a version is discovered (a rare, sticky event),
+    /// view only when capabilities are discovered (a rare, sticky event),
     /// not on every connection-state or bytes mutation the way observing
     /// `connections` would.
-    private var liveSeeleSeekVersion: UInt8? {
-        appState.networkClient.peerConnectionPool.seeleSeekVersions[profile.username]
+    private var liveExtendedClientInfo: ExtendedClientInfo? {
+        appState.networkClient.peerConnectionPool.extendedClientInfoByUser[profile.username]
     }
 }
 

--- a/seeleseek/Features/Social/Views/UserProfileSheet.swift
+++ b/seeleseek/Features/Social/Views/UserProfileSheet.swift
@@ -96,7 +96,7 @@ struct UserProfileSheet: View {
                         .foregroundStyle(SeeleColors.textSecondary)
 
                     if let info = liveExtendedClientInfo {
-                        Text(info.clientInfo.isEmpty ? "extended client" : info.clientInfo)
+                        Text(info.displayLabel)
                             .font(SeeleTypography.caption2)
                             .foregroundStyle(SeeleColors.accent)
                             .padding(.horizontal, SeeleSpacing.xs)

--- a/seeleseek/Features/Statistics/Views/PeerInfoPopover.swift
+++ b/seeleseek/Features/Statistics/Views/PeerInfoPopover.swift
@@ -10,6 +10,13 @@ struct PeerInfoPopover: View {
         !peer.username.isEmpty && peer.username != "unknown"
     }
 
+    /// Capabilities are a per-user fact, so they live in the pool's dedicated
+    /// dict rather than on the connection row.  reading it here invalidates
+    /// this view on discovery alone, not on every bytes update.
+    private var extendedClientInfo: ExtendedClientInfo? {
+        appState.networkClient.peerConnectionPool.extendedClientInfoByUser[peer.username]
+    }
+
     private var displayName: String {
         hasUsername ? peer.username : peer.ip
     }
@@ -84,13 +91,11 @@ struct PeerInfoPopover: View {
                         .font(SeeleTypography.caption)
                         .foregroundStyle(stateColor)
 
-                    if let info = peer.extendedClientInfo {
+                    if let info = extendedClientInfo {
                         // Set only for peers that advertised extensions
                         // (code 10000). Most Soulseek clients do not, so this
-                        // is absent for them. The badge is keyed on presence,
-                        // not on `clientInfo` — that string is optional and
-                        // we send it empty ourselves.
-                        Text(info.clientInfo.isEmpty ? "extended client" : info.clientInfo)
+                        // is absent for them.
+                        Text(info.displayLabel)
                             .font(SeeleTypography.caption2)
                             .foregroundStyle(SeeleColors.accent)
                             .padding(.horizontal, SeeleSpacing.xs)

--- a/seeleseek/Features/Statistics/Views/PeerInfoPopover.swift
+++ b/seeleseek/Features/Statistics/Views/PeerInfoPopover.swift
@@ -84,12 +84,13 @@ struct PeerInfoPopover: View {
                         .font(SeeleTypography.caption)
                         .foregroundStyle(stateColor)
 
-                    if let version = peer.seeleSeekVersion {
-                        // Only set for SeeleSeek peers who completed the
-                        // capability handshake; standard Soulseek clients
-                        // (Nicotine+, SoulseekQt, etc.) never expose their
-                        // version peer-to-peer, so nothing to show.
-                        Text("seeleseek v\(version)")
+                    if let info = peer.extendedClientInfo {
+                        // Set only for peers that advertised extensions
+                        // (code 10000). Most Soulseek clients do not, so this
+                        // is absent for them. The badge is keyed on presence,
+                        // not on `clientInfo` — that string is optional and
+                        // we send it empty ourselves.
+                        Text(info.clientInfo.isEmpty ? "extended client" : info.clientInfo)
                             .font(SeeleTypography.caption2)
                             .foregroundStyle(SeeleColors.accent)
                             .padding(.horizontal, SeeleSpacing.xs)

--- a/seeleseekTests/PeerConnectivityTests.swift
+++ b/seeleseekTests/PeerConnectivityTests.swift
@@ -217,7 +217,7 @@ struct PeerConnectivityTests {
             username: username,
             connectionType: "P",
             token: 0
-        ) + MessageBuilder.seeleseekHandshakeMessage()
+        ) + MessageBuilder.extendedClientInfoMessage()
           + MessageBuilder.queueDownloadMessage(filename: filename)
 
         let receiver = Task { () throws -> Data in

--- a/seeleseekTests/PeerMessageRoundTripTests.swift
+++ b/seeleseekTests/PeerMessageRoundTripTests.swift
@@ -282,7 +282,7 @@ struct PeerMessageRoundTripTests {
         let msg = MessageBuilder.extendedClientInfoMessage()
         let (code, off) = parsePeerMessage(msg)
         #expect(code == SeeleSeekExtendedClientInfoCode.extendedClientInfo.rawValue)
-        #expect(msg.readUInt32(at: off) == MessageBuilder.extendedClientInfoRevision)
+        #expect(msg.readUInt32(at: off) == ExtendedClientInfo.currentRevision)
     }
 
     @Test("artworkRequest message")

--- a/seeleseekTests/PeerMessageRoundTripTests.swift
+++ b/seeleseekTests/PeerMessageRoundTripTests.swift
@@ -281,7 +281,7 @@ struct PeerMessageRoundTripTests {
     func testExtendedClientInfo() {
         let msg = MessageBuilder.extendedClientInfoMessage()
         let (code, off) = parsePeerMessage(msg)
-        #expect(code == SeeleSeekExtendedClientInfoCode.extendedClientInfo.rawValue)
+        #expect(code == ExtendedClientInfoCode.extendedClientInfo.rawValue)
         #expect(msg.readUInt32(at: off) == ExtendedClientInfo.currentRevision)
     }
 
@@ -289,7 +289,7 @@ struct PeerMessageRoundTripTests {
     func testArtworkRequest() {
         let msg = MessageBuilder.artworkRequestMessage(token: 88888, filePath: "Music\\artist\\song.mp3")
         let (code, off) = parsePeerMessage(msg)
-        #expect(code == SeeleSeekExtendedClientInfoCode.artworkRequest.rawValue)
+        #expect(code == ExtendedClientInfoCode.artworkRequest.rawValue)
         var o = off
         #expect(msg.readUInt32(at: o) == 88888); o += 4
         let (path, _) = msg.readString(at: o)!
@@ -301,7 +301,7 @@ struct PeerMessageRoundTripTests {
         let imageData = Data(repeating: 0xAB, count: 256)
         let msg = MessageBuilder.artworkReplyMessage(token: 99999, imageData: imageData)
         let (code, off) = parsePeerMessage(msg)
-        #expect(code == SeeleSeekExtendedClientInfoCode.artworkReply.rawValue)
+        #expect(code == ExtendedClientInfoCode.artworkReply.rawValue)
         var o = off
         #expect(msg.readUInt32(at: o) == 99999); o += 4
         // Remaining bytes are image data

--- a/seeleseekTests/PeerMessageRoundTripTests.swift
+++ b/seeleseekTests/PeerMessageRoundTripTests.swift
@@ -277,19 +277,19 @@ struct PeerMessageRoundTripTests {
 
     // MARK: - SeeleSeek Extension Messages
 
-    @Test("seeleseekHandshake message")
-    func testSeeleSeekHandshake() {
-        let msg = MessageBuilder.seeleseekHandshakeMessage()
+    @Test("extendedClientInfo message")
+    func testExtendedClientInfo() {
+        let msg = MessageBuilder.extendedClientInfoMessage()
         let (code, off) = parsePeerMessage(msg)
-        #expect(code == SeeleSeekPeerCode.handshake.rawValue)
-        #expect(msg.readUInt8(at: off) == 1) // version
+        #expect(code == SeeleSeekExtendedClientInfoCode.extendedClientInfo.rawValue)
+        #expect(msg.readUInt32(at: off) == MessageBuilder.extendedClientInfoRevision)
     }
 
     @Test("artworkRequest message")
     func testArtworkRequest() {
         let msg = MessageBuilder.artworkRequestMessage(token: 88888, filePath: "Music\\artist\\song.mp3")
         let (code, off) = parsePeerMessage(msg)
-        #expect(code == SeeleSeekPeerCode.artworkRequest.rawValue)
+        #expect(code == SeeleSeekExtendedClientInfoCode.artworkRequest.rawValue)
         var o = off
         #expect(msg.readUInt32(at: o) == 88888); o += 4
         let (path, _) = msg.readString(at: o)!
@@ -301,7 +301,7 @@ struct PeerMessageRoundTripTests {
         let imageData = Data(repeating: 0xAB, count: 256)
         let msg = MessageBuilder.artworkReplyMessage(token: 99999, imageData: imageData)
         let (code, off) = parsePeerMessage(msg)
-        #expect(code == SeeleSeekPeerCode.artworkReply.rawValue)
+        #expect(code == SeeleSeekExtendedClientInfoCode.artworkReply.rawValue)
         var o = off
         #expect(msg.readUInt32(at: o) == 99999); o += 4
         // Remaining bytes are image data

--- a/seeleseekTests/SeeleSeekExtensionTests.swift
+++ b/seeleseekTests/SeeleSeekExtensionTests.swift
@@ -259,19 +259,11 @@ struct ExtendedClientInfoParsingTests {
         #expect(MessageParser.parseExtendedClientInfo(Data()) == nil)
     }
 
-    /// SeeleSeek 1.x sent a bare version byte at code 10000. It cannot parse
-    /// as the current format, which is what the legacy fallback keys on.
-    @Test("Legacy one-byte handshake does not parse as the new format")
-    func legacyPayloadDoesNotParse() {
+    /// SeeleSeek 1.x sent a bare version byte at code 10000. Rejecting it is
+    /// intentional — those peers advertised nothing, so they get nothing.
+    @Test("Legacy one-byte handshake is rejected, not special-cased")
+    func legacyPayloadRejected() {
         #expect(MessageParser.parseExtendedClientInfo(Data([1])) == nil)
-    }
-
-    @Test("Legacy fallback grants the 1.x capability set")
-    func legacyFallbackCapabilities() {
-        let info = ExtendedClientInfo.legacySeeleSeek(version: 1)
-        for code in SeeleSeekExtendedClientInfoCode.allCases {
-            #expect(info.supports(code))
-        }
     }
 }
 

--- a/seeleseekTests/SeeleSeekExtensionTests.swift
+++ b/seeleseekTests/SeeleSeekExtensionTests.swift
@@ -18,14 +18,14 @@ struct SeeleSeekMessageBuilderTests {
         #expect(Int(length!) + 4 == message.count)
 
         let code = message.readUInt32(at: 4)
-        #expect(code == SeeleSeekExtendedClientInfoCode.extendedClientInfo.rawValue)
+        #expect(code == ExtendedClientInfoCode.extendedClientInfo.rawValue)
         #expect(code == 10000)
 
         // Payload begins after the length prefix and the message code.
         let info = MessageParser.parseExtendedClientInfo(Data(message[8...]))
         #expect(info?.revision == ExtendedClientInfo.currentRevision)
         #expect(info?.clientInfo == "")
-        for advertised in SeeleSeekExtendedClientInfoCode.advertised {
+        for advertised in ExtendedClientInfoCode.advertised {
             #expect(info?.supports(advertised) == true)
         }
     }
@@ -58,7 +58,7 @@ struct SeeleSeekMessageBuilderTests {
         #expect(Int(msgLength!) + 4 == message.count)
 
         let code = message.readUInt32(at: 4)
-        #expect(code == SeeleSeekExtendedClientInfoCode.artworkRequest.rawValue)
+        #expect(code == ExtendedClientInfoCode.artworkRequest.rawValue)
         #expect(code == 10001)
 
         let parsedToken = message.readUInt32(at: 8)
@@ -80,7 +80,7 @@ struct SeeleSeekMessageBuilderTests {
         #expect(Int(msgLength!) + 4 == message.count)
 
         let code = message.readUInt32(at: 4)
-        #expect(code == SeeleSeekExtendedClientInfoCode.artworkReply.rawValue)
+        #expect(code == ExtendedClientInfoCode.artworkReply.rawValue)
         #expect(code == 10002)
 
         let parsedToken = message.readUInt32(at: 8)
@@ -100,7 +100,7 @@ struct SeeleSeekMessageBuilderTests {
         #expect(message.count == 4 + 4 + 4) // length + code + token
 
         let code = message.readUInt32(at: 4)
-        #expect(code == SeeleSeekExtendedClientInfoCode.artworkReply.rawValue)
+        #expect(code == ExtendedClientInfoCode.artworkReply.rawValue)
 
         let parsedToken = message.readUInt32(at: 8)
         #expect(parsedToken == token)
@@ -127,20 +127,20 @@ struct SeeleSeekMessageBuilderTests {
 
 // MARK: - Extension Code Enum Tests
 
-@Suite("SeeleSeekExtendedClientInfoCode Enum")
+@Suite("ExtendedClientInfoCode Enum")
 struct SeeleSeekExtendedClientInfoCodeTests {
 
     @Test("Code values are in 10000+ range")
     func codeValues() {
-        #expect(SeeleSeekExtendedClientInfoCode.extendedClientInfo.rawValue == 10000)
-        #expect(SeeleSeekExtendedClientInfoCode.artworkRequest.rawValue == 10001)
-        #expect(SeeleSeekExtendedClientInfoCode.artworkReply.rawValue == 10002)
+        #expect(ExtendedClientInfoCode.extendedClientInfo.rawValue == 10000)
+        #expect(ExtendedClientInfoCode.artworkRequest.rawValue == 10001)
+        #expect(ExtendedClientInfoCode.artworkReply.rawValue == 10002)
     }
 
     @Test("Codes don't overlap with standard peer codes")
     func noOverlapWithStandardCodes() {
         let standardCodes: [UInt32] = [0, 1, 4, 5, 8, 9, 15, 16, 36, 37, 40, 41, 42, 43, 44, 46, 50, 51, 52]
-        for code in SeeleSeekExtendedClientInfoCode.allCases {
+        for code in ExtendedClientInfoCode.allCases {
             #expect(!standardCodes.contains(code.rawValue),
                     "Extension code \(code.rawValue) overlaps with standard peer code")
         }
@@ -150,23 +150,23 @@ struct SeeleSeekExtendedClientInfoCodeTests {
     /// protocol contract and must not be renamed casually.
     @Test("Wire names match the published spec")
     func wireNames() {
-        #expect(SeeleSeekExtendedClientInfoCode.extendedClientInfo.wireName == "ExtendedClientInfo")
-        #expect(SeeleSeekExtendedClientInfoCode.artworkRequest.wireName == "ArtworkRequest")
-        #expect(SeeleSeekExtendedClientInfoCode.artworkReply.wireName == "ArtworkReply")
+        #expect(ExtendedClientInfoCode.extendedClientInfo.wireName == "ExtendedClientInfo")
+        #expect(ExtendedClientInfoCode.artworkRequest.wireName == "ArtworkRequest")
+        #expect(ExtendedClientInfoCode.artworkReply.wireName == "ArtworkReply")
     }
 
     @Test("Init from raw value round-trips")
     func rawValueRoundTrip() {
-        for code in SeeleSeekExtendedClientInfoCode.allCases {
-            #expect(SeeleSeekExtendedClientInfoCode(rawValue: code.rawValue) == code)
+        for code in ExtendedClientInfoCode.allCases {
+            #expect(ExtendedClientInfoCode(rawValue: code.rawValue) == code)
         }
     }
 
     @Test("Init from unknown raw value returns nil")
     func unknownRawValue() {
-        #expect(SeeleSeekExtendedClientInfoCode(rawValue: 9999) == nil)
-        #expect(SeeleSeekExtendedClientInfoCode(rawValue: 10003) == nil)
-        #expect(SeeleSeekExtendedClientInfoCode(rawValue: 0) == nil)
+        #expect(ExtendedClientInfoCode(rawValue: 9999) == nil)
+        #expect(ExtendedClientInfoCode(rawValue: 10003) == nil)
+        #expect(ExtendedClientInfoCode(rawValue: 0) == nil)
     }
 }
 

--- a/seeleseekTests/SeeleSeekExtensionTests.swift
+++ b/seeleseekTests/SeeleSeekExtensionTests.swift
@@ -23,9 +23,9 @@ struct SeeleSeekMessageBuilderTests {
 
         // Payload begins after the length prefix and the message code.
         let info = MessageParser.parseExtendedClientInfo(Data(message[8...]))
-        #expect(info?.revision == MessageBuilder.extendedClientInfoRevision)
+        #expect(info?.revision == ExtendedClientInfo.currentRevision)
         #expect(info?.clientInfo == "")
-        for advertised in SeeleSeekExtendedClientInfoCode.allCases {
+        for advertised in SeeleSeekExtendedClientInfoCode.advertised {
             #expect(info?.supports(advertised) == true)
         }
     }
@@ -271,19 +271,6 @@ struct ExtendedClientInfoParsingTests {
 
 @Suite("SeeleSeek Message Round-Trip")
 struct SeeleSeekRoundTripTests {
-
-    @Test("ExtendedClientInfo payload round-trip")
-    func extendedClientInfoRoundTrip() {
-        let message = MessageBuilder.extendedClientInfoMessage(clientInfo: "SeeleSeek/test")
-
-        // Skip length prefix (4 bytes) and code (4 bytes) to get payload
-        let payload = Data(message[8...])
-        let info = MessageParser.parseExtendedClientInfo(payload)
-
-        #expect(info?.clientInfo == "SeeleSeek/test")
-        #expect(info?.capabilities.count == SeeleSeekExtendedClientInfoCode.allCases.count)
-        #expect(info?.capabilities["ArtworkRequest"] == 10001)
-    }
 
     @Test("Artwork request payload round-trip")
     func artworkRequestRoundTrip() {

--- a/seeleseekTests/SeeleSeekExtensionTests.swift
+++ b/seeleseekTests/SeeleSeekExtensionTests.swift
@@ -9,22 +9,41 @@ import AppKit
 @Suite("SeeleSeek Extension Message Builder")
 struct SeeleSeekMessageBuilderTests {
 
-    @Test("Handshake message has correct code and version")
-    func handshakeMessageFormat() {
-        let message = MessageBuilder.seeleseekHandshakeMessage()
-
-        // Format: [length uint32][code uint32][version uint8]
-        #expect(message.count == 4 + 4 + 1) // length(4) + code(4) + version(1)
+    @Test("ExtendedClientInfo message has correct code and parses back")
+    func extendedClientInfoMessageFormat() {
+        let message = MessageBuilder.extendedClientInfoMessage()
 
         let length = message.readUInt32(at: 0)
-        #expect(length == 5) // code(4) + version(1)
+        #expect(length != nil)
+        #expect(Int(length!) + 4 == message.count)
 
         let code = message.readUInt32(at: 4)
-        #expect(code == SeeleSeekPeerCode.handshake.rawValue)
+        #expect(code == SeeleSeekExtendedClientInfoCode.extendedClientInfo.rawValue)
         #expect(code == 10000)
 
-        let version = message.readByte(at: 8)
-        #expect(version == 1)
+        // Payload begins after the length prefix and the message code.
+        let info = MessageParser.parseExtendedClientInfo(Data(message[8...]))
+        #expect(info?.revision == MessageBuilder.extendedClientInfoRevision)
+        #expect(info?.clientInfo == "")
+        for advertised in SeeleSeekExtendedClientInfoCode.allCases {
+            #expect(info?.supports(advertised) == true)
+        }
+    }
+
+    @Test("Client info string is sent verbatim when provided")
+    func extendedClientInfoCarriesClientString() {
+        let message = MessageBuilder.extendedClientInfoMessage(clientInfo: "SeeleSeek/1.2")
+        let info = MessageParser.parseExtendedClientInfo(Data(message[8...]))
+        #expect(info?.clientInfo == "SeeleSeek/1.2")
+    }
+
+    @Test("Advertising a subset omits the rest")
+    func extendedClientInfoSubset() {
+        let message = MessageBuilder.extendedClientInfoMessage(advertising: [.extendedClientInfo])
+        let info = MessageParser.parseExtendedClientInfo(Data(message[8...]))
+        #expect(info?.supports(.extendedClientInfo) == true)
+        #expect(info?.supports(.artworkRequest) == false)
+        #expect(info?.supports(.artworkReply) == false)
     }
 
     @Test("Artwork request message has correct structure")
@@ -39,7 +58,7 @@ struct SeeleSeekMessageBuilderTests {
         #expect(Int(msgLength!) + 4 == message.count)
 
         let code = message.readUInt32(at: 4)
-        #expect(code == SeeleSeekPeerCode.artworkRequest.rawValue)
+        #expect(code == SeeleSeekExtendedClientInfoCode.artworkRequest.rawValue)
         #expect(code == 10001)
 
         let parsedToken = message.readUInt32(at: 8)
@@ -61,7 +80,7 @@ struct SeeleSeekMessageBuilderTests {
         #expect(Int(msgLength!) + 4 == message.count)
 
         let code = message.readUInt32(at: 4)
-        #expect(code == SeeleSeekPeerCode.artworkReply.rawValue)
+        #expect(code == SeeleSeekExtendedClientInfoCode.artworkReply.rawValue)
         #expect(code == 10002)
 
         let parsedToken = message.readUInt32(at: 8)
@@ -81,7 +100,7 @@ struct SeeleSeekMessageBuilderTests {
         #expect(message.count == 4 + 4 + 4) // length + code + token
 
         let code = message.readUInt32(at: 4)
-        #expect(code == SeeleSeekPeerCode.artworkReply.rawValue)
+        #expect(code == SeeleSeekExtendedClientInfoCode.artworkReply.rawValue)
 
         let parsedToken = message.readUInt32(at: 8)
         #expect(parsedToken == token)
@@ -106,47 +125,153 @@ struct SeeleSeekMessageBuilderTests {
     }
 }
 
-// MARK: - SeeleSeekPeerCode Enum Tests
+// MARK: - Extension Code Enum Tests
 
-@Suite("SeeleSeekPeerCode Enum")
-struct SeeleSeekPeerCodeTests {
+@Suite("SeeleSeekExtendedClientInfoCode Enum")
+struct SeeleSeekExtendedClientInfoCodeTests {
 
     @Test("Code values are in 10000+ range")
     func codeValues() {
-        #expect(SeeleSeekPeerCode.handshake.rawValue == 10000)
-        #expect(SeeleSeekPeerCode.artworkRequest.rawValue == 10001)
-        #expect(SeeleSeekPeerCode.artworkReply.rawValue == 10002)
+        #expect(SeeleSeekExtendedClientInfoCode.extendedClientInfo.rawValue == 10000)
+        #expect(SeeleSeekExtendedClientInfoCode.artworkRequest.rawValue == 10001)
+        #expect(SeeleSeekExtendedClientInfoCode.artworkReply.rawValue == 10002)
     }
 
     @Test("Codes don't overlap with standard peer codes")
     func noOverlapWithStandardCodes() {
         let standardCodes: [UInt32] = [0, 1, 4, 5, 8, 9, 15, 16, 36, 37, 40, 41, 42, 43, 44, 46, 50, 51, 52]
-        for code in SeeleSeekPeerCode.allCases {
+        for code in SeeleSeekExtendedClientInfoCode.allCases {
             #expect(!standardCodes.contains(code.rawValue),
-                    "SeeleSeek code \(code.rawValue) overlaps with standard peer code")
+                    "Extension code \(code.rawValue) overlaps with standard peer code")
         }
     }
 
-    @Test("Code descriptions are meaningful")
-    func codeDescriptions() {
-        #expect(SeeleSeekPeerCode.handshake.description == "SeeleSeekHandshake")
-        #expect(SeeleSeekPeerCode.artworkRequest.description == "ArtworkRequest")
-        #expect(SeeleSeekPeerCode.artworkReply.description == "ArtworkReply")
+    /// Wire names are the identity peers match on, so they are part of the
+    /// protocol contract and must not be renamed casually.
+    @Test("Wire names match the published spec")
+    func wireNames() {
+        #expect(SeeleSeekExtendedClientInfoCode.extendedClientInfo.wireName == "ExtendedClientInfo")
+        #expect(SeeleSeekExtendedClientInfoCode.artworkRequest.wireName == "ArtworkRequest")
+        #expect(SeeleSeekExtendedClientInfoCode.artworkReply.wireName == "ArtworkReply")
     }
 
     @Test("Init from raw value round-trips")
     func rawValueRoundTrip() {
-        for code in SeeleSeekPeerCode.allCases {
-            let fromRaw = SeeleSeekPeerCode(rawValue: code.rawValue)
-            #expect(fromRaw == code)
+        for code in SeeleSeekExtendedClientInfoCode.allCases {
+            #expect(SeeleSeekExtendedClientInfoCode(rawValue: code.rawValue) == code)
         }
     }
 
     @Test("Init from unknown raw value returns nil")
     func unknownRawValue() {
-        #expect(SeeleSeekPeerCode(rawValue: 9999) == nil)
-        #expect(SeeleSeekPeerCode(rawValue: 10003) == nil)
-        #expect(SeeleSeekPeerCode(rawValue: 0) == nil)
+        #expect(SeeleSeekExtendedClientInfoCode(rawValue: 9999) == nil)
+        #expect(SeeleSeekExtendedClientInfoCode(rawValue: 10003) == nil)
+        #expect(SeeleSeekExtendedClientInfoCode(rawValue: 0) == nil)
+    }
+}
+
+// MARK: - ExtendedClientInfo Parsing
+
+/// The parser is the only thing standing between a hostile peer and our
+/// message loop, so the malformed cases matter more than the happy path.
+@Suite("ExtendedClientInfo parsing")
+struct ExtendedClientInfoParsingTests {
+
+    private func advertisement(
+        revision: UInt32 = 1,
+        clientInfo: String = "",
+        declaredCount: UInt32? = nil,
+        entries: [(UInt32, String)]
+    ) -> Data {
+        var d = Data()
+        d.appendUInt32(revision)
+        d.appendString(clientInfo)
+        d.appendUInt32(declaredCount ?? UInt32(entries.count))
+        for (code, name) in entries {
+            d.appendUInt32(code)
+            d.appendString(name)
+            d.appendUInt32(0)
+        }
+        return d
+    }
+
+    @Test("Unknown revision is rejected rather than guessed at")
+    func unknownRevisionRejected() {
+        let d = advertisement(revision: 2, entries: [(10001, "ArtworkRequest")])
+        #expect(MessageParser.parseExtendedClientInfo(d) == nil)
+    }
+
+    @Test("Truncated entry is rejected")
+    func truncatedRejected() {
+        let full = advertisement(entries: [(10001, "ArtworkRequest")])
+        let chopped = Data(full.prefix(full.count - 3))
+        #expect(MessageParser.parseExtendedClientInfo(chopped) == nil)
+    }
+
+    @Test("Count larger than the body is rejected")
+    func lyingCountRejected() {
+        let d = advertisement(declaredCount: 5, entries: [(10001, "ArtworkRequest")])
+        #expect(MessageParser.parseExtendedClientInfo(d) == nil)
+    }
+
+    @Test("Count over the cap is rejected before iterating")
+    func oversizedCountRejected() {
+        let d = advertisement(declaredCount: .max, entries: [])
+        #expect(MessageParser.parseExtendedClientInfo(d) == nil)
+    }
+
+    @Test("Empty advertisement parses but supports nothing")
+    func emptyAdvertisement() {
+        let info = MessageParser.parseExtendedClientInfo(advertisement(entries: []))
+        #expect(info != nil)
+        #expect(info?.supports(.artworkRequest) == false)
+    }
+
+    /// The spec says a mismatched code means we must not send that message,
+    /// even when the name is one we know.
+    @Test("Known name bound to a different code is not supported")
+    func mismatchedCodeNotSupported() {
+        let info = MessageParser.parseExtendedClientInfo(
+            advertisement(entries: [(10005, "ArtworkRequest")])
+        )
+        #expect(info != nil)
+        #expect(info?.supports(.artworkRequest) == false)
+    }
+
+    @Test("Unknown capability names are retained, not dropped")
+    func unknownNamesRetained() {
+        let info = MessageParser.parseExtendedClientInfo(
+            advertisement(entries: [(10042, "SomeOtherFeature")])
+        )
+        #expect(info?.capabilities["SomeOtherFeature"] == 10042)
+    }
+
+    @Test("Client info string round-trips")
+    func clientInfoRoundTrip() {
+        let info = MessageParser.parseExtendedClientInfo(
+            advertisement(clientInfo: "OtherClient/2.1", entries: [])
+        )
+        #expect(info?.clientInfo == "OtherClient/2.1")
+    }
+
+    @Test("Empty payload is rejected")
+    func emptyPayloadRejected() {
+        #expect(MessageParser.parseExtendedClientInfo(Data()) == nil)
+    }
+
+    /// SeeleSeek 1.x sent a bare version byte at code 10000. It cannot parse
+    /// as the current format, which is what the legacy fallback keys on.
+    @Test("Legacy one-byte handshake does not parse as the new format")
+    func legacyPayloadDoesNotParse() {
+        #expect(MessageParser.parseExtendedClientInfo(Data([1])) == nil)
+    }
+
+    @Test("Legacy fallback grants the 1.x capability set")
+    func legacyFallbackCapabilities() {
+        let info = ExtendedClientInfo.legacySeeleSeek(version: 1)
+        for code in SeeleSeekExtendedClientInfoCode.allCases {
+            #expect(info.supports(code))
+        }
     }
 }
 
@@ -155,16 +280,17 @@ struct SeeleSeekPeerCodeTests {
 @Suite("SeeleSeek Message Round-Trip")
 struct SeeleSeekRoundTripTests {
 
-    @Test("Handshake message payload round-trip")
-    func handshakeRoundTrip() {
-        let message = MessageBuilder.seeleseekHandshakeMessage()
+    @Test("ExtendedClientInfo payload round-trip")
+    func extendedClientInfoRoundTrip() {
+        let message = MessageBuilder.extendedClientInfoMessage(clientInfo: "SeeleSeek/test")
 
         // Skip length prefix (4 bytes) and code (4 bytes) to get payload
         let payload = Data(message[8...])
+        let info = MessageParser.parseExtendedClientInfo(payload)
 
-        // Parse: version byte
-        #expect(payload.count == 1)
-        #expect(payload[payload.startIndex] == 1)
+        #expect(info?.clientInfo == "SeeleSeek/test")
+        #expect(info?.capabilities.count == SeeleSeekExtendedClientInfoCode.allCases.count)
+        #expect(info?.capabilities["ArtworkRequest"] == 10001)
     }
 
     @Test("Artwork request payload round-trip")

--- a/seeleseekTests/SeeleSeekExtensionTests.swift
+++ b/seeleseekTests/SeeleSeekExtensionTests.swift
@@ -24,7 +24,10 @@ struct SeeleSeekMessageBuilderTests {
         // Payload begins after the length prefix and the message code.
         let info = MessageParser.parseExtendedClientInfo(Data(message[8...]))
         #expect(info?.revision == ExtendedClientInfo.currentRevision)
-        #expect(info?.clientInfo == "")
+        // Sent by default, so the field is not dead on the wire. The exact
+        // string tracks the host bundle version, hence the prefix check.
+        #expect(info?.clientInfo == ExtendedClientInfo.localClientInfo)
+        #expect(info?.clientInfo.hasPrefix("SeeleSeek/") == true)
         for advertised in ExtendedClientInfoCode.advertised {
             #expect(info?.supports(advertised) == true)
         }


### PR DESCRIPTION
### Description

This PR refactors and modernizes how peer extension capabilities are advertised, tracked, and enforced in the SeeleSeek protocol implementation. It replaces the old version-based handshake with a more robust, extensible `ExtendedClientInfo` advertisement, ensuring that extension messages are only sent to peers that have explicitly advertised support. The changes also update event handling and internal state to reflect this new model.

Key changes include:

**Protocol extension handshake and capability enforcement:**

* Introduced the `ExtendedClientInfo` struct to represent a peer's advertised protocol extensions, replacing the old version byte handshake. This enables richer and more accurate extension negotiation.
* Replaced the previous `sendSeeleSeekHandshake` and version tracking with `sendExtendedClientInfo`, and updated all handshake and extension message flows to use the new capability advertisement. [[1]](diffhunk://#diff-d706c86a469135e21918307a668b2a2cf738f80364802caea506c4ed865fbf8dL446-R473) [[2]](diffhunk://#diff-d706c86a469135e21918307a668b2a2cf738f80364802caea506c4ed865fbf8dL1514-R1533) [[3]](diffhunk://#diff-af1a120c8853931a0f416baef1b56dc753f4b91e163a75740f3065a4ae9f707fL525-R525)
* Added per-socket capability enforcement: extension messages can now only be sent if the peer has advertised support for the relevant code, with a new error case for violations. [[1]](diffhunk://#diff-d706c86a469135e21918307a668b2a2cf738f80364802caea506c4ed865fbf8dL93-R100) [[2]](diffhunk://#diff-d706c86a469135e21918307a668b2a2cf738f80364802caea506c4ed865fbf8dR2064) [[3]](diffhunk://#diff-d706c86a469135e21918307a668b2a2cf738f80364802caea506c4ed865fbf8dR2075) [[4]](diffhunk://#diff-f3aa9a82ee1ce3b938a3e39e5b875ff339f1ffad68029fbf374f19ebeaa6c60cL2668-R2679) [[5]](diffhunk://#diff-f3aa9a82ee1ce3b938a3e39e5b875ff339f1ffad68029fbf374f19ebeaa6c60cL2681-R2691) [[6]](diffhunk://#diff-f3aa9a82ee1ce3b938a3e39e5b875ff339f1ffad68029fbf374f19ebeaa6c60cL2694-R2704) [[7]](diffhunk://#diff-f3aa9a82ee1ce3b938a3e39e5b875ff339f1ffad68029fbf374f19ebeaa6c60cL2706-R2716) [[8]](diffhunk://#diff-f3aa9a82ee1ce3b938a3e39e5b875ff339f1ffad68029fbf374f19ebeaa6c60cR2769-R2775)

**Event handling and state tracking:**

* Updated the `PeerConnectionEvent` enum and event handling to emit and store full `ExtendedClientInfo` objects instead of version numbers, and updated all relevant state and UI tracking to reflect this. [[1]](diffhunk://#diff-95dc70b443c7af0fca739dd27235fbf89829287f00da37a4278e27c8aa861c5aL25-R25) [[2]](diffhunk://#diff-b56ebc520dbee8cd683f123b7709cbfa882317690d4676417789071581ab8955L36-R52) [[3]](diffhunk://#diff-b56ebc520dbee8cd683f123b7709cbfa882317690d4676417789071581ab8955L158-R169) [[4]](diffhunk://#diff-b56ebc520dbee8cd683f123b7709cbfa882317690d4676417789071581ab8955L1103-R1111)
* Removed legacy version tracking fields and logic, consolidating extension capability state into the new `extendedClientInfo` structures. [[1]](diffhunk://#diff-b56ebc520dbee8cd683f123b7709cbfa882317690d4676417789071581ab8955L158-R169) [[2]](diffhunk://#diff-b56ebc520dbee8cd683f123b7709cbfa882317690d4676417789071581ab8955L1103-R1111)

**Message parsing and dispatch:**

* Updated message dispatch and parsing logic to handle the new `ExtendedClientInfo` advertisement and related extension codes, replacing the old version byte handler. [[1]](diffhunk://#diff-d706c86a469135e21918307a668b2a2cf738f80364802caea506c4ed865fbf8dL1582-R1607) [[2]](diffhunk://#diff-d706c86a469135e21918307a668b2a2cf738f80364802caea506c4ed865fbf8dL1613-R1647)

These changes make the protocol more robust, extensible, and standards-compliant, and lay the groundwork for future extension features.

This PR addresses and implements the RFC outlined in #74 

<!--
### Future work
A place to describe changes that can or will be done in follow-up PRs
-->

### How to test

- Ensure all checks pass

### Author checklist

This PR:

- [x] Satisfies a goal that is specific & clearly motivated
- [x] Adds value in isolation (whether user-facing or sustainability-related)
- [x] Contains a concise & easy-to-understand title + description
- [x] Adheres to [SRP](https://en.wikipedia.org/wiki/Single-responsibility_principle) by default
- [x] Presents the best possible implementation to meet its goal, given constraints at hand
