### PR TITLE
reduce port collision in testing

### DIFF
--- a/seeleseekTests/NetworkTests.swift
+++ b/seeleseekTests/NetworkTests.swift
@@ -107,14 +107,27 @@ struct NetworkTests {
         #expect(data[3] == 0x01)
     }
 
-    /// Random port in a high-entropy range that production code never uses.
-    /// Concurrent tests stepping on each other across the fixed 2234-2240
-    /// production range was a long-standing flake source; randomizing here
-    /// gives each test its own pair of consecutive ports.
+    /// Random port in a range production code never uses. Concurrent tests
+    /// stepping on each other across the fixed 2234-2240 production range was
+    /// a long-standing flake source; randomizing gives each test its own pair
+    /// of consecutive ports.
+    ///
+    /// Must stay below `net.inet.ip.portrange.first` (49152 on macOS), or the
+    /// OS can hand the same port to a sibling test's outbound socket and the
+    /// bind fails. Even, so `port + 1` (the obfuscated pair) stays in band.
     static func randomTestPort() -> UInt16 {
-        // Keep even so `port + 1` (the obfuscated pair) stays in the same
-        // band. Upper bound leaves headroom below the ephemeral-port ceiling.
-        UInt16(Int.random(in: 40000...59998) & ~1)
+        UInt16(Int.random(in: 20000...39998) & ~1)
+    }
+
+    /// Bind with a fresh port on collision: even inside a private band another
+    /// process on a busy CI runner can hold the pair we happened to draw.
+    static func startListenerOnFreePort(_ listener: ListenerService) async throws -> (port: UInt16, obfuscatedPort: UInt16) {
+        for _ in 0..<9 {
+            if let ports = try? await listener.start(preferredPort: randomTestPort(), fallbackToDefaultRange: false) {
+                return ports
+            }
+        }
+        return try await listener.start(preferredPort: randomTestPort(), fallbackToDefaultRange: false)
     }
 
     // MARK: - Local Loopback Connection Tests
@@ -123,14 +136,11 @@ struct NetworkTests {
     func listenerStartsOnAvailablePort() async throws {
         let listener = ListenerService()
 
-        // High-entropy random port keeps concurrent test suites off the
-        // production 2234-2240 range. fallback=false turns a collision into
-        // a clean error instead of falling through to that fixed range and
-        // contending with other tests.
-        let preferred = Self.randomTestPort()
-        let ports = try await listener.start(preferredPort: preferred, fallbackToDefaultRange: false)
+        // fallback=false keeps a collision from silently falling through to
+        // the production 2234-2240 range and contending with other tests.
+        let ports = try await Self.startListenerOnFreePort(listener)
 
-        #expect(ports.port == preferred, "Should bind to the preferred port")
+        #expect(ports.port >= 20000, "Should bind outside the production range")
         #expect(ports.obfuscatedPort == ports.port + 1, "Obfuscated port should be port + 1")
 
         await listener.stop()
@@ -148,7 +158,7 @@ struct NetworkTests {
             }
         }
 
-        let ports = try await listener.start(preferredPort: Self.randomTestPort(), fallbackToDefaultRange: false)
+        let ports = try await Self.startListenerOnFreePort(listener)
 
         // Connect to ourselves
         let peerInfo = PeerConnection.PeerInfo(username: "localtest", ip: "127.0.0.1", port: Int(ports.port))
@@ -170,7 +180,7 @@ struct NetworkTests {
         let listener = ListenerService()
         var receivedData: Data?
 
-        let ports = try await listener.start(preferredPort: Self.randomTestPort(), fallbackToDefaultRange: false)
+        let ports = try await Self.startListenerOnFreePort(listener)
 
         await confirmation("Receive PierceFirewall") { confirm in
             Task {


### PR DESCRIPTION
### Description

This PR improves the reliability of network-related tests by reducing port collision issues and making test setup more robust. The main changes focus on randomizing the port selection to avoid conflicts and adding logic to handle port binding collisions gracefully.

**Test port selection and listener startup improvements:**

* The `randomTestPort` method now selects ports from a lower, safer range (`20000...39998`) to avoid conflicts with ephemeral ports used by the OS, and maintains the even/odd pairing for obfuscated ports.
* Added a new `startListenerOnFreePort` helper that retries binding the listener on a fresh random port up to 9 times to avoid collisions, improving test stability on busy CI runners.

**Test refactoring for reliability:**

* Updated all test cases to use the new `startListenerOnFreePort` helper instead of directly calling `listener.start` with a random port, reducing the likelihood of port conflicts during parallel test runs. [[1]](diffhunk://#diff-0475f42ad5ec6d8b2f7afb154311042e8d80773bb135fc931d9003f367bf3263L126-R143) [[2]](diffhunk://#diff-0475f42ad5ec6d8b2f7afb154311042e8d80773bb135fc931d9003f367bf3263L151-R161) [[3]](diffhunk://#diff-0475f42ad5ec6d8b2f7afb154311042e8d80773bb135fc931d9003f367bf3263L173-R183)
* Adjusted test assertions to check that the bound port is outside the production range, reflecting the new port selection logic.

These changes should make the network tests more reliable, especially in concurrent or CI environments.

<!--
### Future work
A place to describe changes that can or will be done in follow-up PRs
-->

### How to test

- Ensure all checks pass

### Author checklist

This PR:

- [x] Satisfies a goal that is specific & clearly motivated
- [x] Adds value in isolation (whether user-facing or sustainability-related)
- [x] Contains a concise & easy-to-understand title + description
- [x] Adheres to [SRP](https://en.wikipedia.org/wiki/Single-responsibility_principle) by default
- [x] Presents the best possible implementation to meet its goal, given constraints at hand
