### PR TITLE
fix+improve download locations

### DIFF
--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Protocols.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Protocols.swift
@@ -86,6 +86,7 @@ public protocol StatisticsRecording: AnyObject, Sendable {
 /// Protocol for download-related settings. Implemented by the app's SettingsState.
 @MainActor
 public protocol DownloadSettingsProviding: AnyObject, Sendable {
+    var downloadDirectory: URL { get }
     var activeDownloadTemplate: String { get }
     var incompleteDownloadDirectory: URL { get }
     var setFolderIcons: Bool { get }

--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Storage/DownloadManager.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Storage/DownloadManager.swift
@@ -61,18 +61,16 @@ public final class DownloadManager {
     private var metadataReader: (any MetadataReading)?
     /// Directories that already have folder icons applied (avoid redundant work)
     private var iconAppliedDirs: Set<URL> = []
-    /// Destination directory settled on for a remote folder, keyed by
-    /// `sourceFolderKey`. Tag-derived templates ({artist}/{album}) resolve to
-    /// different directories for tagged and untagged files from the *same*
-    /// folder, which used to scatter cover art and untagged tracks away from
-    /// their album. The first file with usable tags claims the directory and
-    /// every sibling — earlier or later — follows it.
+    /// Directory each remote folder settled on, keyed by `sourceFolderKey`.
+    /// Tag-derived templates resolve differently for tagged and untagged files
+    /// of one folder, so the first file with usable tags claims the directory
+    /// and every sibling — earlier or later — follows it.
     private var folderDestinations: [String: URL] = [:]
-    /// Completed files parked at their folder-name-derived path because they
-    /// had no usable tags, awaiting a sibling that claims the real directory.
+    /// Completed files parked at their folder-derived path, waiting for a
+    /// sibling with usable tags to claim the real directory.
     private var pendingFolderJoins: [String: [PlacedFile]] = [:]
-    /// Last download root passed to `createDirectory`, so the syscall runs on
-    /// a settings change rather than on every path computation.
+    /// Last root passed to `createDirectory`, so the syscall runs on a
+    /// settings change rather than on every path computation.
     private var createdDownloadDir: URL?
 
     struct PlacedFile {
@@ -1382,16 +1380,13 @@ public final class DownloadManager {
 
     // MARK: - Helpers
 
-    /// Where downloads land when no settings provider is attached (tests,
-    /// early startup). The user-facing default in `SettingsState` matches.
+    /// Fallback when no settings provider is attached (tests, early startup).
     public nonisolated static let defaultDownloadDirectory: URL =
         FileManager.default.urls(for: .downloadsDirectory, in: .userDomainMask)[0]
             .appendingPathComponent("SeeleSeek")
 
     private func getDownloadDirectory() -> URL {
         let downloadsDir = settings?.downloadDirectory ?? Self.defaultDownloadDirectory
-        // Called for every path computation; only pay the syscall when the
-        // configured location actually changes.
         if createdDownloadDir == downloadsDir { return downloadsDir }
 
         do {
@@ -1417,14 +1412,11 @@ public final class DownloadManager {
             ?? getDownloadDirectory().appendingPathComponent("Incomplete", isDirectory: true)
     }
 
-    /// Where a completed file belongs: the configured download root plus the
-    /// active template, unless a sibling from the same shared folder already
-    /// settled on a directory.
     private func computeDestPath(for soulseekPath: String, username: String) -> URL {
         let template = activeTemplate
 
-        // A claim only applies while the template that produced it is still
-        // in effect — switching to a path-based one must not keep grouping.
+        // A claim only applies while the template that produced it is in
+        // effect: switching to a path-based one must not keep grouping.
         if Self.isTagBased(template),
            let claimed = folderDestinations[Self.sourceFolderKey(soulseekPath: soulseekPath, username: username)] {
             return claimed.appendingPathComponent(Self.sanitizedLeafName(of: soulseekPath))
@@ -1445,17 +1437,15 @@ public final class DownloadManager {
 
     public static let fallbackTemplate = "{folder}/{filename}"
 
-    /// Tokens whose value comes from the file's tags rather than its path.
-    /// Templates using them are the only ones whose destination varies between
-    /// files of the same folder, so they are the only ones that need grouping.
+    /// Tokens read from tags rather than the path — templates using them are
+    /// the only ones whose destination varies between files of one folder.
     nonisolated static let tagTokens = ["{artist}", "{album}"]
 
     nonisolated static func isTagBased(_ template: String) -> Bool {
         tagTokens.contains { template.contains($0) }
     }
 
-    /// Identity of the remote folder a file came from — everything from one
-    /// `user\...\Album` folder shares a destination directory.
+    /// Everything from one `user\...\Album` folder shares a destination.
     nonisolated static func sourceFolderKey(soulseekPath: String, username: String) -> String {
         let folder = soulseekPath[..<(soulseekPath.lastIndex(of: "\\") ?? soulseekPath.startIndex)]
         return "\(username)\u{0}\(folder)"
@@ -1562,8 +1552,7 @@ public final class DownloadManager {
         return parent.appendingPathComponent(fallbackName)
     }
 
-    /// Shared with the app layer so "reveal in Finder" fallbacks and the
-    /// settings preview can't drift from what the manager actually writes.
+    /// Shared with the app layer so nothing re-implements this and drifts.
     public nonisolated static func destinationURL(
         downloadDirectory: URL,
         soulseekPath: String,
@@ -1644,9 +1633,8 @@ public final class DownloadManager {
         return result
     }
 
-    /// Single pass over the template, so token order carries no meaning and a
-    /// substituted value that happens to look like a token (an album named
-    /// "{artist}") is never re-substituted.
+    /// Single pass: token order carries no meaning, and a substituted value
+    /// that looks like a token (an album named "{artist}") is left alone.
     private nonisolated static func substituteTokens(in template: String, values: [String: String]) -> String {
         var result = ""
         var rest = Substring(template)
@@ -1800,18 +1788,14 @@ public final class DownloadManager {
     }
 
     /// Under a tag-based template the file has not reached its final directory
-    /// yet — `organizeCompletedDownload` may move it, and applies the icon
-    /// there. Skipping here avoids decoding album art onto a directory that is
-    /// about to be emptied and pruned.
+    /// yet; `organizeCompletedDownload` applies the icon after it moves.
     private func applyFolderArtworkAfterCompletion(for filePath: URL) {
         guard !Self.isTagBased(activeTemplate) else { return }
         applyFolderArtworkIfNeeded(for: filePath)
     }
 
     /// Settle a completed download into the directory its shared folder is
-    /// using. Only tag-based templates need this: their destination depends on
-    /// tags the path can't supply, so files from one folder would otherwise
-    /// scatter. Fire-and-forget.
+    /// using. Fire-and-forget.
     func organizeCompletedDownload(
         currentPath: URL,
         soulseekFilename: String,
@@ -1824,15 +1808,13 @@ public final class DownloadManager {
         let key = Self.sourceFolderKey(soulseekPath: soulseekFilename, username: username)
         let file = PlacedFile(transferId: transferId, path: currentPath)
 
-        // A sibling already claimed this folder's directory, so skip the tag
-        // read entirely — it is an AVAsset open per file.
+        // Claimed already — skip the tag read, it is an AVAsset open per file.
         if let claimed = folderDestinations[key] {
             relocate([file], toDirectory: claimed)
             return
         }
 
-        // Cover art, cue sheets and logs can never fill a tag token, so they
-        // go straight to the park queue rather than through AVFoundation.
+        // Non-audio can never fill a tag token.
         guard let metadataReader,
               FileTypes.isAudio(currentPath.pathExtension.lowercased()) else {
             placeInFolder(key: key, candidate: nil, file: file)
@@ -1843,10 +1825,9 @@ public final class DownloadManager {
         Task.detached { [weak self] in
             let metadata = await metadataReader.extractAudioMetadata(from: currentPath)
 
-            // Tags only settle the folder if they fill every tag token the
-            // template uses. A file tagged with a title but no album would
-            // otherwise "claim" the directory using folder-derived fallbacks
-            // and win over the tracks that are properly tagged.
+            // Partial tags must not claim: a file with a title but no album
+            // would resolve via folder-derived fallbacks and beat the tracks
+            // that are properly tagged.
             let tagValues: [String: String?] = ["{artist}": metadata?.artist, "{album}": metadata?.album]
             let satisfiesTemplate = tagValues.allSatisfy { token, value in
                 !template.contains(token) || !(value ?? "").isEmpty
@@ -1866,24 +1847,20 @@ public final class DownloadManager {
         }
     }
 
-    /// Decide where a just-completed file belongs relative to its siblings.
-    /// Runs without suspension so concurrent completions from one folder can't
-    /// both claim a destination.
+    /// Must not suspend: concurrent completions from one folder would
+    /// otherwise both claim a destination.
     private func placeInFolder(key: String, candidate: URL?, file: PlacedFile) {
-        // Bounded like `iconAppliedDirs`: forgetting a mapping only costs a
-        // folder downloaded much later re-deciding its destination. Folders
-        // that never produce a tagged file only ever grow `pendingFolderJoins`,
-        // so both maps count toward the cap.
+        // Both maps count toward the cap: a folder that never produces a
+        // tagged file only ever grows `pendingFolderJoins`. Forgetting a
+        // mapping just means a later folder re-decides its destination.
         if folderDestinations.count + pendingFolderJoins.count > 512 {
             folderDestinations.removeAll(keepingCapacity: true)
             pendingFolderJoins.removeAll(keepingCapacity: true)
         }
 
-        // An existing claim wins over this file's own tags, so one shared
-        // folder can never split across two destinations.
+        // An existing claim wins over this file's own tags.
         guard let destination = folderDestinations[key] ?? candidate else {
-            // No usable tags — leave it at the folder-derived path and wait for
-            // a tagged sibling to pull it across.
+            // Wait for a tagged sibling to pull it across.
             pendingFolderJoins[key, default: []].append(file)
             return
         }
@@ -1893,8 +1870,6 @@ public final class DownloadManager {
         relocate([file] + strays, toDirectory: destination)
     }
 
-    /// Move completed files into `directory`, keeping their filenames, and
-    /// point their transfers at the new locations.
     private func relocate(_ files: [PlacedFile], toDirectory directory: URL) {
         let moves = files.filter { $0.path.deletingLastPathComponent() != directory }
         guard !moves.isEmpty else { return }
@@ -1944,9 +1919,8 @@ public final class DownloadManager {
     }
 
     private nonisolated static func pruneEmptyDirectories(from directory: URL, upTo root: URL) {
-        // Only ever delete inside the download root. Changing the download
-        // location mid-transfer can leave `directory` pointing into an
-        // unrelated tree, and a depth-only check would happily walk up it.
+        // Changing the download location mid-transfer can leave `directory`
+        // in an unrelated tree, which a depth-only check would walk up.
         let rootComponents = root.standardizedFileURL.pathComponents
         var dir = directory.standardizedFileURL
         guard dir.pathComponents.starts(with: rootComponents) else { return }
@@ -3278,8 +3252,7 @@ public final class DownloadManager {
         computeDestPath(for: soulseekPath, username: username)
     }
 
-    /// Also the tests' synchronization point: parking a file is the observable
-    /// end of the detached tag read.
+    /// Tests sequence on this: parking is the observable end of the tag read.
     internal var _pendingFolderJoinCount: Int {
         pendingFolderJoins.values.reduce(0) { $0 + $1.count }
     }

--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Storage/DownloadManager.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Storage/DownloadManager.swift
@@ -61,6 +61,24 @@ public final class DownloadManager {
     private var metadataReader: (any MetadataReading)?
     /// Directories that already have folder icons applied (avoid redundant work)
     private var iconAppliedDirs: Set<URL> = []
+    /// Destination directory settled on for a remote folder, keyed by
+    /// `sourceFolderKey`. Tag-derived templates ({artist}/{album}) resolve to
+    /// different directories for tagged and untagged files from the *same*
+    /// folder, which used to scatter cover art and untagged tracks away from
+    /// their album. The first file with usable tags claims the directory and
+    /// every sibling — earlier or later — follows it.
+    private var folderDestinations: [String: URL] = [:]
+    /// Completed files parked at their folder-name-derived path because they
+    /// had no usable tags, awaiting a sibling that claims the real directory.
+    private var pendingFolderJoins: [String: [PlacedFile]] = [:]
+    /// Last download root passed to `createDirectory`, so the syscall runs on
+    /// a settings change rather than on every path computation.
+    private var createdDownloadDir: URL?
+
+    struct PlacedFile {
+        let transferId: UUID
+        let path: URL
+    }
 
     // MARK: - Retry Configuration
     // Mixed ladder: a quick 10s first retry catches transient blips (TCP
@@ -1009,7 +1027,7 @@ public final class DownloadManager {
 
             logger.info("Download complete (outgoing F): \(filename) -> \(finalPath.path)")
             ActivityLogger.shared?.logDownloadCompleted(filename: filename)
-            applyFolderArtworkIfNeeded(for: finalPath)
+            applyFolderArtworkAfterCompletion(for: finalPath)
             organizeCompletedDownload(currentPath: finalPath, soulseekFilename: pending.filename, username: username, transferId: pending.transferId)
 
             // Record only bytes received THIS session against the session
@@ -1364,14 +1382,21 @@ public final class DownloadManager {
 
     // MARK: - Helpers
 
-    private func getDownloadDirectory() -> URL {
-        if let override = _downloadDirectoryOverride { return override }
-        let paths = FileManager.default.urls(for: .downloadsDirectory, in: .userDomainMask)
-        let downloadsDir = paths[0].appendingPathComponent("SeeleSeek")
+    /// Where downloads land when no settings provider is attached (tests,
+    /// early startup). The user-facing default in `SettingsState` matches.
+    public nonisolated static let defaultDownloadDirectory: URL =
+        FileManager.default.urls(for: .downloadsDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("SeeleSeek")
 
-        // Create directory if it doesn't exist
+    private func getDownloadDirectory() -> URL {
+        let downloadsDir = settings?.downloadDirectory ?? Self.defaultDownloadDirectory
+        // Called for every path computation; only pay the syscall when the
+        // configured location actually changes.
+        if createdDownloadDir == downloadsDir { return downloadsDir }
+
         do {
             try FileManager.default.createDirectory(at: downloadsDir, withIntermediateDirectories: true)
+            createdDownloadDir = downloadsDir
             logger.debug("Download directory: \(downloadsDir.path)")
         } catch {
             logger.error("Failed to create download directory: \(downloadsDir.path) - \(error)")
@@ -1388,37 +1413,61 @@ public final class DownloadManager {
     }
 
     private func getIncompleteDownloadDirectory() -> URL {
-        if let override = _downloadDirectoryOverride {
-            return override.appendingPathComponent("Incomplete", isDirectory: true)
-        }
-        return settings?.incompleteDownloadDirectory
+        settings?.incompleteDownloadDirectory
             ?? getDownloadDirectory().appendingPathComponent("Incomplete", isDirectory: true)
     }
 
-    /// Compute destination path preserving folder structure from SoulSeek path
-    /// e.g., "@@music\Artist\Album\01 Song.mp3" -> "Downloads/SeeleSeek/Artist/Album/01 Song.mp3"
+    /// Where a completed file belongs: the configured download root plus the
+    /// active template, unless a sibling from the same shared folder already
+    /// settled on a directory.
     private func computeDestPath(for soulseekPath: String, username: String) -> URL {
-        let downloadDir = getDownloadDirectory()
-        let template = settings?.activeDownloadTemplate ?? "{username}/{folders}/{filename}"
-        let relativePath = DownloadManager.resolveDownloadPath(
+        let template = activeTemplate
+
+        // A claim only applies while the template that produced it is still
+        // in effect — switching to a path-based one must not keep grouping.
+        if Self.isTagBased(template),
+           let claimed = folderDestinations[Self.sourceFolderKey(soulseekPath: soulseekPath, username: username)] {
+            return claimed.appendingPathComponent(Self.sanitizedLeafName(of: soulseekPath))
+        }
+
+        return Self.destinationURL(
+            downloadDirectory: getDownloadDirectory(),
             soulseekPath: soulseekPath,
             username: username,
             template: template
         )
+    }
 
-        // Split into components, sanitize each, and build the URL
-        let resultComponents = relativePath.split(separator: "/").map(String.init)
-        var destURL = downloadDir
-        for component in resultComponents {
-            destURL = destURL.appendingPathComponent(Self.sanitizeFilename(component))
-        }
+    private var activeTemplate: String {
+        let template = settings?.activeDownloadTemplate ?? Self.fallbackTemplate
+        return template.isEmpty ? Self.fallbackTemplate : template
+    }
 
-        return destURL
+    public static let fallbackTemplate = "{folder}/{filename}"
+
+    /// Tokens whose value comes from the file's tags rather than its path.
+    /// Templates using them are the only ones whose destination varies between
+    /// files of the same folder, so they are the only ones that need grouping.
+    nonisolated static let tagTokens = ["{artist}", "{album}"]
+
+    nonisolated static func isTagBased(_ template: String) -> Bool {
+        tagTokens.contains { template.contains($0) }
+    }
+
+    /// Identity of the remote folder a file came from — everything from one
+    /// `user\...\Album` folder shares a destination directory.
+    nonisolated static func sourceFolderKey(soulseekPath: String, username: String) -> String {
+        let folder = soulseekPath[..<(soulseekPath.lastIndex(of: "\\") ?? soulseekPath.startIndex)]
+        return "\(username)\u{0}\(folder)"
+    }
+
+    nonisolated static func sanitizedLeafName(of soulseekPath: String) -> String {
+        sanitizeFilename(soulseekPath.split(separator: "\\").last.map(String.init) ?? "download")
     }
 
     private func computeIncompletePath(for soulseekPath: String, username: String) -> URL {
         let incompleteDir = getIncompleteDownloadDirectory()
-        let displayName = Self.sanitizeFilename(soulseekPath.split(separator: "\\").last.map(String.init) ?? "download")
+        let displayName = Self.sanitizedLeafName(of: soulseekPath)
         let digest = SHA256.hash(data: Data("\(username)\u{0}\(soulseekPath)".utf8))
         let hash = digest.map { String(format: "%02x", $0) }.joined()
         // Constant prefix is 75 bytes ("INCOMPLETE" + 64-hex + "_"); macOS
@@ -1513,10 +1562,32 @@ public final class DownloadManager {
         return parent.appendingPathComponent(fallbackName)
     }
 
+    /// Shared with the app layer so "reveal in Finder" fallbacks and the
+    /// settings preview can't drift from what the manager actually writes.
+    public nonisolated static func destinationURL(
+        downloadDirectory: URL,
+        soulseekPath: String,
+        username: String,
+        template: String,
+        metadata: AudioFileMetadata? = nil
+    ) -> URL {
+        let relativePath = resolveDownloadPath(
+            soulseekPath: soulseekPath,
+            username: username,
+            template: template,
+            metadata: metadata
+        )
+        var destURL = downloadDirectory
+        for component in relativePath.split(separator: "/") {
+            destURL = destURL.appendingPathComponent(sanitizeFilename(String(component)))
+        }
+        return destURL
+    }
+
     /// Resolve a SoulSeek path into a relative download path using a template.
     /// Prefers metadata values (artist, album) over folder-derived values when available.
     /// Returns a relative path string (no leading/trailing slashes).
-    nonisolated static func resolveDownloadPath(
+    public nonisolated static func resolveDownloadPath(
         soulseekPath: String,
         username: String,
         template: String,
@@ -1551,13 +1622,17 @@ public final class DownloadManager {
         let artist = metadata?.artist ?? folderArtist
         let album = metadata?.album ?? folderAlbum
 
-        // Substitute tokens
-        var result = template
-            .replacingOccurrences(of: "{username}", with: username)
-            .replacingOccurrences(of: "{folders}", with: folders)
-            .replacingOccurrences(of: "{artist}", with: artist)
-            .replacingOccurrences(of: "{album}", with: album)
-            .replacingOccurrences(of: "{filename}", with: filename)
+        // `{folders}` is the legacy spelling of `{full-path}`, kept for
+        // templates users saved before the rename.
+        var result = substituteTokens(in: template, values: [
+            "username": username,
+            "full-path": folders,
+            "folders": folders,
+            "folder": folderAlbum,
+            "artist": artist,
+            "album": album,
+            "filename": filename,
+        ])
 
         // Clean up double slashes from empty tokens (e.g. empty folders)
         while result.contains("//") {
@@ -1567,6 +1642,26 @@ public final class DownloadManager {
         result = result.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
 
         return result
+    }
+
+    /// Single pass over the template, so token order carries no meaning and a
+    /// substituted value that happens to look like a token (an album named
+    /// "{artist}") is never re-substituted.
+    private nonisolated static func substituteTokens(in template: String, values: [String: String]) -> String {
+        var result = ""
+        var rest = Substring(template)
+        while let open = rest.firstIndex(of: "{") {
+            guard let close = rest[open...].firstIndex(of: "}") else { break }
+            let name = String(rest[rest.index(after: open)..<close])
+            guard let value = values[name] else {
+                result += rest[..<rest.index(after: open)]
+                rest = rest[rest.index(after: open)...]
+                continue
+            }
+            result += rest[..<open] + value
+            rest = rest[rest.index(after: close)...]
+        }
+        return result + rest
     }
 
     /// Sanitize a filename/folder name for the filesystem
@@ -1704,82 +1799,165 @@ public final class DownloadManager {
         }
     }
 
-    /// Re-organize a completed download using actual audio metadata (artist, album).
-    /// If the active template uses {artist} or {album} tokens, reads metadata from the file
-    /// and moves it to the metadata-derived path if different. Fire-and-forget.
-    private func organizeCompletedDownload(
+    /// Under a tag-based template the file has not reached its final directory
+    /// yet — `organizeCompletedDownload` may move it, and applies the icon
+    /// there. Skipping here avoids decoding album art onto a directory that is
+    /// about to be emptied and pruned.
+    private func applyFolderArtworkAfterCompletion(for filePath: URL) {
+        guard !Self.isTagBased(activeTemplate) else { return }
+        applyFolderArtworkIfNeeded(for: filePath)
+    }
+
+    /// Settle a completed download into the directory its shared folder is
+    /// using. Only tag-based templates need this: their destination depends on
+    /// tags the path can't supply, so files from one folder would otherwise
+    /// scatter. Fire-and-forget.
+    func organizeCompletedDownload(
         currentPath: URL,
         soulseekFilename: String,
         username: String,
         transferId: UUID
     ) {
-        let template = settings?.activeDownloadTemplate ?? "{username}/{folders}/{filename}"
+        let template = activeTemplate
+        guard Self.isTagBased(template) else { return }
 
-        // Only worth doing if the template uses artist or album tokens
-        guard template.contains("{artist}") || template.contains("{album}") else { return }
+        let key = Self.sourceFolderKey(soulseekPath: soulseekFilename, username: username)
+        let file = PlacedFile(transferId: transferId, path: currentPath)
+
+        // A sibling already claimed this folder's directory, so skip the tag
+        // read entirely — it is an AVAsset open per file.
+        if let claimed = folderDestinations[key] {
+            relocate([file], toDirectory: claimed)
+            return
+        }
+
+        // Cover art, cue sheets and logs can never fill a tag token, so they
+        // go straight to the park queue rather than through AVFoundation.
+        guard let metadataReader,
+              FileTypes.isAudio(currentPath.pathExtension.lowercased()) else {
+            placeInFolder(key: key, candidate: nil, file: file)
+            return
+        }
 
         let downloadDir = getDownloadDirectory()
+        Task.detached { [weak self] in
+            let metadata = await metadataReader.extractAudioMetadata(from: currentPath)
 
-        Task.detached { [metadataReader, logger, transferState = self.transferState] in
-            guard let metadataReader,
-                  let metadata = await metadataReader.extractAudioMetadata(from: currentPath) else {
+            // Tags only settle the folder if they fill every tag token the
+            // template uses. A file tagged with a title but no album would
+            // otherwise "claim" the directory using folder-derived fallbacks
+            // and win over the tracks that are properly tagged.
+            let tagValues: [String: String?] = ["{artist}": metadata?.artist, "{album}": metadata?.album]
+            let satisfiesTemplate = tagValues.allSatisfy { token, value in
+                !template.contains(token) || !(value ?? "").isEmpty
+            }
+
+            let candidate: URL? = satisfiesTemplate
+                ? DownloadManager.destinationURL(
+                    downloadDirectory: downloadDir,
+                    soulseekPath: soulseekFilename,
+                    username: username,
+                    template: template,
+                    metadata: metadata
+                ).deletingLastPathComponent()
+                : nil
+
+            await self?.placeInFolder(key: key, candidate: candidate, file: file)
+        }
+    }
+
+    /// Decide where a just-completed file belongs relative to its siblings.
+    /// Runs without suspension so concurrent completions from one folder can't
+    /// both claim a destination.
+    private func placeInFolder(key: String, candidate: URL?, file: PlacedFile) {
+        // Bounded like `iconAppliedDirs`: forgetting a mapping only costs a
+        // folder downloaded much later re-deciding its destination. Folders
+        // that never produce a tagged file only ever grow `pendingFolderJoins`,
+        // so both maps count toward the cap.
+        if folderDestinations.count + pendingFolderJoins.count > 512 {
+            folderDestinations.removeAll(keepingCapacity: true)
+            pendingFolderJoins.removeAll(keepingCapacity: true)
+        }
+
+        // An existing claim wins over this file's own tags, so one shared
+        // folder can never split across two destinations.
+        guard let destination = folderDestinations[key] ?? candidate else {
+            // No usable tags — leave it at the folder-derived path and wait for
+            // a tagged sibling to pull it across.
+            pendingFolderJoins[key, default: []].append(file)
+            return
+        }
+        folderDestinations[key] = destination
+
+        let strays = pendingFolderJoins.removeValue(forKey: key) ?? []
+        relocate([file] + strays, toDirectory: destination)
+    }
+
+    /// Move completed files into `directory`, keeping their filenames, and
+    /// point their transfers at the new locations.
+    private func relocate(_ files: [PlacedFile], toDirectory directory: URL) {
+        let moves = files.filter { $0.path.deletingLastPathComponent() != directory }
+        guard !moves.isEmpty else { return }
+        let downloadDir = getDownloadDirectory()
+
+        Task.detached { [weak self, logger, transferState = self.transferState] in
+            let fm = FileManager.default
+            do {
+                try fm.createDirectory(at: directory, withIntermediateDirectories: true)
+            } catch {
+                logger.warning("Failed to create organized directory: \(error.localizedDescription)")
                 return
             }
 
-            // Re-resolve path with metadata
-            let newRelativePath = DownloadManager.resolveDownloadPath(
-                soulseekPath: soulseekFilename,
-                username: username,
-                template: template,
-                metadata: metadata
-            )
-
-            // Build the new full path with sanitized components
-            let newComponents = newRelativePath.split(separator: "/").map(String.init)
-            var newPath = downloadDir
-            for component in newComponents {
-                newPath = newPath.appendingPathComponent(DownloadManager.sanitizeFilename(component))
-            }
-
-            // If the path didn't change, nothing to do
-            guard newPath != currentPath else { return }
-
-            let fm = FileManager.default
-
-            // Create parent directories
-            let newDir = newPath.deletingLastPathComponent()
-            try? fm.createDirectory(at: newDir, withIntermediateDirectories: true)
-
-            // Move the file
-            do {
-                // If a file already exists at destination, skip (don't overwrite)
+            var moved: [PlacedFile] = []
+            var vacated: Set<URL> = []
+            for file in moves {
+                let newPath = directory.appendingPathComponent(file.path.lastPathComponent)
+                // Never overwrite: a same-named file here is either this very
+                // download (already moved) or a pre-existing copy.
                 guard !fm.fileExists(atPath: newPath.path) else {
-                    logger.debug("Metadata-organized path already exists, skipping move")
-                    return
+                    logger.debug("Organized path already occupied, leaving \(file.path.lastPathComponent) in place")
+                    continue
                 }
-                try fm.moveItem(at: currentPath, to: newPath)
-                logger.info("Reorganized download: \(currentPath.lastPathComponent) → \(newRelativePath)")
-
-                // Update the transfer's localPath on the main actor
-                await MainActor.run {
-                    transferState?.updateTransfer(id: transferId) { t in
-                        t.localPath = newPath
-                    }
+                do {
+                    try fm.moveItem(at: file.path, to: newPath)
+                    moved.append(PlacedFile(transferId: file.transferId, path: newPath))
+                    vacated.insert(file.path.deletingLastPathComponent())
+                } catch {
+                    logger.warning("Failed to reorganize download: \(error.localizedDescription)")
                 }
-
-                // Clean up empty parent directories from the old location
-                var oldDir = currentPath.deletingLastPathComponent()
-                while oldDir != downloadDir {
-                    let contents = (try? fm.contentsOfDirectory(atPath: oldDir.path)) ?? []
-                    // Only remove if truly empty (ignore .DS_Store)
-                    let meaningful = contents.filter { $0 != ".DS_Store" }
-                    guard meaningful.isEmpty else { break }
-                    try? fm.removeItem(at: oldDir)
-                    oldDir = oldDir.deletingLastPathComponent()
-                }
-            } catch {
-                logger.warning("Failed to reorganize download: \(error.localizedDescription)")
             }
+            guard let first = moved.first else { return }
+            logger.info("Reorganized \(moved.count) file(s) into \(directory.lastPathComponent)")
+
+            await MainActor.run {
+                for file in moved {
+                    transferState?.updateTransfer(id: file.transferId) { $0.localPath = file.path }
+                }
+            }
+            await self?.applyFolderArtworkIfNeeded(for: first.path)
+
+            for vacatedDirectory in vacated {
+                DownloadManager.pruneEmptyDirectories(from: vacatedDirectory, upTo: downloadDir)
+            }
+        }
+    }
+
+    private nonisolated static func pruneEmptyDirectories(from directory: URL, upTo root: URL) {
+        // Only ever delete inside the download root. Changing the download
+        // location mid-transfer can leave `directory` pointing into an
+        // unrelated tree, and a depth-only check would happily walk up it.
+        let rootComponents = root.standardizedFileURL.pathComponents
+        var dir = directory.standardizedFileURL
+        guard dir.pathComponents.starts(with: rootComponents) else { return }
+
+        let fm = FileManager.default
+        while dir.pathComponents.count > rootComponents.count {
+            let contents = (try? fm.contentsOfDirectory(atPath: dir.path)) ?? []
+            // Only remove if truly empty (ignore .DS_Store)
+            guard contents.filter({ $0 != ".DS_Store" }).isEmpty else { break }
+            try? fm.removeItem(at: dir)
+            dir = dir.deletingLastPathComponent()
         }
     }
 
@@ -1948,7 +2126,7 @@ public final class DownloadManager {
                 t.error = nil
             }
             ActivityLogger.shared?.logDownloadCompleted(filename: finalPath.lastPathComponent)
-            applyFolderArtworkIfNeeded(for: finalPath)
+            applyFolderArtworkAfterCompletion(for: finalPath)
             organizeCompletedDownload(currentPath: finalPath, soulseekFilename: pending.filename, username: pending.username, transferId: pending.transferId)
             // Record only this session's bytes (resumed portion was on disk).
             statisticsState?.recordTransfer(
@@ -3083,6 +3261,29 @@ public final class DownloadManager {
         pendingDownloads[token] = pending
     }
 
+    /// `settings` is `weak` in production; retain the double strongly too, or
+    /// ARC releases a test-local mock before the assertions run.
+    internal func _setSettingsForTest(_ settings: any DownloadSettingsProviding) {
+        self._testStrongSettings = settings
+        self.settings = settings
+    }
+
+    private var _testStrongSettings: (any DownloadSettingsProviding)?
+
+    internal func _setMetadataReaderForTest(_ reader: any MetadataReading) {
+        self.metadataReader = reader
+    }
+
+    internal func _destinationForTest(soulseekPath: String, username: String) -> URL {
+        computeDestPath(for: soulseekPath, username: username)
+    }
+
+    /// Also the tests' synchronization point: parking a file is the observable
+    /// end of the detached tag read.
+    internal var _pendingFolderJoinCount: Int {
+        pendingFolderJoins.values.reduce(0) { $0 + $1.count }
+    }
+
     /// Drive the queue-position handler from tests. Real callers reach
     /// it via the pool's `.placeInQueueReply` event in NetworkClient.
     internal func _handlePlaceInQueueReplyForTest(username: String, filename: String, position: UInt32) {
@@ -3170,16 +3371,7 @@ public final class DownloadManager {
 
     private var _testStrongTransferState: (any TransferTracking)?
 
-    /// Redirect `getDownloadDirectory()` to a test-controlled URL so file
-    /// I/O paths (resume detection, partial-file deletion) can run against
-    /// a temp directory instead of `~/Downloads/SeeleSeek`.
-    internal func _setDownloadDirectoryOverrideForTest(_ url: URL?) {
-        _downloadDirectoryOverride = url
-    }
-
     internal func _incompleteBasenameForTest(soulseekPath: String, username: String) -> String {
         computeIncompletePath(for: soulseekPath, username: username).lastPathComponent
     }
-
-    private var _downloadDirectoryOverride: URL?
 }

--- a/seeleseek/Features/Settings/SettingsState.swift
+++ b/seeleseek/Features/Settings/SettingsState.swift
@@ -42,6 +42,7 @@ enum NotificationSound: String, CaseIterable {
 }
 
 enum DownloadFolderFormat: String, CaseIterable {
+    case folderOnly = "folderOnly"
     case usernameAndPath = "usernameAndPath"
     case pathOnly = "pathOnly"
     case artistAlbum = "artistAlbum"
@@ -50,6 +51,7 @@ enum DownloadFolderFormat: String, CaseIterable {
 
     var displayName: String {
         switch self {
+        case .folderOnly: "Folder"
         case .usernameAndPath: "Username / Full Path"
         case .pathOnly: "Full Path"
         case .artistAlbum: "Artist - Album"
@@ -60,12 +62,19 @@ enum DownloadFolderFormat: String, CaseIterable {
 
     var template: String {
         switch self {
-        case .usernameAndPath: "{username}/{folders}/{filename}"
-        case .pathOnly: "{folders}/{filename}"
+        case .folderOnly: "{folder}/{filename}"
+        case .usernameAndPath: "{username}/{full-path}/{filename}"
+        case .pathOnly: "{full-path}/{filename}"
         case .artistAlbum: "{artist} - {album}/{filename}"
         case .flat: "{filename}"
         case .custom: ""
         }
+    }
+
+    /// The template actually in effect, given the user's custom text.
+    func resolvedTemplate(custom: String) -> String {
+        let resolved = self == .custom ? custom : template
+        return resolved.isEmpty ? DownloadManager.fallbackTemplate : resolved
     }
 }
 
@@ -85,6 +94,7 @@ final class SettingsState: DownloadSettingsProviding {
     private let incompleteLocationKey = "settingsIncompleteLocation"
     private let downloadFolderFormatKey = "settingsDownloadFolderFormat"
     private let downloadFolderTemplateKey = "settingsDownloadFolderTemplate"
+    private let downloadDefaultsMigratedKey = "settingsDownloadDefaultsMigratedV2"
     private let launchAtLoginKey = "settingsLaunchAtLogin"
     private let showInMenuBarKey = "settingsShowInMenuBar"
     private let notifyDownloadsKey = "settingsNotifyDownloads"
@@ -100,31 +110,37 @@ final class SettingsState: DownloadSettingsProviding {
     /// created by "streaming-service" apps that queue uploads en masse without sharing.
     static let defaultBlockedUsernamePatterns: [String] = ["slsk_*"]
 
+    static let defaultDownloadLocation = DownloadManager.defaultDownloadDirectory
+    static let defaultIncompleteLocation = defaultDownloadLocation.appendingPathComponent("Incomplete")
+    static let defaultDownloadFolderFormat = DownloadFolderFormat.folderOnly
+    /// Starting point for a custom template, not the shipped default layout.
+    static let defaultDownloadFolderTemplate = DownloadFolderFormat.usernameAndPath.template
+
     private let logger = Logger(subsystem: "com.seeleseek", category: "Settings")
 
     // Flag to prevent save during load
     private var isLoading = false
 
     // MARK: - General Settings
-    var downloadLocation: URL = FileManager.default.urls(for: .downloadsDirectory, in: .userDomainMask).first! {
+    var downloadLocation: URL = SettingsState.defaultDownloadLocation {
         didSet {
             guard !isLoading else { return }
             save()
         }
     }
-    var incompleteLocation: URL = FileManager.default.urls(for: .downloadsDirectory, in: .userDomainMask).first!.appendingPathComponent("Incomplete") {
+    var incompleteLocation: URL = SettingsState.defaultIncompleteLocation {
         didSet {
             guard !isLoading else { return }
             save()
         }
     }
-    var downloadFolderFormat: DownloadFolderFormat = .usernameAndPath {
+    var downloadFolderFormat: DownloadFolderFormat = SettingsState.defaultDownloadFolderFormat {
         didSet {
             guard !isLoading else { return }
             save()
         }
     }
-    var downloadFolderTemplate: String = "{username}/{folders}/{filename}" {
+    var downloadFolderTemplate: String = SettingsState.defaultDownloadFolderTemplate {
         didSet {
             guard !isLoading else { return }
             save()
@@ -352,10 +368,10 @@ final class SettingsState: DownloadSettingsProviding {
     }
 
     func resetToDefaults() {
-        downloadLocation = FileManager.default.urls(for: .downloadsDirectory, in: .userDomainMask).first!
-        incompleteLocation = downloadLocation.appendingPathComponent("Incomplete")
-        downloadFolderFormat = .usernameAndPath
-        downloadFolderTemplate = "{username}/{folders}/{filename}"
+        downloadLocation = SettingsState.defaultDownloadLocation
+        incompleteLocation = SettingsState.defaultIncompleteLocation
+        downloadFolderFormat = SettingsState.defaultDownloadFolderFormat
+        downloadFolderTemplate = SettingsState.defaultDownloadFolderTemplate
         launchAtLogin = false
         showInMenuBar = true
         listenPort = 2234
@@ -520,6 +536,7 @@ final class SettingsState: DownloadSettingsProviding {
         if let template = UserDefaults.standard.string(forKey: downloadFolderTemplateKey) {
             downloadFolderTemplate = template
         }
+        migrateDownloadDefaultsIfNeeded()
         if UserDefaults.standard.object(forKey: showInMenuBarKey) != nil {
             showInMenuBar = UserDefaults.standard.bool(forKey: showInMenuBarKey)
         }
@@ -548,6 +565,45 @@ final class SettingsState: DownloadSettingsProviding {
         if UserDefaults.standard.object(forKey: showJoinLeaveMessagesKey) != nil {
             showJoinLeaveMessages = UserDefaults.standard.bool(forKey: showJoinLeaveMessagesKey)
         }
+    }
+
+    /// Keep an existing library laid out the way its owner already has it.
+    /// Both download defaults changed in this version, and each would silently
+    /// re-lay-out an upgraded install:
+    ///
+    /// - the location was collected but never used — files always went to
+    ///   `~/Downloads/SeeleSeek` — so honoring a stored `~/Downloads` (the old
+    ///   default, which nobody's files landed in) would start dumping
+    ///   downloads loose into the user's Downloads folder;
+    /// - the folder structure default became `.folderOnly`, so anyone who
+    ///   never opened Settings — and therefore has no stored format, since
+    ///   `save()` only runs from a property `didSet` — would have new
+    ///   downloads land beside, not inside, their `{username}/{path}` library.
+    ///
+    /// Old versions created `~/Downloads/SeeleSeek` eagerly at launch, so its
+    /// presence is the marker for "this machine ran a pre-1.1.x build".
+    /// A value the user actually chose is always left alone.
+    private func migrateDownloadDefaultsIfNeeded() {
+        let defaults = UserDefaults.standard
+        guard !defaults.bool(forKey: downloadDefaultsMigratedKey) else { return }
+        defaults.set(true, forKey: downloadDefaultsMigratedKey)
+
+        let isUpgrade = FileManager.default.fileExists(atPath: SettingsState.defaultDownloadLocation.path)
+
+        if isUpgrade, defaults.string(forKey: downloadFolderFormatKey) == nil {
+            logger.info("Pinning pre-existing library to the previous folder structure default")
+            downloadFolderFormat = .usernameAndPath
+            // `isLoading` suppresses the `didSet` that would normally persist
+            // this, and the one-shot flag is already burned.
+            defaults.set(downloadFolderFormat.rawValue, forKey: downloadFolderFormatKey)
+        }
+
+        let legacyDefault = FileManager.default.urls(for: .downloadsDirectory, in: .userDomainMask)[0]
+        guard downloadLocation.standardizedFileURL == legacyDefault.standardizedFileURL else { return }
+
+        logger.info("Migrating download location from \(legacyDefault.path) to \(SettingsState.defaultDownloadLocation.path)")
+        downloadLocation = SettingsState.defaultDownloadLocation
+        defaults.set(downloadLocation.path, forKey: downloadLocationKey)
     }
 
     /// Load settings from database (called after DB initialization)
@@ -585,12 +641,12 @@ final class SettingsState: DownloadSettingsProviding {
 
 // MARK: - Download Folder Template
 extension SettingsState {
-    /// Returns the active template string based on the current format setting
     var activeDownloadTemplate: String {
-        if downloadFolderFormat == .custom {
-            return downloadFolderTemplate
-        }
-        return downloadFolderFormat.template
+        downloadFolderFormat.resolvedTemplate(custom: downloadFolderTemplate)
+    }
+
+    var downloadDirectory: URL {
+        downloadLocation
     }
 
     var incompleteDownloadDirectory: URL {

--- a/seeleseek/Features/Settings/SettingsState.swift
+++ b/seeleseek/Features/Settings/SettingsState.swift
@@ -71,7 +71,6 @@ enum DownloadFolderFormat: String, CaseIterable {
         }
     }
 
-    /// The template actually in effect, given the user's custom text.
     func resolvedTemplate(custom: String) -> String {
         let resolved = self == .custom ? custom : template
         return resolved.isEmpty ? DownloadManager.fallbackTemplate : resolved
@@ -567,22 +566,13 @@ final class SettingsState: DownloadSettingsProviding {
         }
     }
 
-    /// Keep an existing library laid out the way its owner already has it.
-    /// Both download defaults changed in this version, and each would silently
-    /// re-lay-out an upgraded install:
-    ///
-    /// - the location was collected but never used — files always went to
-    ///   `~/Downloads/SeeleSeek` — so honoring a stored `~/Downloads` (the old
-    ///   default, which nobody's files landed in) would start dumping
-    ///   downloads loose into the user's Downloads folder;
-    /// - the folder structure default became `.folderOnly`, so anyone who
-    ///   never opened Settings — and therefore has no stored format, since
-    ///   `save()` only runs from a property `didSet` — would have new
-    ///   downloads land beside, not inside, their `{username}/{path}` library.
-    ///
+    /// Both download defaults changed in this version, and each would
+    /// re-lay-out an upgraded install: a stored `~/Downloads` (the old
+    /// default, which was never actually used) would dump files loose into
+    /// Downloads, and the new `.folderOnly` structure would apply to anyone
+    /// who never opened Settings, since `save()` only runs from a `didSet`.
     /// Old versions created `~/Downloads/SeeleSeek` eagerly at launch, so its
-    /// presence is the marker for "this machine ran a pre-1.1.x build".
-    /// A value the user actually chose is always left alone.
+    /// presence marks a pre-1.1.x install. Chosen values are left alone.
     private func migrateDownloadDefaultsIfNeeded() {
         let defaults = UserDefaults.standard
         guard !defaults.bool(forKey: downloadDefaultsMigratedKey) else { return }

--- a/seeleseek/Features/Settings/Views/GeneralSettingsSection.swift
+++ b/seeleseek/Features/Settings/Views/GeneralSettingsSection.swift
@@ -6,19 +6,15 @@ struct GeneralSettingsSection: View {
     @Bindable var settings: SettingsState
     @State private var showNicotineImport = false
 
+    /// Rendered through the same resolver the download manager uses, so the
+    /// preview can't drift from where files actually land.
     private var folderStructurePreview: String {
-        let template = settings.activeDownloadTemplate
-        var result = template
-            .replacingOccurrences(of: "{username}", with: "user123")
-            .replacingOccurrences(of: "{folders}", with: "Daft Punk/Discovery")
-            .replacingOccurrences(of: "{artist}", with: "Daft Punk")
-            .replacingOccurrences(of: "{album}", with: "Discovery")
-            .replacingOccurrences(of: "{filename}", with: "01 Track.mp3")
-        while result.contains("//") {
-            result = result.replacingOccurrences(of: "//", with: "/")
-        }
-        result = result.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
-        return result.isEmpty ? "01 Track.mp3" : result
+        DownloadManager.resolveDownloadPath(
+            soulseekPath: #"@@music\Daft Punk\Discovery\01 Track.mp3"#,
+            username: "user123",
+            template: settings.activeDownloadTemplate,
+            metadata: AudioFileMetadata(artist: "Daft Punk", album: "Discovery")
+        )
     }
 
     var body: some View {
@@ -57,11 +53,11 @@ struct GeneralSettingsSection: View {
                                 .foregroundStyle(SeeleColors.textSecondary)
                                 .accessibilityHidden(true)
 
-                            TextField("{username}/{folders}/{filename}", text: $settings.downloadFolderTemplate)
+                            TextField("{username}/{full-path}/{filename}", text: $settings.downloadFolderTemplate)
                                 .textFieldStyle(SeeleTextFieldStyle())
                                 .accessibilityLabel("Download folder template")
 
-                            Text("Tokens: {username}, {folders}, {artist}, {album}, {filename}")
+                            Text("Tokens: {username}, {folder}, {full-path}, {artist}, {album}, {filename}")
                                 .font(SeeleTypography.caption2)
                                 .foregroundStyle(SeeleColors.textTertiary)
                         }

--- a/seeleseek/Features/Settings/Views/GeneralSettingsSection.swift
+++ b/seeleseek/Features/Settings/Views/GeneralSettingsSection.swift
@@ -6,8 +6,7 @@ struct GeneralSettingsSection: View {
     @Bindable var settings: SettingsState
     @State private var showNicotineImport = false
 
-    /// Rendered through the same resolver the download manager uses, so the
-    /// preview can't drift from where files actually land.
+    /// Uses the manager's own resolver so the preview can't drift.
     private var folderStructurePreview: String {
         DownloadManager.resolveDownloadPath(
             soulseekPath: #"@@music\Daft Punk\Discovery\01 Track.mp3"#,

--- a/seeleseek/Features/Transfers/TransferState.swift
+++ b/seeleseek/Features/Transfers/TransferState.swift
@@ -15,8 +15,7 @@ struct TransferHistoryItem: Identifiable, Sendable {
     let isDownload: Bool
     let localPath: URL?
 
-    /// Resolved local path — the stored path, or where the current download
-    /// settings say the file would have landed.
+    /// The stored path, or where the given settings say the file would be.
     func resolvedLocalPath(downloadDirectory: URL, template: String) -> URL? {
         if let localPath, FileManager.default.fileExists(atPath: localPath.path) {
             return localPath

--- a/seeleseek/Features/Transfers/TransferState.swift
+++ b/seeleseek/Features/Transfers/TransferState.swift
@@ -15,50 +15,29 @@ struct TransferHistoryItem: Identifiable, Sendable {
     let isDownload: Bool
     let localPath: URL?
 
-    /// Resolved local path - uses stored path, or tries the default download location
-    var resolvedLocalPath: URL? {
+    /// Resolved local path — the stored path, or where the current download
+    /// settings say the file would have landed.
+    func resolvedLocalPath(downloadDirectory: URL, template: String) -> URL? {
         if let localPath, FileManager.default.fileExists(atPath: localPath.path) {
             return localPath
         }
         // Only downloads land in the download directory. An upload's source
         // can be anywhere on disk, so a fabricated path is always wrong.
         guard isDownload else { return nil }
-        // Try default download directory: ~/Downloads/SeeleSeek/{username}/{folders}/{filename}
-        return Self.inferDownloadPath(filename: filename, username: username)
-    }
 
-    var fileExists: Bool {
-        resolvedLocalPath != nil
+        let inferred = DownloadManager.destinationURL(
+            downloadDirectory: downloadDirectory,
+            soulseekPath: filename,
+            username: username,
+            template: template
+        )
+        return FileManager.default.fileExists(atPath: inferred.path) ? inferred : nil
     }
 
     var isAudioFile: Bool {
         let audioExtensions = ["mp3", "flac", "ogg", "m4a", "aac", "wav", "aiff", "alac", "wma", "ape", "aif"]
         let ext = (displayFilename as NSString).pathExtension.lowercased()
         return audioExtensions.contains(ext)
-    }
-
-    /// Reconstruct the likely download path from the soulseek filename
-    private static func inferDownloadPath(filename: String, username: String) -> URL? {
-        let paths = FileManager.default.urls(for: .downloadsDirectory, in: .userDomainMask)
-        let baseDir = paths[0].appendingPathComponent("SeeleSeek")
-
-        var components = filename.split(separator: "\\").map(String.init)
-        // Strip @@ root share marker
-        if !components.isEmpty && components[0].hasPrefix("@@") {
-            components.removeFirst()
-        }
-        guard !components.isEmpty else { return nil }
-
-        // Default template: {username}/{folders}/{filename}
-        var url = baseDir.appendingPathComponent(username)
-        for component in components {
-            url = url.appendingPathComponent(component)
-        }
-
-        if FileManager.default.fileExists(atPath: url.path) {
-            return url
-        }
-        return nil
     }
 
     var displayFilename: String {

--- a/seeleseek/Features/Transfers/Views/HistoryRow.swift
+++ b/seeleseek/Features/Transfers/Views/HistoryRow.swift
@@ -43,7 +43,10 @@ struct HistoryRow: View {
     }
 
     private func refreshResolvedPath() {
-        resolvedPath = item.resolvedLocalPath
+        resolvedPath = item.resolvedLocalPath(
+            downloadDirectory: appState.settings.downloadLocation,
+            template: appState.settings.activeDownloadTemplate
+        )
     }
 
     var body: some View {

--- a/seeleseekTests/DownloadFolderPlacementTests.swift
+++ b/seeleseekTests/DownloadFolderPlacementTests.swift
@@ -1,0 +1,199 @@
+import Foundation
+import Testing
+@testable import SeeleseekCore
+
+@MainActor
+@Suite("Download folder placement")
+struct DownloadFolderPlacementTests {
+    private let user = "alice"
+    private let folder = #"@@music\Milton\1988 - Eu Sou O Rio"#
+    private let tagged = AudioFileMetadata(artist: "Milton Nascimento", album: "Eu Sou O Rio")
+
+    private func makeTempRoot() throws -> URL {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("seeleseek-placement-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        return root
+    }
+
+    /// The placement work runs in detached tasks; poll rather than sleep a
+    /// fixed amount so the suite stays fast when it converges immediately.
+    private func waitUntil(_ condition: () -> Bool) async -> Bool {
+        for _ in 0..<200 {
+            if condition() { return true }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return condition()
+    }
+
+    private func write(_ url: URL) throws {
+        try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try Data("x".utf8).write(to: url)
+    }
+
+    /// Issue #75: completed files must land under the configured download
+    /// location, not a hardcoded `~/Downloads/SeeleSeek`.
+    @Test("Destination honors the configured download location")
+    func destinationUsesConfiguredLocation() throws {
+        let root = try makeTempRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let manager = DownloadManager()
+        let settings = MockDownloadSettings(downloadDirectory: root, template: "{folder}/{filename}")
+        manager._setSettingsForTest(settings)
+
+        let dest = manager._destinationForTest(soulseekPath: #"\#(folder)\01 track.mp3"#, username: user)
+        #expect(dest == root.appendingPathComponent("1988 - Eu Sou O Rio/01 track.mp3"))
+    }
+
+    /// Issue #76: a file whose tags are missing must not strand itself in a
+    /// folder-name-derived directory while its tagged siblings go elsewhere.
+    @Test("Untagged siblings are pulled into the album folder claimed by a tagged file")
+    func untaggedFilesFollowTaggedSibling() async throws {
+        let root = try makeTempRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let manager = DownloadManager()
+        let settings = MockDownloadSettings(downloadDirectory: root, template: "{artist} - {album}/{filename}")
+        manager._setSettingsForTest(settings)
+        let reader = MockMetadataReader()
+        manager._setMetadataReaderForTest(reader)
+        let tracking = MockTransferTracking()
+        manager._setTransferStateForTest(tracking)
+
+        // Folder-derived directory: what every file resolves to without tags.
+        let fallbackDir = root.appendingPathComponent("Milton - 1988 - Eu Sou O Rio")
+        let albumDir = root.appendingPathComponent("Milton Nascimento - Eu Sou O Rio")
+
+        let untagged = fallbackDir.appendingPathComponent("10 track.mp3")
+        let cover = fallbackDir.appendingPathComponent("cover.jpg")
+        let taggedFile = fallbackDir.appendingPathComponent("01 track.mp3")
+        try write(untagged)
+        try write(cover)
+        try write(taggedFile)
+        reader.metadata[taggedFile] = tagged
+
+        let ids = [untagged: UUID(), cover: UUID(), taggedFile: UUID()]
+        for (path, id) in ids {
+            let soulseek = #"\#(folder)\\#(path.lastPathComponent)"#
+            tracking.downloads.append(Transfer(id: id, username: user, filename: soulseek, size: 1, direction: .download, status: .completed))
+        }
+        func complete(_ path: URL) {
+            manager.organizeCompletedDownload(
+                currentPath: path,
+                soulseekFilename: #"\#(folder)\\#(path.lastPathComponent)"#,
+                username: user,
+                transferId: ids[path]!
+            )
+        }
+
+        // The two untagged files complete first — the ordering that produced
+        // the split in the issue.
+        complete(untagged)
+        complete(cover)
+        #expect(await waitUntil { manager._pendingFolderJoinCount == 2 })
+
+        complete(taggedFile)
+
+        let fm = FileManager.default
+        #expect(await waitUntil {
+            fm.fileExists(atPath: albumDir.appendingPathComponent("10 track.mp3").path)
+                && fm.fileExists(atPath: albumDir.appendingPathComponent("cover.jpg").path)
+                && fm.fileExists(atPath: albumDir.appendingPathComponent("01 track.mp3").path)
+        }, "all three files belong in the album folder claimed by the tagged track")
+        #expect(await waitUntil { !fm.fileExists(atPath: fallbackDir.path) },
+                "the emptied fallback directory should be pruned")
+
+        // The whole group moves in one batched task; every transfer in it must
+        // still be repointed at its own new location.
+        for (path, id) in ids {
+            #expect(tracking.getTransfer(id: id)?.localPath == albumDir.appendingPathComponent(path.lastPathComponent))
+        }
+
+        // A later arrival from the same folder goes straight to the claimed
+        // directory, without another move.
+        let laterDest = manager._destinationForTest(soulseekPath: #"\#(folder)\11 track.mp3"#, username: user)
+        #expect(laterDest == albumDir.appendingPathComponent("11 track.mp3"))
+    }
+
+    /// The prune walk deletes empty directories by depth; it must refuse to
+    /// start when the vacated directory is not inside the download root, which
+    /// happens if the download location changes mid-transfer.
+    @Test("Files vacated outside the download root are not pruned")
+    func pruneStaysInsideDownloadRoot() async throws {
+        let root = try makeTempRoot()
+        let elsewhere = try makeTempRoot()
+        defer {
+            try? FileManager.default.removeItem(at: root)
+            try? FileManager.default.removeItem(at: elsewhere)
+        }
+
+        let manager = DownloadManager()
+        let settings = MockDownloadSettings(downloadDirectory: root, template: "{artist} - {album}/{filename}")
+        manager._setSettingsForTest(settings)
+        let reader = MockMetadataReader()
+        manager._setMetadataReaderForTest(reader)
+
+        // The file sits under the *old* root, two levels deep, so a depth-only
+        // walk would climb out of it.
+        let strandedDir = elsewhere.appendingPathComponent("Old Root/Milton - 1988 - Eu Sou O Rio")
+        let stranded = strandedDir.appendingPathComponent("01 track.mp3")
+        try write(stranded)
+        reader.metadata[stranded] = tagged
+
+        manager.organizeCompletedDownload(currentPath: stranded, soulseekFilename: #"\#(folder)\01 track.mp3"#, username: user, transferId: UUID())
+
+        let albumDir = root.appendingPathComponent("Milton Nascimento - Eu Sou O Rio")
+        let fm = FileManager.default
+        #expect(await waitUntil { fm.fileExists(atPath: albumDir.appendingPathComponent("01 track.mp3").path) })
+        #expect(fm.fileExists(atPath: elsewhere.appendingPathComponent("Old Root").path),
+                "directories outside the download root must survive the move")
+    }
+
+    /// Tags that don't fill the tokens the template uses must not claim the
+    /// folder — otherwise a title-only file wins over properly tagged tracks.
+    @Test("Partial tags do not claim the folder destination")
+    func partialTagsDoNotClaim() async throws {
+        let root = try makeTempRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let manager = DownloadManager()
+        let settings = MockDownloadSettings(downloadDirectory: root, template: "{artist} - {album}/{filename}")
+        manager._setSettingsForTest(settings)
+        let reader = MockMetadataReader()
+        manager._setMetadataReaderForTest(reader)
+
+        let soulseek = #"\#(folder)\10 track.mp3"#
+        let file = root.appendingPathComponent("Milton - 1988 - Eu Sou O Rio/10 track.mp3")
+        try write(file)
+        reader.metadata[file] = AudioFileMetadata(artist: nil, album: nil, title: "Track Ten")
+
+        manager.organizeCompletedDownload(currentPath: file, soulseekFilename: soulseek, username: user, transferId: UUID())
+
+        #expect(await waitUntil { manager._pendingFolderJoinCount == 1 })
+        #expect(FileManager.default.fileExists(atPath: file.path), "it stays put until a tagged sibling arrives")
+    }
+
+    /// Grouping only exists to reconcile tag-derived paths; path-based
+    /// templates already agree across a folder and must stay untouched.
+    @Test("Path-based templates skip placement entirely")
+    func pathTemplatesSkipPlacement() throws {
+        let root = try makeTempRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let manager = DownloadManager()
+        let settings = MockDownloadSettings(downloadDirectory: root, template: "{folder}/{filename}")
+        manager._setSettingsForTest(settings)
+
+        let soulseek = #"\#(folder)\01 track.mp3"#
+        let file = root.appendingPathComponent("1988 - Eu Sou O Rio/01 track.mp3")
+        try write(file)
+
+        // Returns at the `isTagBased` guard without scheduling anything, so
+        // there is nothing to wait for.
+        manager.organizeCompletedDownload(currentPath: file, soulseekFilename: soulseek, username: user, transferId: UUID())
+
+        #expect(manager._pendingFolderJoinCount == 0)
+        #expect(FileManager.default.fileExists(atPath: file.path))
+    }
+}

--- a/seeleseekTests/DownloadFolderPlacementTests.swift
+++ b/seeleseekTests/DownloadFolderPlacementTests.swift
@@ -16,8 +16,7 @@ struct DownloadFolderPlacementTests {
         return root
     }
 
-    /// The placement work runs in detached tasks; poll rather than sleep a
-    /// fixed amount so the suite stays fast when it converges immediately.
+    /// Placement runs in detached tasks, so poll rather than sleep a fixed amount.
     private func waitUntil(_ condition: () -> Bool) async -> Bool {
         for _ in 0..<200 {
             if condition() { return true }
@@ -31,8 +30,7 @@ struct DownloadFolderPlacementTests {
         try Data("x".utf8).write(to: url)
     }
 
-    /// Issue #75: completed files must land under the configured download
-    /// location, not a hardcoded `~/Downloads/SeeleSeek`.
+    /// Issue #75.
     @Test("Destination honors the configured download location")
     func destinationUsesConfiguredLocation() throws {
         let root = try makeTempRoot()
@@ -46,8 +44,7 @@ struct DownloadFolderPlacementTests {
         #expect(dest == root.appendingPathComponent("1988 - Eu Sou O Rio/01 track.mp3"))
     }
 
-    /// Issue #76: a file whose tags are missing must not strand itself in a
-    /// folder-name-derived directory while its tagged siblings go elsewhere.
+    /// Issue #76.
     @Test("Untagged siblings are pulled into the album folder claimed by a tagged file")
     func untaggedFilesFollowTaggedSibling() async throws {
         let root = try makeTempRoot()
@@ -61,7 +58,7 @@ struct DownloadFolderPlacementTests {
         let tracking = MockTransferTracking()
         manager._setTransferStateForTest(tracking)
 
-        // Folder-derived directory: what every file resolves to without tags.
+        // Where every file resolves without tags.
         let fallbackDir = root.appendingPathComponent("Milton - 1988 - Eu Sou O Rio")
         let albumDir = root.appendingPathComponent("Milton Nascimento - Eu Sou O Rio")
 
@@ -87,8 +84,7 @@ struct DownloadFolderPlacementTests {
             )
         }
 
-        // The two untagged files complete first — the ordering that produced
-        // the split in the issue.
+        // Untagged files first — the ordering that produced the split.
         complete(untagged)
         complete(cover)
         #expect(await waitUntil { manager._pendingFolderJoinCount == 2 })
@@ -104,21 +100,18 @@ struct DownloadFolderPlacementTests {
         #expect(await waitUntil { !fm.fileExists(atPath: fallbackDir.path) },
                 "the emptied fallback directory should be pruned")
 
-        // The whole group moves in one batched task; every transfer in it must
-        // still be repointed at its own new location.
+        // The group moves in one batched task; each transfer still repoints.
         for (path, id) in ids {
             #expect(tracking.getTransfer(id: id)?.localPath == albumDir.appendingPathComponent(path.lastPathComponent))
         }
 
-        // A later arrival from the same folder goes straight to the claimed
-        // directory, without another move.
+        // A later arrival skips the fallback directory entirely.
         let laterDest = manager._destinationForTest(soulseekPath: #"\#(folder)\11 track.mp3"#, username: user)
         #expect(laterDest == albumDir.appendingPathComponent("11 track.mp3"))
     }
 
-    /// The prune walk deletes empty directories by depth; it must refuse to
-    /// start when the vacated directory is not inside the download root, which
-    /// happens if the download location changes mid-transfer.
+    /// The prune walk deletes by depth, so it must refuse to start outside
+    /// the download root — reachable by changing the location mid-transfer.
     @Test("Files vacated outside the download root are not pruned")
     func pruneStaysInsideDownloadRoot() async throws {
         let root = try makeTempRoot()
@@ -134,8 +127,7 @@ struct DownloadFolderPlacementTests {
         let reader = MockMetadataReader()
         manager._setMetadataReaderForTest(reader)
 
-        // The file sits under the *old* root, two levels deep, so a depth-only
-        // walk would climb out of it.
+        // Two levels deep under the *old* root, so a depth-only walk escapes.
         let strandedDir = elsewhere.appendingPathComponent("Old Root/Milton - 1988 - Eu Sou O Rio")
         let stranded = strandedDir.appendingPathComponent("01 track.mp3")
         try write(stranded)
@@ -150,8 +142,7 @@ struct DownloadFolderPlacementTests {
                 "directories outside the download root must survive the move")
     }
 
-    /// Tags that don't fill the tokens the template uses must not claim the
-    /// folder — otherwise a title-only file wins over properly tagged tracks.
+    /// A title-only file must not beat the properly tagged tracks.
     @Test("Partial tags do not claim the folder destination")
     func partialTagsDoNotClaim() async throws {
         let root = try makeTempRoot()
@@ -174,8 +165,7 @@ struct DownloadFolderPlacementTests {
         #expect(FileManager.default.fileExists(atPath: file.path), "it stays put until a tagged sibling arrives")
     }
 
-    /// Grouping only exists to reconcile tag-derived paths; path-based
-    /// templates already agree across a folder and must stay untouched.
+    /// Path-based templates already agree across a folder.
     @Test("Path-based templates skip placement entirely")
     func pathTemplatesSkipPlacement() throws {
         let root = try makeTempRoot()
@@ -189,8 +179,7 @@ struct DownloadFolderPlacementTests {
         let file = root.appendingPathComponent("1988 - Eu Sou O Rio/01 track.mp3")
         try write(file)
 
-        // Returns at the `isTagBased` guard without scheduling anything, so
-        // there is nothing to wait for.
+        // Returns at the `isTagBased` guard, so there is nothing to await.
         manager.organizeCompletedDownload(currentPath: file, soulseekFilename: soulseek, username: user, transferId: UUID())
 
         #expect(manager._pendingFolderJoinCount == 0)

--- a/seeleseekTests/DownloadPathTests.swift
+++ b/seeleseekTests/DownloadPathTests.swift
@@ -38,6 +38,71 @@ struct DownloadPathTests {
         #expect(result == "Daft Punk - Discovery/01 One More Time.mp3")
     }
 
+    @Test("Folder template keeps only the containing folder")
+    func testFolderOnly() {
+        let result = DownloadManager.resolveDownloadPath(
+            soulseekPath: "@@music\\Daft Punk\\Discovery\\01 One More Time.mp3",
+            username: "cooldj",
+            template: "{folder}/{filename}"
+        )
+        #expect(result == "Discovery/01 One More Time.mp3")
+    }
+
+    @Test("full-path token is the current spelling of the legacy folders token")
+    func testFullPathAlias() {
+        let path = "@@music\\Daft Punk\\Discovery\\01 One More Time.mp3"
+        let legacy = DownloadManager.resolveDownloadPath(soulseekPath: path, username: "cooldj", template: "{folders}/{filename}")
+        let current = DownloadManager.resolveDownloadPath(soulseekPath: path, username: "cooldj", template: "{full-path}/{filename}")
+        #expect(legacy == current)
+        #expect(current == "Daft Punk/Discovery/01 One More Time.mp3")
+    }
+
+    /// `{folder}` is a prefix of `{folders}`, so substitution order matters —
+    /// a naive pass would leave a stray "s" behind.
+    @Test("folder and folders tokens coexist in one template")
+    func testFolderTokenPrefixCollision() {
+        let result = DownloadManager.resolveDownloadPath(
+            soulseekPath: "@@music\\Daft Punk\\Discovery\\01 One More Time.mp3",
+            username: "cooldj",
+            template: "{folders}/{folder}/{filename}"
+        )
+        #expect(result == "Daft Punk/Discovery/Discovery/01 One More Time.mp3")
+    }
+
+    /// Substitution is a single pass, so a value that happens to look like a
+    /// token is data, not another token to expand.
+    @Test("Token-shaped metadata values are not re-substituted")
+    func testValuesAreNotRecursivelySubstituted() {
+        let metadata = AudioFileMetadata(artist: "{album}", album: "Real Album", title: nil)
+        let result = DownloadManager.resolveDownloadPath(
+            soulseekPath: "@@music\\X\\Y\\01 track.mp3",
+            username: "cooldj",
+            template: "{artist}/{album}/{filename}",
+            metadata: metadata
+        )
+        #expect(result == "{album}/Real Album/01 track.mp3")
+    }
+
+    @Test("Unknown tokens are left untouched")
+    func testUnknownTokenPreserved() {
+        let result = DownloadManager.resolveDownloadPath(
+            soulseekPath: "@@music\\Daft Punk\\Discovery\\01 track.mp3",
+            username: "cooldj",
+            template: "{bitrate}/{folder}/{filename}"
+        )
+        #expect(result == "{bitrate}/Discovery/01 track.mp3")
+    }
+
+    @Test("Unbalanced brace does not swallow the rest of the template")
+    func testUnbalancedBrace() {
+        let result = DownloadManager.resolveDownloadPath(
+            soulseekPath: "@@music\\Daft Punk\\Discovery\\01 track.mp3",
+            username: "cooldj",
+            template: "{folder/{filename}"
+        )
+        #expect(result == "{folder/01 track.mp3")
+    }
+
     @Test("Flat template (filename only)")
     func testFlat() {
         let result = DownloadManager.resolveDownloadPath(

--- a/seeleseekTests/DownloadPathTests.swift
+++ b/seeleseekTests/DownloadPathTests.swift
@@ -57,8 +57,7 @@ struct DownloadPathTests {
         #expect(current == "Daft Punk/Discovery/01 One More Time.mp3")
     }
 
-    /// `{folder}` is a prefix of `{folders}`, so substitution order matters —
-    /// a naive pass would leave a stray "s" behind.
+    /// `{folder}` is a prefix of `{folders}`; a naive pass leaves a stray "s".
     @Test("folder and folders tokens coexist in one template")
     func testFolderTokenPrefixCollision() {
         let result = DownloadManager.resolveDownloadPath(
@@ -69,8 +68,7 @@ struct DownloadPathTests {
         #expect(result == "Daft Punk/Discovery/Discovery/01 One More Time.mp3")
     }
 
-    /// Substitution is a single pass, so a value that happens to look like a
-    /// token is data, not another token to expand.
+    /// A value that looks like a token is data, not another token to expand.
     @Test("Token-shaped metadata values are not re-substituted")
     func testValuesAreNotRecursivelySubstituted() {
         let metadata = AudioFileMetadata(artist: "{album}", album: "Real Album", title: nil)

--- a/seeleseekTests/DownloadRetryFlowTests.swift
+++ b/seeleseekTests/DownloadRetryFlowTests.swift
@@ -158,7 +158,7 @@ struct DownloadRetryFlowTests {
             .appendingPathComponent("seeleseek-tests-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: tempRoot) }
-        manager._setDownloadDirectoryOverrideForTest(tempRoot)
+        manager._setSettingsForTest(MockDownloadSettings(downloadDirectory: tempRoot))
 
         let partialPath = tempRoot
             .appendingPathComponent("Incomplete")
@@ -197,7 +197,7 @@ struct DownloadRetryFlowTests {
             .appendingPathComponent("seeleseek-tests-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: tempRoot) }
-        manager._setDownloadDirectoryOverrideForTest(tempRoot)
+        manager._setSettingsForTest(MockDownloadSettings(downloadDirectory: tempRoot))
 
         let partialPath = tempRoot
             .appendingPathComponent("Incomplete")

--- a/seeleseekTests/DownloadTestDoubles.swift
+++ b/seeleseekTests/DownloadTestDoubles.swift
@@ -15,8 +15,8 @@ final class MockDownloadSettings: DownloadSettingsProviding {
     }
 }
 
-/// Returns tags only for paths explicitly registered, so tests can model a
-/// mixed folder: tagged tracks, an untagged track, and cover art.
+/// Returns tags only for registered paths, so a folder can mix tagged and
+/// untagged files.
 final class MockMetadataReader: MetadataReading, @unchecked Sendable {
     var metadata: [URL: AudioFileMetadata] = [:]
 

--- a/seeleseekTests/DownloadTestDoubles.swift
+++ b/seeleseekTests/DownloadTestDoubles.swift
@@ -1,0 +1,26 @@
+import Foundation
+@testable import SeeleseekCore
+
+@MainActor
+final class MockDownloadSettings: DownloadSettingsProviding {
+    var downloadDirectory: URL
+    var activeDownloadTemplate: String
+    var incompleteDownloadDirectory: URL
+    var setFolderIcons: Bool = false
+
+    init(downloadDirectory: URL, template: String = DownloadManager.fallbackTemplate) {
+        self.downloadDirectory = downloadDirectory
+        self.activeDownloadTemplate = template
+        self.incompleteDownloadDirectory = downloadDirectory.appendingPathComponent("Incomplete")
+    }
+}
+
+/// Returns tags only for paths explicitly registered, so tests can model a
+/// mixed folder: tagged tracks, an untagged track, and cover art.
+final class MockMetadataReader: MetadataReading, @unchecked Sendable {
+    var metadata: [URL: AudioFileMetadata] = [:]
+
+    func extractAudioMetadata(from url: URL) async -> AudioFileMetadata? { metadata[url] }
+    func extractArtwork(from url: URL) async -> Data? { nil }
+    func applyArtworkAsFolderIcon(for directory: URL) async -> Bool { false }
+}

--- a/seeleseekTests/TransferHistoryPathTests.swift
+++ b/seeleseekTests/TransferHistoryPathTests.swift
@@ -9,6 +9,14 @@ import Foundation
 @Suite("TransferHistoryItem path resolution")
 struct TransferHistoryPathTests {
 
+    /// Stand-in for the live settings the history row passes in.
+    private let downloads = SettingsState.defaultDownloadLocation
+    private let template = DownloadFolderFormat.usernameAndPath.template
+
+    private func resolved(_ item: TransferHistoryItem) -> URL? {
+        item.resolvedLocalPath(downloadDirectory: downloads, template: template)
+    }
+
     private func item(isDownload: Bool, localPath: URL?) -> TransferHistoryItem {
         TransferHistoryItem(
             id: UUID().uuidString,
@@ -26,8 +34,7 @@ struct TransferHistoryPathTests {
     @Test("Upload with no stored path resolves to nil, never an inferred download path")
     func uploadWithoutPathResolvesNil() {
         let upload = item(isDownload: false, localPath: nil)
-        #expect(upload.resolvedLocalPath == nil)
-        #expect(upload.fileExists == false)
+        #expect(resolved(upload) == nil)
     }
 
     @Test("Upload with a stored path that exists on disk resolves to it")
@@ -38,15 +45,14 @@ struct TransferHistoryPathTests {
         defer { try? FileManager.default.removeItem(at: file) }
 
         let upload = item(isDownload: false, localPath: file)
-        #expect(upload.resolvedLocalPath == file)
-        #expect(upload.fileExists == true)
+        #expect(resolved(upload) == file)
     }
 
     @Test("Upload with a stored path that no longer exists resolves to nil")
     func uploadWithDeadPathResolvesNil() {
         let dead = URL(fileURLWithPath: "/nonexistent/\(UUID().uuidString).flac")
         let upload = item(isDownload: false, localPath: dead)
-        #expect(upload.resolvedLocalPath == nil)
+        #expect(resolved(upload) == nil)
     }
 
     @Test("Download with no stored path may still infer, but never crashes")
@@ -54,6 +60,6 @@ struct TransferHistoryPathTests {
         let download = item(isDownload: true, localPath: nil)
         // The inferred path only resolves when the file exists on disk;
         // with a fabricated filename it must be nil, not a bogus URL.
-        #expect(download.resolvedLocalPath == nil)
+        #expect(resolved(download) == nil)
     }
 }

--- a/site/src/content/docs/guide/transfers.md
+++ b/site/src/content/docs/guide/transfers.md
@@ -79,7 +79,7 @@ Configure downloads in **Settings > General > Downloads**:
 
 ### Download Location
 
-Set the folder for completed files. The default is `~/Downloads/seeleseek/`.
+Set the folder for completed files. The default is `~/Downloads/SeeleSeek/`.
 
 A different folder holds the **incomplete files**. The app keeps a download there until the download is complete.
 
@@ -89,13 +89,16 @@ Select the structure for downloaded files:
 
 | Template | Example |
 |----------|---------|
+| Folder (default) | `Album/track.flac` |
 | Username / Full Path | `alice/Music/Artist/Album/track.flac` |
 | Full Path | `Music/Artist/Album/track.flac` |
 | Artist - Album | `Artist - Album/track.flac` |
 | Filename Only | `track.flac` |
 | Custom | A template that you make with tokens |
 
-These tokens are available for custom templates: `{username}`, `{folders}`, `{artist}`, `{album}`, `{filename}`.
+These tokens are available for custom templates: `{username}`, `{folder}`, `{full-path}`, `{artist}`, `{album}`, `{filename}`. The `{folder}` token is the one folder that contains the file. The `{full-path}` token is all the folders of the path on the other user's computer. The older name `{folders}` continues to operate and is equivalent to `{full-path}`.
+
+The **Artist - Album** template, and custom templates with `{artist}` or `{album}`, read the tags of the file. Files that have no tags, such as cover images, go into the same folder as the other files from that download. This keeps one shared folder together in one destination folder.
 
 ### Transfer Slots
 


### PR DESCRIPTION
### Description

This PR introduces significant improvements to the download organization logic in `DownloadManager`, adding robust support for tag-based destination templates and improving testability. The main changes revolve around how completed downloads are organized, how download paths are computed, and how the system manages folder destinations for files with and without audio metadata tags.

**Download organization and path computation improvements:**

* Added a mechanism to consistently organize completed downloads into tag-derived directories when templates use `{artist}` or `{album}` tokens, ensuring all files from the same source folder end up together once a tagged file claims the directory. This includes new logic for tracking pending files and relocating them once the final destination is determined. [[1]](diffhunk://#diff-473413f7f7c0b9edac4781f0bf57f99ae1309950eb2d67ce1c095e6485308d58R64-R79) [[2]](diffhunk://#diff-473413f7f7c0b9edac4781f0bf57f99ae1309950eb2d67ce1c095e6485308d58L1707-R1935)
* Refactored the computation of download and incomplete paths to use a shared, public `destinationURL` and `resolveDownloadPath` method, with improved token substitution that supports both legacy and new template tokens (e.g., `{folders}` and `{full-path}`). [[1]](diffhunk://#diff-473413f7f7c0b9edac4781f0bf57f99ae1309950eb2d67ce1c095e6485308d58L1391-R1460) [[2]](diffhunk://#diff-473413f7f7c0b9edac4781f0bf57f99ae1309950eb2d67ce1c095e6485308d58R1555-R1579) [[3]](diffhunk://#diff-473413f7f7c0b9edac4781f0bf57f99ae1309950eb2d67ce1c095e6485308d58L1554-R1624) [[4]](diffhunk://#diff-473413f7f7c0b9edac4781f0bf57f99ae1309950eb2d67ce1c095e6485308d58R1636-R1654)
* Added a public `downloadDirectory` property to the `DownloadSettingsProviding` protocol, allowing the download directory to be customized and accessed consistently throughout the codebase.
* Improved directory creation and cleanup logic, including tracking the last created download directory to avoid redundant syscalls and a new method to recursively prune empty directories after file moves. [[1]](diffhunk://#diff-473413f7f7c0b9edac4781f0bf57f99ae1309950eb2d67ce1c095e6485308d58R1383-R1394) [[2]](diffhunk://#diff-473413f7f7c0b9edac4781f0bf57f99ae1309950eb2d67ce1c095e6485308d58L1707-R1935)

**Testability enhancements:**

* Added several internal methods and properties to facilitate unit testing, such as `_setSettingsForTest`, `_setMetadataReaderForTest`, and `_pendingFolderJoinCount`, allowing tests to inject dependencies and verify internal state.

**Other notable changes:**

* Changed folder artwork application to occur after completion and only when not using a tag-based template, preventing premature artwork assignment before files are organized. [[1]](diffhunk://#diff-473413f7f7c0b9edac4781f0bf57f99ae1309950eb2d67ce1c095e6485308d58L1012-R1028) [[2]](diffhunk://#diff-473413f7f7c0b9edac4781f0bf57f99ae1309950eb2d67ce1c095e6485308d58L1951-R2103) [[3]](diffhunk://#diff-473413f7f7c0b9edac4781f0bf57f99ae1309950eb2d67ce1c095e6485308d58L1707-R1935)

These changes collectively make download organization more robust, especially for music collections with inconsistent or missing tags, and lay the groundwork for more flexible and testable file management.

Closes #75  #76  #77 

<!--
### Future work
A place to describe changes that can or will be done in follow-up PRs
-->

### How to test

- Ensure all checks pass

### Author checklist

This PR:

- [x] Satisfies a goal that is specific & clearly motivated
- [x] Adds value in isolation (whether user-facing or sustainability-related)
- [x] Contains a concise & easy-to-understand title + description
- [x] Adheres to [SRP](https://en.wikipedia.org/wiki/Single-responsibility_principle) by default
- [x] Presents the best possible implementation to meet its goal, given constraints at hand
