### PR TITLE
fix browsing users with many files 

### DIFF
--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Models/SharedFile.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Models/SharedFile.swift
@@ -82,78 +82,65 @@ public struct SharedFile: Identifiable, Hashable, Sendable {
     /// Build a hierarchical tree from flat file paths
     /// Input: Flat array of files with paths like "@@share\Folder\Subfolder\file.mp3"
     /// Output: Tree structure with directories containing children
+    ///
+    /// Adjacency is precomputed in the discovery pass. Mega-shares are real
+    /// (250k+ folders, 2M+ files seen in the field), so anything that scans
+    /// all folders per folder is minutes of CPU, not a constant factor.
     public nonisolated static func buildTree(from flatFiles: [SharedFile]) -> [SharedFile] {
-        // Use a dictionary to track folders by their full path
-        var folderMap: [String: (id: UUID, children: [SharedFile])] = [:]
+        var folderIDs: [String: UUID] = [:]
+        var filesByFolder: [String: [SharedFile]] = [:]
+        var subfolders: [String: [String]] = [:]
         var rootFolders: [String] = []
 
         for file in flatFiles {
             let pathComponents = file.filename.split(separator: "\\").map(String.init)
             guard !pathComponents.isEmpty else { continue }
 
-            // Build folder hierarchy
+            guard pathComponents.count > 1 else {
+                // File at root level (unusual but handle it): keep the
+                // longstanding behavior of surfacing it as an empty folder.
+                if folderIDs[file.filename] == nil {
+                    folderIDs[file.filename] = UUID()
+                    rootFolders.append(file.filename)
+                }
+                continue
+            }
+
+            // Register any not-yet-seen folders along the path
             var currentPath = ""
             for (index, component) in pathComponents.dropLast().enumerated() {
-                _ = currentPath
+                let parentPath = currentPath
                 currentPath = currentPath.isEmpty ? component : "\(currentPath)\\\(component)"
 
-                if folderMap[currentPath] == nil {
-                    folderMap[currentPath] = (id: UUID(), children: [])
-
-                    // Track root folders
-                    if index == 0 && !rootFolders.contains(currentPath) {
+                if folderIDs[currentPath] == nil {
+                    folderIDs[currentPath] = UUID()
+                    if index == 0 {
                         rootFolders.append(currentPath)
+                    } else {
+                        subfolders[parentPath, default: []].append(currentPath)
                     }
                 }
             }
-
-            // Add file to its parent folder
-            if pathComponents.count > 1 {
-                let parentPath = pathComponents.dropLast().joined(separator: "\\")
-                folderMap[parentPath]?.children.append(file)
-            } else {
-                // File at root level (unusual but handle it)
-                if !rootFolders.contains(file.filename) {
-                    rootFolders.append(file.filename)
-                    folderMap[file.filename] = (id: UUID(), children: [])
-                }
-            }
+            filesByFolder[currentPath, default: []].append(file)
         }
 
-        // Build the tree recursively
-        func buildFolder(path: String, name: String) -> SharedFile {
-            guard let folderData = folderMap[path] else {
-                return SharedFile(filename: path, isDirectory: true)
-            }
+        func buildFolder(path: String) -> SharedFile {
+            var children = (subfolders[path] ?? []).map(buildFolder)
+            children.append(contentsOf: filesByFolder[path] ?? [])
 
-            // Find child folders
-            var children: [SharedFile] = []
-
-            // Add subfolders
-            for (childPath, _) in folderMap {
-                // Check if childPath is a direct child of path
-                if childPath.hasPrefix(path + "\\") {
-                    let remaining = String(childPath.dropFirst(path.count + 1))
-                    if !remaining.contains("\\") {
-                        // Direct child folder
-                        let childName = remaining
-                        children.append(buildFolder(path: childPath, name: childName))
+            // Sort: folders first, then files, alphabetically. Keys are
+            // cached — displayName re-splits the path per call, which the
+            // comparator would otherwise do millions of times.
+            children = children
+                .map { (file: $0, key: $0.displayName) }
+                .sorted { a, b in
+                    if a.file.isDirectory != b.file.isDirectory {
+                        return a.file.isDirectory
                     }
+                    return a.key.localizedCaseInsensitiveCompare(b.key) == .orderedAscending
                 }
-            }
+                .map(\.file)
 
-            // Add files (already in folderData.children)
-            children.append(contentsOf: folderData.children)
-
-            // Sort: folders first, then files, alphabetically
-            children.sort { a, b in
-                if a.isDirectory != b.isDirectory {
-                    return a.isDirectory
-                }
-                return a.displayName.localizedCaseInsensitiveCompare(b.displayName) == .orderedAscending
-            }
-
-            // Calculate total size and file count for folder
             let totalSize = children.reduce(0) { $0 + $1.size }
             let totalFiles = children.reduce(0) { $0 + ($1.isDirectory ? $1.fileCount : 1) }
 
@@ -166,7 +153,7 @@ public struct SharedFile: Identifiable, Hashable, Sendable {
             let isFolderPrivate = !children.isEmpty && children.allSatisfy { $0.isPrivate }
 
             return SharedFile(
-                id: folderData.id,
+                id: folderIDs[path] ?? UUID(),
                 filename: path,
                 size: totalSize,
                 isDirectory: true,
@@ -176,13 +163,6 @@ public struct SharedFile: Identifiable, Hashable, Sendable {
             )
         }
 
-        // Build root folders
-        var result: [SharedFile] = []
-        for rootPath in rootFolders.sorted() {
-            let name = rootPath.split(separator: "\\").last.map(String.init) ?? rootPath
-            result.append(buildFolder(path: rootPath, name: name))
-        }
-
-        return result
+        return rootFolders.sorted().map(buildFolder)
     }
 }

--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Models/SharedFile.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Models/SharedFile.swift
@@ -62,6 +62,18 @@ public struct SharedFile: Identifiable, Hashable, Sendable {
     public var isArchiveFile: Bool { FileTypes.isArchive(fileExtension) }
     public var isLossless: Bool { FileTypes.isLossless(fileExtension) }
 
+    /// The one formula for a folder's aggregates: directories contribute
+    /// their cached counts, files contribute themselves. Every producer of
+    /// `fileCount` (tree build, cache rehydration) must use these — a
+    /// producer that forgets makes cache-loaded counts diverge from fresh.
+    public nonisolated static func aggregateFileCount(of children: [SharedFile]) -> Int {
+        children.reduce(0) { $0 + ($1.isDirectory ? $1.fileCount : 1) }
+    }
+
+    public nonisolated static func aggregateSize(of children: [SharedFile]) -> UInt64 {
+        children.reduce(0) { $0 + $1.size }
+    }
+
     /// Recursively collect all non-directory files from a tree
     public static func collectAllFiles(in files: [SharedFile]) -> [SharedFile] {
         var result: [SharedFile] = []
@@ -83,9 +95,8 @@ public struct SharedFile: Identifiable, Hashable, Sendable {
     /// Input: Flat array of files with paths like "@@share\Folder\Subfolder\file.mp3"
     /// Output: Tree structure with directories containing children
     ///
-    /// Adjacency is precomputed in the discovery pass. Mega-shares are real
-    /// (250k+ folders, 2M+ files seen in the field), so anything that scans
-    /// all folders per folder is minutes of CPU, not a constant factor.
+    /// Mega-shares reach 250k+ folders / 2M+ files — keep this linear, no
+    /// per-folder scans.
     public nonisolated static func buildTree(from flatFiles: [SharedFile]) -> [SharedFile] {
         var folderIDs: [String: UUID] = [:]
         var filesByFolder: [String: [SharedFile]] = [:]
@@ -93,12 +104,22 @@ public struct SharedFile: Identifiable, Hashable, Sendable {
         var rootFolders: [String] = []
 
         for file in flatFiles {
+            // Siblings share a folder, so most files can skip the
+            // per-component walk: a registered parent implies its whole
+            // ancestor chain is registered.
+            if let cut = file.filename.lastIndex(of: "\\") {
+                let parentPath = String(file.filename[..<cut])
+                if folderIDs[parentPath] != nil {
+                    filesByFolder[parentPath, default: []].append(file)
+                    continue
+                }
+            }
+
             let pathComponents = file.filename.split(separator: "\\").map(String.init)
             guard !pathComponents.isEmpty else { continue }
 
             guard pathComponents.count > 1 else {
-                // File at root level (unusual but handle it): keep the
-                // longstanding behavior of surfacing it as an empty folder.
+                // Root-level file: surface as an empty folder (legacy behavior).
                 if folderIDs[file.filename] == nil {
                     folderIDs[file.filename] = UUID()
                     rootFolders.append(file.filename)
@@ -128,9 +149,8 @@ public struct SharedFile: Identifiable, Hashable, Sendable {
             var children = (subfolders[path] ?? []).map(buildFolder)
             children.append(contentsOf: filesByFolder[path] ?? [])
 
-            // Sort: folders first, then files, alphabetically. Keys are
-            // cached — displayName re-splits the path per call, which the
-            // comparator would otherwise do millions of times.
+            // Folders first, then files, alphabetically. Sort keys
+            // precomputed: displayName re-splits the path per call.
             children = children
                 .map { (file: $0, key: $0.displayName) }
                 .sorted { a, b in
@@ -141,8 +161,8 @@ public struct SharedFile: Identifiable, Hashable, Sendable {
                 }
                 .map(\.file)
 
-            let totalSize = children.reduce(0) { $0 + $1.size }
-            let totalFiles = children.reduce(0) { $0 + ($1.isDirectory ? $1.fileCount : 1) }
+            let totalSize = aggregateSize(of: children)
+            let totalFiles = aggregateFileCount(of: children)
 
             // A folder is considered private when every descendant is
             // private — i.e. the peer marked the whole folder buddy-only

--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Models/UserShares.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Models/UserShares.swift
@@ -17,50 +17,44 @@ public struct UserShares: Identifiable, Sendable {
         username: String,
         folders: [SharedFile] = [],
         isLoading: Bool = true,
-        error: String? = nil
+        error: String? = nil,
+        totalFiles: Int? = nil,
+        totalSize: UInt64? = nil
     ) {
         self.id = id
         self.username = username
         self.folders = folders
         self.isLoading = isLoading
         self.error = error
+        self.cachedTotalFiles = totalFiles
+        self.cachedTotalSize = totalSize
     }
 
+    // These getters run inside UI bodies (tab labels, browse headers) on
+    // every render, so they must never walk the tree: profiling caught the
+    // old recursive fallback spending seconds per render on a 2M-node share.
+    // Root nodes carry aggregates from tree building, making the fallback
+    // O(roots).
+
     public var totalFiles: Int {
-        cachedTotalFiles ?? countFiles(in: folders)
+        cachedTotalFiles ?? Self.rootFileCount(of: folders)
     }
 
     public var totalSize: UInt64 {
-        cachedTotalSize ?? sumSize(in: folders)
+        cachedTotalSize ?? Self.rootSize(of: folders)
     }
 
-    /// Compute and cache stats (call this after building tree, off main thread)
+    /// Cache the aggregates so even O(roots) is paid once.
     public nonisolated mutating func computeStats() {
-        cachedTotalFiles = countFiles(in: folders)
-        cachedTotalSize = sumSize(in: folders)
+        cachedTotalFiles = Self.rootFileCount(of: folders)
+        cachedTotalSize = Self.rootSize(of: folders)
     }
 
-    private nonisolated func countFiles(in files: [SharedFile]) -> Int {
-        var count = 0
-        for file in files {
-            if file.isDirectory, let children = file.children {
-                count += countFiles(in: children)
-            } else if !file.isDirectory {
-                count += 1
-            }
-        }
-        return count
+    private nonisolated static func rootFileCount(of folders: [SharedFile]) -> Int {
+        folders.reduce(0) { $0 + ($1.isDirectory ? $1.fileCount : 1) }
     }
 
-    private nonisolated func sumSize(in files: [SharedFile]) -> UInt64 {
-        var total: UInt64 = 0
-        for file in files {
-            if file.isDirectory, let children = file.children {
-                total += sumSize(in: children)
-            } else {
-                total += file.size
-            }
-        }
-        return total
+    private nonisolated static func rootSize(of folders: [SharedFile]) -> UInt64 {
+        folders.reduce(0) { $0 + $1.size }
     }
 }

--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Models/UserShares.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Models/UserShares.swift
@@ -30,31 +30,19 @@ public struct UserShares: Identifiable, Sendable {
         self.cachedTotalSize = totalSize
     }
 
-    // These getters run inside UI bodies (tab labels, browse headers) on
-    // every render, so they must never walk the tree: profiling caught the
-    // old recursive fallback spending seconds per render on a 2M-node share.
-    // Root nodes carry aggregates from tree building, making the fallback
-    // O(roots).
+    // Run inside UI bodies on every render — must stay O(roots), never walk
+    // the tree.
 
     public var totalFiles: Int {
-        cachedTotalFiles ?? Self.rootFileCount(of: folders)
+        cachedTotalFiles ?? SharedFile.aggregateFileCount(of: folders)
     }
 
     public var totalSize: UInt64 {
-        cachedTotalSize ?? Self.rootSize(of: folders)
+        cachedTotalSize ?? SharedFile.aggregateSize(of: folders)
     }
 
-    /// Cache the aggregates so even O(roots) is paid once.
     public nonisolated mutating func computeStats() {
-        cachedTotalFiles = Self.rootFileCount(of: folders)
-        cachedTotalSize = Self.rootSize(of: folders)
-    }
-
-    private nonisolated static func rootFileCount(of folders: [SharedFile]) -> Int {
-        folders.reduce(0) { $0 + ($1.isDirectory ? $1.fileCount : 1) }
-    }
-
-    private nonisolated static func rootSize(of folders: [SharedFile]) -> UInt64 {
-        folders.reduce(0) { $0 + $1.size }
+        cachedTotalFiles = SharedFile.aggregateFileCount(of: folders)
+        cachedTotalSize = SharedFile.aggregateSize(of: folders)
     }
 }

--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Connections/PeerConnection.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Connections/PeerConnection.swift
@@ -1,7 +1,6 @@
 import Foundation
 import Network
 import os
-import Compression
 import Synchronization
 
 /// Manages a single peer-to-peer connection
@@ -1743,7 +1742,7 @@ public actor PeerConnection {
         // Shares are zlib compressed per protocol spec.
         let decompressed: Data
         do {
-            decompressed = try decompressZlib(data)
+            decompressed = try ZlibDecompression.decompress(data)
             logger.debug("[\(self.peerInfo.username)] Decompressed shares: \(data.count) -> \(decompressed.count) bytes")
         } catch {
             logger.error("[\(self.peerInfo.username)] Failed to decompress shares: \(error)")
@@ -1779,7 +1778,7 @@ public actor PeerConnection {
         var candidatePayloads: [(data: Data, wasCompressed: Bool)] = [(data, false)]
         if data.count > 4 {
             do {
-                let decompressed = try decompressZlib(data)
+                let decompressed = try ZlibDecompression.decompress(data)
                 logger.debug("[\(self.peerInfo.username)] Decompressed search reply from \(data.count) to \(decompressed.count) bytes")
                 candidatePayloads.insert((decompressed, true), at: 0)
             } catch {
@@ -1945,7 +1944,7 @@ public actor PeerConnection {
 
     private func handleFolderContentsReply(_ data: Data) async {
         // Folder contents are zlib compressed
-        guard let decompressed = try? decompressZlib(data) else {
+        guard let decompressed = try? ZlibDecompression.decompress(data) else {
             logger.error("Failed to decompress folder contents")
             return
         }
@@ -1990,115 +1989,6 @@ public actor PeerConnection {
         touchLastActivity()
     }
 
-    // MARK: - Zlib Decompression
-
-    private func decompressZlib(_ data: Data) throws -> Data {
-        // SoulSeek uses standard zlib format (RFC 1950):
-        // - 2-byte header
-        // - DEFLATE compressed data
-        // - 4-byte Adler-32 checksum
-        //
-        // Apple's COMPRESSION_ZLIB expects raw DEFLATE (RFC 1951) without header/footer.
-        // We need to strip the 2-byte header and 4-byte footer.
-
-        guard data.count > 6 else {
-            logger.debug("Decompression: data too short (\(data.count) bytes)")
-            throw PeerError.decompressionFailed
-        }
-
-        // Verify zlib header (first byte should have compression method 8 = deflate)
-        let cmf = data[data.startIndex]
-        let compressionMethod = cmf & 0x0F
-        #if DEBUG
-        let flg = data[data.startIndex + 1]
-        logger.debug("Decompression: CMF=0x\(String(format: "%02x", cmf)) FLG=0x\(String(format: "%02x", flg)) method=\(compressionMethod)")
-        #endif
-
-        guard compressionMethod == 8 else {
-            logger.debug("Not zlib format (method != 8), trying raw deflate")
-            // Not zlib format, try raw deflate
-            return try decompressRawDeflate(data)
-        }
-
-        // Strip zlib header (2 bytes) and Adler-32 checksum (4 bytes)
-        let deflateData = data.dropFirst(2).dropLast(4)
-        logger.debug("Stripped zlib header/footer: \(data.count) -> \(deflateData.count) bytes")
-
-        let result = try decompressRawDeflate(Data(deflateData))
-        #if DEBUG
-        let preview = result.prefix(20).map { String(format: "%02x", $0) }.joined(separator: " ")
-        logger.debug("Decompressed: \(deflateData.count) -> \(result.count) bytes, preview: \(preview)")
-        #endif
-
-        return result
-    }
-
-    private func decompressRawDeflate(_ data: Data) throws -> Data {
-        // SECURITY: Maximum decompressed size to prevent decompression bombs
-        let maxDecompressedSize = 50 * 1024 * 1024  // 50MB max
-        // SECURITY: Maximum compression ratio (normal zlib is ~10-50x, >1000x is suspicious)
-        let maxCompressionRatio = 1000
-
-        let decompressed = try data.withUnsafeBytes { sourceBuffer -> Data in
-            let sourceSize = data.count
-            guard let baseAddress = sourceBuffer.bindMemory(to: UInt8.self).baseAddress else {
-                throw PeerError.decompressionFailed
-            }
-
-            // Start with a reasonable estimate, expand if needed
-            var destinationSize = min(max(sourceSize * 20, 65536), maxDecompressedSize)
-            var destinationBuffer = [UInt8](repeating: 0, count: destinationSize)
-
-            var decodedSize = compression_decode_buffer(
-                &destinationBuffer,
-                destinationSize,
-                baseAddress,
-                sourceSize,
-                nil,
-                COMPRESSION_ZLIB
-            )
-
-            // If output buffer was too small, try with larger buffer (but capped)
-            if decodedSize == 0 || decodedSize == destinationSize {
-                destinationSize = min(sourceSize * 100, maxDecompressedSize)
-                // SECURITY: Check if we've hit the limit
-                guard destinationSize <= maxDecompressedSize else {
-                    logger.warning("SECURITY: Decompression size limit exceeded")
-                    throw PeerError.decompressionFailed
-                }
-                destinationBuffer = [UInt8](repeating: 0, count: destinationSize)
-                decodedSize = compression_decode_buffer(
-                    &destinationBuffer,
-                    destinationSize,
-                    baseAddress,
-                    sourceSize,
-                    nil,
-                    COMPRESSION_ZLIB
-                )
-            }
-
-            guard decodedSize > 0 else {
-                throw PeerError.decompressionFailed
-            }
-
-            // SECURITY: Check compression ratio
-            let compressionRatio = decodedSize / max(sourceSize, 1)
-            if compressionRatio > maxCompressionRatio {
-                logger.warning("SECURITY: Suspicious compression ratio \(compressionRatio):1")
-                throw PeerError.decompressionFailed
-            }
-
-            // SECURITY: Final size check
-            guard decodedSize <= maxDecompressedSize else {
-                logger.warning("SECURITY: Decompressed size \(decodedSize) exceeds limit \(maxDecompressedSize)")
-                throw PeerError.decompressionFailed
-            }
-
-            return Data(destinationBuffer.prefix(decodedSize))
-        }
-
-        return decompressed
-    }
 }
 
 // MARK: - Types

--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Protocol/Decompression.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Protocol/Decompression.swift
@@ -14,8 +14,11 @@ public enum DecompressionError: Error {
 /// Standalone zlib/deflate decompression utility.
 /// Mirrors the logic in PeerConnection but is testable in isolation.
 public enum ZlibDecompression {
-    /// Maximum decompressed output size (50 MB)
-    nonisolated static let maxDecompressedSize = 50 * 1024 * 1024
+    /// Maximum decompressed output size. Real share lists from large sharers
+    /// exceed 50 MiB decompressed (seen in the field at ~1.04:1 ratio), so
+    /// this bounds hostile bombs, not legitimate traffic — keep it well above
+    /// the 150 MiB framed-message receive cap times typical list ratios.
+    nonisolated static let maxDecompressedSize = 256 * 1024 * 1024
     /// Maximum allowed compression ratio before flagging as suspicious
     nonisolated static let maxCompressionRatio = 1000
 

--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Protocol/Decompression.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Protocol/Decompression.swift
@@ -14,10 +14,8 @@ public enum DecompressionError: Error {
 /// Standalone zlib/deflate decompression utility.
 /// Mirrors the logic in PeerConnection but is testable in isolation.
 public enum ZlibDecompression {
-    /// Maximum decompressed output size. Real share lists from large sharers
-    /// exceed 50 MiB decompressed (seen in the field at ~1.04:1 ratio), so
-    /// this bounds hostile bombs, not legitimate traffic — keep it well above
-    /// the 150 MiB framed-message receive cap times typical list ratios.
+    /// Bounds hostile bombs, not legitimate traffic: real share lists exceed
+    /// 50 MiB decompressed, so stay well above the 150 MiB receive cap.
     nonisolated static let maxDecompressedSize = 256 * 1024 * 1024
     /// Maximum allowed compression ratio before flagging as suspicious
     nonisolated static let maxCompressionRatio = 1000
@@ -58,21 +56,25 @@ public enum ZlibDecompression {
 
     /// RFC 1950 Adler-32, with the standard deferred-modulo chunking so the
     /// hot loop is pure adds (5552 is the largest n with no UInt32 overflow).
+    /// Raw-pointer loop: Data's byte iterator is several times slower, which
+    /// matters at share-list sizes.
     nonisolated static func adler32(_ data: Data) -> UInt32 {
-        var a: UInt32 = 1
-        var b: UInt32 = 0
-        var index = data.startIndex
-        while index < data.endIndex {
-            let chunkEnd = data.index(index, offsetBy: 5552, limitedBy: data.endIndex) ?? data.endIndex
-            for byte in data[index..<chunkEnd] {
-                a &+= UInt32(byte)
-                b &+= a
+        data.withUnsafeBytes { buffer in
+            var a: UInt32 = 1
+            var b: UInt32 = 0
+            var index = 0
+            while index < buffer.count {
+                let chunkEnd = min(index + 5552, buffer.count)
+                while index < chunkEnd {
+                    a &+= UInt32(buffer[index])
+                    b &+= a
+                    index += 1
+                }
+                a %= 65521
+                b %= 65521
             }
-            a %= 65521
-            b %= 65521
-            index = chunkEnd
+            return (b << 16) | a
         }
-        return (b << 16) | a
     }
 
     /// Decompress raw DEFLATE data (RFC 1951) using Apple's Compression framework.
@@ -88,7 +90,12 @@ public enum ZlibDecompression {
             // Grow and retry until the output no longer fills the buffer;
             // a result that still fills a max-size buffer is truncation, not
             // success, so it must throw rather than return partial data.
-            var destinationSize = min(max(sourceSize * 20, 65536), maxDecompressedSize)
+            //
+            // Large inputs (share lists) inflate at ~1-4:1, so 20x would just
+            // zero a 256 MiB scratch buffer; the grow loop covers the rare
+            // denser payload.
+            let multiplier = sourceSize >= 8 * 1024 * 1024 ? 4 : 20
+            var destinationSize = min(max(sourceSize * multiplier, 65536), maxDecompressedSize)
             while true {
                 var destinationBuffer = [UInt8](repeating: 0, count: destinationSize)
                 let decodedSize = compression_decode_buffer(

--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Protocol/MessageParser.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Protocol/MessageParser.swift
@@ -14,12 +14,10 @@ public enum MessageParser {
     /// Maximum number of attributes per file
     nonisolated static let maxAttributeCount: UInt32 = 100
 
-    /// Count guard for size-bounded lists (share lists, folder contents),
-    /// where a fixed cap rejects real mega-sharers — 250k+ directories seen
-    /// in the field. Every entry consumes at least `minBytesPerItem`, so any
-    /// count the remaining payload cannot hold is a lie; loop work stays
-    /// proportional to actual data because each iteration's reads fail once
-    /// the payload runs dry.
+    /// Count guard for size-bounded lists (share lists, folder contents) —
+    /// a fixed cap rejects real 250k+-directory shares. Every entry consumes
+    /// at least `minBytesPerItem`, so any count the remaining payload cannot
+    /// hold is a lie.
     private nonisolated static func plausibleItemCount(
         _ count: UInt32, at offset: Int, in data: Data, minBytesPerItem: Int = 8
     ) -> Bool {

--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Protocol/MessageParser.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Network/Protocol/MessageParser.swift
@@ -13,6 +13,18 @@ public enum MessageParser {
     nonisolated static let maxItemCount: UInt32 = 100_000
     /// Maximum number of attributes per file
     nonisolated static let maxAttributeCount: UInt32 = 100
+
+    /// Count guard for size-bounded lists (share lists, folder contents),
+    /// where a fixed cap rejects real mega-sharers — 250k+ directories seen
+    /// in the field. Every entry consumes at least `minBytesPerItem`, so any
+    /// count the remaining payload cannot hold is a lie; loop work stays
+    /// proportional to actual data because each iteration's reads fail once
+    /// the payload runs dry.
+    private nonisolated static func plausibleItemCount(
+        _ count: UInt32, at offset: Int, in data: Data, minBytesPerItem: Int = 8
+    ) -> Bool {
+        count <= UInt32(clamping: (data.count - offset) / minBytesPerItem)
+    }
     /// Maximum message size — large share lists can exceed 10MB compressed.
     public nonisolated static let maxMessageSize: UInt32 = 100_000_000  // 100MB
 
@@ -564,7 +576,7 @@ public enum MessageParser {
         var files: [ShareFileInfo] = []
 
         guard let dirCount = decompressed.readUInt32(at: offset) else { return nil }
-        guard dirCount <= maxItemCount else { return nil }
+        guard plausibleItemCount(dirCount, at: offset + 4, in: decompressed) else { return nil }
         offset += 4
 
         for _ in 0..<dirCount {
@@ -572,7 +584,7 @@ public enum MessageParser {
             offset += dirLen
 
             guard let fileCount = decompressed.readUInt32(at: offset) else { return nil }
-            guard fileCount <= maxItemCount else { return nil }
+            guard plausibleItemCount(fileCount, at: offset + 4, in: decompressed) else { return nil }
             offset += 4
 
             for _ in 0..<fileCount {
@@ -590,14 +602,15 @@ public enum MessageParser {
         // malformed entry stops the WHOLE section — the offset is misaligned
         // past that point, so continuing the outer loop would decode garbage.
         if let privateDirCount = decompressed.readUInt32(at: offset),
-           privateDirCount > 0, privateDirCount <= maxItemCount {
+           privateDirCount > 0, plausibleItemCount(privateDirCount, at: offset + 4, in: decompressed) {
             offset += 4
 
             privateSection: for _ in 0..<privateDirCount {
                 guard let (dirName, dirLen) = decompressed.readString(at: offset) else { break privateSection }
                 offset += dirLen
 
-                guard let fileCount = decompressed.readUInt32(at: offset), fileCount <= maxItemCount else { break privateSection }
+                guard let fileCount = decompressed.readUInt32(at: offset),
+                      plausibleItemCount(fileCount, at: offset + 4, in: decompressed) else { break privateSection }
                 offset += 4
 
                 for _ in 0..<fileCount {
@@ -627,7 +640,7 @@ public enum MessageParser {
         offset += folderLen
 
         guard let folderCount = decompressed.readUInt32(at: offset) else { return nil }
-        guard folderCount <= maxItemCount else { return nil }
+        guard plausibleItemCount(folderCount, at: offset + 4, in: decompressed) else { return nil }
         offset += 4
 
         var files: [ShareFileInfo] = []
@@ -638,7 +651,8 @@ public enum MessageParser {
             guard let (_, dirLen) = decompressed.readString(at: offset) else { break folderScan }
             offset += dirLen
 
-            guard let fileCount = decompressed.readUInt32(at: offset), fileCount <= maxItemCount else { break folderScan }
+            guard let fileCount = decompressed.readUInt32(at: offset),
+                  plausibleItemCount(fileCount, at: offset + 4, in: decompressed) else { break folderScan }
             offset += 4
 
             for _ in 0..<fileCount {

--- a/seeleseek/Database/Records/SharedFileRecord.swift
+++ b/seeleseek/Database/Records/SharedFileRecord.swift
@@ -94,9 +94,12 @@ struct SharedFileRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             childrenByParentId[key]?.sort { $0.sortOrder < $1.sortOrder }
         }
 
-        // Recursively build tree
+        // Recursively build tree. fileCount is not a column — restore the
+        // aggregate here or cache-loaded folders show no counts and
+        // UserShares' O(roots) totals read zeros.
         func buildFile(from record: SharedFileRecord) -> SharedFile {
             let children = childrenByParentId[record.id]?.map { buildFile(from: $0) }
+            let fileCount = children?.reduce(0) { $0 + ($1.isDirectory ? $1.fileCount : 1) } ?? 0
             return SharedFile(
                 id: UUID(uuidString: record.id) ?? UUID(),
                 filename: record.filename,
@@ -105,7 +108,8 @@ struct SharedFileRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
                 duration: record.duration.map { UInt32($0) },
                 isDirectory: record.isDirectory,
                 isPrivate: record.isPrivate,
-                children: children
+                children: children,
+                fileCount: fileCount
             )
         }
 

--- a/seeleseek/Database/Records/SharedFileRecord.swift
+++ b/seeleseek/Database/Records/SharedFileRecord.swift
@@ -79,12 +79,9 @@ struct SharedFileRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
 
     /// Convert flat records to hierarchical SharedFile structure
     static func toSharedFiles(from records: [SharedFileRecord]) -> [SharedFile] {
-        // Build lookup maps
-        var recordsById: [String: SharedFileRecord] = [:]
         var childrenByParentId: [String: [SharedFileRecord]] = [:]
 
         for record in records {
-            recordsById[record.id] = record
             let parentKey = record.parentId ?? "root"
             childrenByParentId[parentKey, default: []].append(record)
         }
@@ -94,12 +91,11 @@ struct SharedFileRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             childrenByParentId[key]?.sort { $0.sortOrder < $1.sortOrder }
         }
 
-        // Recursively build tree. fileCount is not a column — restore the
-        // aggregate here or cache-loaded folders show no counts and
-        // UserShares' O(roots) totals read zeros.
+        // fileCount is not a column — recompute it or cache-loaded totals
+        // read zero.
         func buildFile(from record: SharedFileRecord) -> SharedFile {
             let children = childrenByParentId[record.id]?.map { buildFile(from: $0) }
-            let fileCount = children?.reduce(0) { $0 + ($1.isDirectory ? $1.fileCount : 1) } ?? 0
+            let fileCount = children.map(SharedFile.aggregateFileCount(of:)) ?? 0
             return SharedFile(
                 id: UUID(uuidString: record.id) ?? UUID(),
                 filename: record.filename,

--- a/seeleseek/Database/Records/UserSharesRecord.swift
+++ b/seeleseek/Database/Records/UserSharesRecord.swift
@@ -12,10 +12,7 @@ struct UserSharesRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     var totalFiles: Int
     var totalSize: Int64
 
-    /// Convert database record to domain model (folders loaded separately).
-    /// The stored aggregates must ride along: without them every
-    /// totalFiles/totalSize access on a cache-loaded browse recomputed from
-    /// the tree, in UI render paths.
+    /// Convert database record to domain model (folders loaded separately)
     func toUserShares(folders: [SharedFile] = []) -> UserShares {
         UserShares(
             id: UUID(uuidString: id) ?? UUID(),

--- a/seeleseek/Database/Records/UserSharesRecord.swift
+++ b/seeleseek/Database/Records/UserSharesRecord.swift
@@ -12,14 +12,19 @@ struct UserSharesRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     var totalFiles: Int
     var totalSize: Int64
 
-    /// Convert database record to domain model (folders loaded separately)
+    /// Convert database record to domain model (folders loaded separately).
+    /// The stored aggregates must ride along: without them every
+    /// totalFiles/totalSize access on a cache-loaded browse recomputed from
+    /// the tree, in UI render paths.
     func toUserShares(folders: [SharedFile] = []) -> UserShares {
         UserShares(
             id: UUID(uuidString: id) ?? UUID(),
             username: username,
             folders: folders,
             isLoading: false,
-            error: nil
+            error: nil,
+            totalFiles: totalFiles,
+            totalSize: UInt64(max(totalSize, 0))
         )
     }
 

--- a/seeleseek/DesignSystem/Components/Visualizations/BitrateDistribution.swift
+++ b/seeleseek/DesignSystem/Components/Visualizations/BitrateDistribution.swift
@@ -11,7 +11,9 @@ struct BitrateDistribution: View {
     /// the full file list six times per render.
     let buckets: [Bucket]
 
-    static func summarize(files: [SharedFile]) -> [Bucket] {
+    // nonisolated is load-bearing: the app target defaults to MainActor
+    // isolation, and this runs inside the panel's detached stats task.
+    nonisolated static func summarize(files: [SharedFile]) -> [Bucket] {
         let ranges: [(String, ClosedRange<UInt32>)] = [
             ("< 128", 0...127),
             ("128", 128...191),

--- a/seeleseek/DesignSystem/Components/Visualizations/BitrateDistribution.swift
+++ b/seeleseek/DesignSystem/Components/Visualizations/BitrateDistribution.swift
@@ -2,9 +2,16 @@ import SwiftUI
 import SeeleseekCore
 
 struct BitrateDistribution: View {
-    let files: [SharedFile]
+    struct Bucket: Equatable, Sendable {
+        let range: String
+        let count: Int
+    }
 
-    private var buckets: [(range: String, count: Int)] {
+    /// Precomputed off-main by the caller: bucketing in `body` re-filtered
+    /// the full file list six times per render.
+    let buckets: [Bucket]
+
+    static func summarize(files: [SharedFile]) -> [Bucket] {
         let ranges: [(String, ClosedRange<UInt32>)] = [
             ("< 128", 0...127),
             ("128", 128...191),
@@ -14,14 +21,14 @@ struct BitrateDistribution: View {
             ("> 320", 321...10000)
         ]
 
-        return ranges.map { label, range in
-            let count = files.filter { file in
-                guard let bitrate = file.bitrate else { return false }
-                return range.contains(bitrate)
-            }.count
-
-            return (range: label, count: count)
+        var counts = [Int](repeating: 0, count: ranges.count)
+        for file in files {
+            guard let bitrate = file.bitrate else { continue }
+            if let index = ranges.firstIndex(where: { $0.1.contains(bitrate) }) {
+                counts[index] += 1
+            }
         }
+        return zip(ranges, counts).map { Bucket(range: $0.0, count: $1) }
     }
 
     private var maxCount: Int {
@@ -61,7 +68,7 @@ struct BitrateDistribution: View {
 }
 
 #Preview {
-    BitrateDistribution(files: [])
+    BitrateDistribution(buckets: BitrateDistribution.summarize(files: []))
         .frame(width: 400)
         .padding()
         .background(SeeleColors.background)

--- a/seeleseek/DesignSystem/Components/Visualizations/BitrateDistribution.swift
+++ b/seeleseek/DesignSystem/Components/Visualizations/BitrateDistribution.swift
@@ -7,12 +7,10 @@ struct BitrateDistribution: View {
         let count: Int
     }
 
-    /// Precomputed off-main by the caller: bucketing in `body` re-filtered
-    /// the full file list six times per render.
+    /// Precomputed off-main by the caller.
     let buckets: [Bucket]
 
-    // nonisolated is load-bearing: the app target defaults to MainActor
-    // isolation, and this runs inside the panel's detached stats task.
+    // nonisolated: runs in the panel's detached stats task (app default is MainActor).
     nonisolated static func summarize(files: [SharedFile]) -> [Bucket] {
         let ranges: [(String, ClosedRange<UInt32>)] = [
             ("< 128", 0...127),

--- a/seeleseek/DesignSystem/Components/Visualizations/FileTypeDistribution.swift
+++ b/seeleseek/DesignSystem/Components/Visualizations/FileTypeDistribution.swift
@@ -2,25 +2,43 @@ import SwiftUI
 import SeeleseekCore
 
 struct FileTypeDistribution: View {
-    let files: [SharedFile]
+    struct Entry: Equatable, Sendable {
+        let type: String
+        let count: Int
+        let size: UInt64
+    }
 
-    private var distribution: [(type: String, count: Int, size: UInt64, color: Color)] {
+    /// Top extensions by size, with the total over ALL files (so the bar
+    /// leaves a gap for types beyond the top 8). Precomputed off-main by the
+    /// caller: aggregating in `body` walks every file per render, which
+    /// beachballs on 2M-file shares.
+    let entries: [Entry]
+    let allFilesSize: UInt64
+
+    static func summarize(files: [SharedFile]) -> (entries: [Entry], allFilesSize: UInt64) {
         var grouped: [String: (count: Int, size: UInt64)] = [:]
+        var total: UInt64 = 0
 
         for file in files {
             let ext = file.fileExtension.isEmpty ? "other" : file.fileExtension.lowercased()
             grouped[ext, default: (0, 0)].count += 1
             grouped[ext, default: (0, 0)].size += file.size
+            total += file.size
         }
 
-        return grouped
+        let top = grouped
             .sorted { $0.value.size > $1.value.size }
             .prefix(8)
-            .map { (type: $0.key, count: $0.value.count, size: $0.value.size, color: colorForType($0.key)) }
+            .map { Entry(type: $0.key, count: $0.value.count, size: $0.value.size) }
+        return (top, max(total, 1))
+    }
+
+    private var distribution: [(type: String, count: Int, size: UInt64, color: Color)] {
+        entries.map { (type: $0.type, count: $0.count, size: $0.size, color: colorForType($0.type)) }
     }
 
     private var totalSize: UInt64 {
-        max(files.reduce(0) { $0 + $1.size }, 1)
+        max(allFilesSize, 1)
     }
 
     var body: some View {
@@ -77,7 +95,7 @@ struct FileTypeDistribution: View {
 }
 
 #Preview {
-    FileTypeDistribution(files: [])
+    FileTypeDistribution(entries: [], allFilesSize: 1)
         .frame(width: 400)
         .padding()
         .background(SeeleColors.background)

--- a/seeleseek/DesignSystem/Components/Visualizations/FileTypeDistribution.swift
+++ b/seeleseek/DesignSystem/Components/Visualizations/FileTypeDistribution.swift
@@ -15,7 +15,9 @@ struct FileTypeDistribution: View {
     let entries: [Entry]
     let allFilesSize: UInt64
 
-    static func summarize(files: [SharedFile]) -> (entries: [Entry], allFilesSize: UInt64) {
+    // nonisolated is load-bearing: the app target defaults to MainActor
+    // isolation, and this runs inside the panel's detached stats task.
+    nonisolated static func summarize(files: [SharedFile]) -> (entries: [Entry], allFilesSize: UInt64) {
         var grouped: [String: (count: Int, size: UInt64)] = [:]
         var total: UInt64 = 0
 

--- a/seeleseek/DesignSystem/Components/Visualizations/FileTypeDistribution.swift
+++ b/seeleseek/DesignSystem/Components/Visualizations/FileTypeDistribution.swift
@@ -8,21 +8,20 @@ struct FileTypeDistribution: View {
         let size: UInt64
     }
 
-    /// Top extensions by size, with the total over ALL files (so the bar
-    /// leaves a gap for types beyond the top 8). Precomputed off-main by the
-    /// caller: aggregating in `body` walks every file per render, which
-    /// beachballs on 2M-file shares.
+    /// Top extensions by size; allFilesSize covers ALL files so the bar
+    /// leaves a gap for types past the top 8. Precomputed off-main by the
+    /// caller.
     let entries: [Entry]
     let allFilesSize: UInt64
 
-    // nonisolated is load-bearing: the app target defaults to MainActor
-    // isolation, and this runs inside the panel's detached stats task.
+    // nonisolated: runs in the panel's detached stats task (app default is MainActor).
     nonisolated static func summarize(files: [SharedFile]) -> (entries: [Entry], allFilesSize: UInt64) {
         var grouped: [String: (count: Int, size: UInt64)] = [:]
         var total: UInt64 = 0
 
         for file in files {
-            let ext = file.fileExtension.isEmpty ? "other" : file.fileExtension.lowercased()
+            let fileExtension = file.fileExtension
+            let ext = fileExtension.isEmpty ? "other" : fileExtension
             grouped[ext, default: (0, 0)].count += 1
             grouped[ext, default: (0, 0)].size += file.size
             total += file.size
@@ -32,7 +31,7 @@ struct FileTypeDistribution: View {
             .sorted { $0.value.size > $1.value.size }
             .prefix(8)
             .map { Entry(type: $0.key, count: $0.value.count, size: $0.value.size) }
-        return (top, max(total, 1))
+        return (top, total)
     }
 
     private var distribution: [(type: String, count: Int, size: UInt64, color: Color)] {

--- a/seeleseek/Features/Browse/BrowseState.swift
+++ b/seeleseek/Features/Browse/BrowseState.swift
@@ -2,10 +2,15 @@ import SwiftUI
 import os
 import SeeleseekCore
 
-struct FlatTreeItem: Identifiable {
+struct FlatTreeItem: Identifiable, Sendable {
     let id: UUID
     let file: SharedFile
     let depth: Int
+    /// Computed during flat-tree construction rather than read from
+    /// `expandedFolders` inside each row: a row-side read makes every
+    /// materialized row observe the set, so one toggle re-rendered them all —
+    /// seconds of main-thread work on large trees.
+    let isExpanded: Bool
 }
 
 @Observable
@@ -36,14 +41,18 @@ final class BrowseState {
     // MARK: - UI State
     var expandedFolders: Set<UUID> = []
     var selectedFile: SharedFile?
-    var filterQuery: String = ""
+    var filterQuery: String = "" {
+        didSet { scheduleFilter() }
+    }
 
     /// Target path to auto-expand after browse loads (e.g., "@@music\\Artist\\Album")
     private var targetPath: String?
 
     /// Current folder path being viewed (nil = show all shares from root)
     /// When set, only shows contents of this specific folder
-    var currentFolderPath: String?
+    var currentFolderPath: String? {
+        didSet { scheduleFilter() }
+    }
 
     /// The folders to display (filtered by currentFolderPath if set)
     var displayedFolders: [SharedFile] {
@@ -65,17 +74,57 @@ final class BrowseState {
         return result
     }
 
-    /// Filtered flat tree: if filterQuery is non-empty, walks the FULL
-    /// tree (not just expanded rows — the old behavior silently missed
-    /// matches inside collapsed folders) and includes every match plus
-    /// its ancestor chain, with matching subtrees rendered expanded for
-    /// display. The no-filter path is unchanged.
+    /// Filtered flat tree: if filterQuery is non-empty, the FULL tree is
+    /// walked (not just expanded rows — collapsed folders would silently
+    /// hide matches) and every match plus its ancestor chain is included.
+    /// The walk runs debounced off the main actor: on mega-shares (2M+
+    /// nodes) a synchronous per-keystroke walk beachballed the app.
     var filteredFlatTree: [FlatTreeItem] {
         let query = filterQuery.trimmingCharacters(in: .whitespaces)
         guard !query.isEmpty else { return visibleFlatTree }
+        return filterResults ?? []
+    }
 
+    /// Published by the most recent completed filter walk; nil while no
+    /// filter is active.
+    private var filterResults: [FlatTreeItem]?
+    private(set) var isFiltering = false
+    private var filterTask: Task<Void, Never>?
+
+    /// Debounce, then walk the tree off-main. Called whenever the query or
+    /// the displayed scope (tab, folder navigation, fresh results) changes.
+    private func scheduleFilter() {
+        filterTask?.cancel()
+        let query = filterQuery.trimmingCharacters(in: .whitespaces)
+        guard !query.isEmpty else {
+            filterTask = nil
+            filterResults = nil
+            isFiltering = false
+            return
+        }
+
+        isFiltering = true
+        let roots = displayedFolders
+        filterTask = Task.detached(priority: .userInitiated) { [weak self] in
+            try? await Task.sleep(for: .milliseconds(250))
+            guard !Task.isCancelled,
+                  let result = Self.matchingFlatTree(in: roots, query: query) else { return }
+            await self?.applyFilterResults(result, for: query)
+        }
+    }
+
+    private func applyFilterResults(_ items: [FlatTreeItem], for query: String) {
+        // A superseded walk can finish after its replacement; only the walk
+        // for the current query may publish.
+        guard filterQuery.trimmingCharacters(in: .whitespaces) == query else { return }
+        filterResults = items
+        isFiltering = false
+    }
+
+    /// nil means the walk was cancelled mid-flight.
+    private nonisolated static func matchingFlatTree(in files: [SharedFile], query: String) -> [FlatTreeItem]? {
         var result: [FlatTreeItem] = []
-        appendMatching(files: displayedFolders, depth: 0, query: query, to: &result)
+        guard (try? appendMatching(files: files, depth: 0, query: query, to: &result)) != nil else { return nil }
         return result
     }
 
@@ -85,21 +134,24 @@ final class BrowseState {
     /// before recursing and removed again when the subtree contributed
     /// nothing. Returns true if anything at this level (or below) matched.
     @discardableResult
-    private func appendMatching(
+    private nonisolated static func appendMatching(
         files: [SharedFile],
         depth: Int,
         query: String,
         to result: inout [FlatTreeItem]
-    ) -> Bool {
+    ) throws -> Bool {
         var anyMatch = false
         for file in files {
+            try Task.checkCancellation()
             let selfMatch = file.displayName.localizedCaseInsensitiveContains(query)
             if file.isDirectory {
                 let insertIndex = result.count
-                result.append(FlatTreeItem(id: file.id, file: file, depth: depth))
+                // Filter results render matches with their ancestor chain, so
+                // every directory row displays expanded.
+                result.append(FlatTreeItem(id: file.id, file: file, depth: depth, isExpanded: true))
                 var childMatch = false
                 if let children = file.children {
-                    childMatch = appendMatching(files: children, depth: depth + 1, query: query, to: &result)
+                    childMatch = try appendMatching(files: children, depth: depth + 1, query: query, to: &result)
                 }
                 if selfMatch || childMatch {
                     anyMatch = true
@@ -109,7 +161,7 @@ final class BrowseState {
                     result.removeSubrange(insertIndex..<result.count)
                 }
             } else if selfMatch {
-                result.append(FlatTreeItem(id: file.id, file: file, depth: depth))
+                result.append(FlatTreeItem(id: file.id, file: file, depth: depth, isExpanded: false))
                 anyMatch = true
             }
         }
@@ -118,8 +170,9 @@ final class BrowseState {
 
     private func appendVisible(files: [SharedFile], depth: Int, to result: inout [FlatTreeItem]) {
         for file in files {
-            result.append(FlatTreeItem(id: file.id, file: file, depth: depth))
-            if file.isDirectory, expandedFolders.contains(file.id), let children = file.children {
+            let expanded = file.isDirectory && expandedFolders.contains(file.id)
+            result.append(FlatTreeItem(id: file.id, file: file, depth: depth, isExpanded: expanded))
+            if expanded, let children = file.children {
                 appendVisible(files: children, depth: depth + 1, to: &result)
             }
         }
@@ -435,6 +488,8 @@ final class BrowseState {
                 // Find the browse by ID (index may have changed)
                 if let idx = self.browses.firstIndex(where: { $0.id == browseId }) {
                     self.browses[idx] = precomputedShares
+                    // Fresh results changed the scope under any active filter.
+                    self.scheduleFilter()
                     self.logger.info("Got \(flatFiles.count) files -> \(precomputedShares.folders.count) root folders for \(username)")
 
                     // Cache the results
@@ -481,6 +536,9 @@ final class BrowseState {
         if selectedBrowseIndex >= browses.count {
             selectedBrowseIndex = max(0, browses.count - 1)
         }
+
+        // The displayed scope changed under any active filter.
+        scheduleFilter()
 
         logger.info("Closed tab at index \(index)")
     }

--- a/seeleseek/Features/Browse/BrowseState.swift
+++ b/seeleseek/Features/Browse/BrowseState.swift
@@ -6,10 +6,6 @@ struct FlatTreeItem: Identifiable, Sendable {
     let id: UUID
     let file: SharedFile
     let depth: Int
-    /// Computed during flat-tree construction rather than read from
-    /// `expandedFolders` inside each row: a row-side read makes every
-    /// materialized row observe the set, so one toggle re-rendered them all —
-    /// seconds of main-thread work on large trees.
     let isExpanded: Bool
 }
 
@@ -74,11 +70,9 @@ final class BrowseState {
         return result
     }
 
-    /// Filtered flat tree: if filterQuery is non-empty, the FULL tree is
-    /// walked (not just expanded rows — collapsed folders would silently
-    /// hide matches) and every match plus its ancestor chain is included.
-    /// The walk runs debounced off the main actor: on mega-shares (2M+
-    /// nodes) a synchronous per-keystroke walk beachballed the app.
+    /// Non-empty filter: full-tree walk (collapsed folders would hide
+    /// matches) with every match plus its ancestor chain, debounced off the
+    /// main actor.
     var filteredFlatTree: [FlatTreeItem] {
         let query = filterQuery.trimmingCharacters(in: .whitespaces)
         guard !query.isEmpty else { return visibleFlatTree }
@@ -91,8 +85,7 @@ final class BrowseState {
     private(set) var isFiltering = false
     private var filterTask: Task<Void, Never>?
 
-    /// Debounce, then walk the tree off-main. Called whenever the query or
-    /// the displayed scope (tab, folder navigation, fresh results) changes.
+    /// Debounce, then walk the tree off-main.
     private func scheduleFilter() {
         filterTask?.cancel()
         let query = filterQuery.trimmingCharacters(in: .whitespaces)
@@ -107,8 +100,10 @@ final class BrowseState {
         let roots = displayedFolders
         filterTask = Task.detached(priority: .userInitiated) { [weak self] in
             try? await Task.sleep(for: .milliseconds(250))
+            var result: [FlatTreeItem] = []
             guard !Task.isCancelled,
-                  let result = Self.matchingFlatTree(in: roots, query: query) else { return }
+                  (try? Self.appendMatching(files: roots, depth: 0, query: query, to: &result)) != nil
+            else { return }
             await self?.applyFilterResults(result, for: query)
         }
     }
@@ -119,13 +114,6 @@ final class BrowseState {
         guard filterQuery.trimmingCharacters(in: .whitespaces) == query else { return }
         filterResults = items
         isFiltering = false
-    }
-
-    /// nil means the walk was cancelled mid-flight.
-    private nonisolated static func matchingFlatTree(in files: [SharedFile], query: String) -> [FlatTreeItem]? {
-        var result: [FlatTreeItem] = []
-        guard (try? appendMatching(files: files, depth: 0, query: query, to: &result)) != nil else { return nil }
-        return result
     }
 
     /// Depth-first walk of the full tree, ignoring `expandedFolders`. A
@@ -146,8 +134,6 @@ final class BrowseState {
             let selfMatch = file.displayName.localizedCaseInsensitiveContains(query)
             if file.isDirectory {
                 let insertIndex = result.count
-                // Filter results render matches with their ancestor chain, so
-                // every directory row displays expanded.
                 result.append(FlatTreeItem(id: file.id, file: file, depth: depth, isExpanded: true))
                 var childMatch = false
                 if let children = file.children {
@@ -583,16 +569,6 @@ final class BrowseState {
     }
 
     // MARK: - UI Actions
-
-    func setShares(_ folders: [SharedFile]) {
-        currentBrowse?.folders = folders
-        currentBrowse?.isLoading = false
-    }
-
-    func setError(_ message: String) {
-        currentBrowse?.error = message
-        currentBrowse?.isLoading = false
-    }
 
     func toggleFolder(_ id: UUID) {
         if expandedFolders.contains(id) {

--- a/seeleseek/Features/Browse/Views/BrowseView.swift
+++ b/seeleseek/Features/Browse/Views/BrowseView.swift
@@ -314,12 +314,26 @@ struct BrowseView: View {
                     .padding(.horizontal, SeeleSpacing.lg)
                     .padding(.vertical, SeeleSpacing.xs)
 
+                if browseState.isFiltering {
+                    HStack(spacing: SeeleSpacing.xs) {
+                        ProgressView()
+                            .scaleEffect(0.5)
+                        Text("Filtering...")
+                            .font(SeeleTypography.caption)
+                            .foregroundStyle(SeeleColors.textTertiary)
+                        Spacer()
+                    }
+                    .padding(.horizontal, SeeleSpacing.lg)
+                    .padding(.vertical, SeeleSpacing.xxs)
+                }
+
                 ScrollView {
                     LazyVStack(spacing: 0) {
                         ForEach(browseState.filteredFlatTree) { item in
                             FileTreeRow(
                                 file: item.file,
                                 depth: item.depth,
+                                isExpanded: item.isExpanded,
                                 browseState: browseState,
                                 username: shares.username
                             )

--- a/seeleseek/Features/Browse/Views/FileTreeRow.swift
+++ b/seeleseek/Features/Browse/Views/FileTreeRow.swift
@@ -8,6 +8,10 @@ struct FileTreeRow: View {
     @Environment(\.appState) private var appState
     let file: SharedFile
     let depth: Int
+    /// Plain input, precomputed on the FlatTreeItem — reading the state's
+    /// `expandedFolders` here would subscribe every materialized row to it
+    /// and re-render them all on each toggle.
+    let isExpanded: Bool
     var browseState: BrowseState
     let username: String
     @State private var isHovered = false
@@ -20,16 +24,6 @@ struct FileTreeRow: View {
     /// menu item that could only ever fail.
     private var peerServesArtwork: Bool {
         appState.networkClient.peerConnectionPool.hasAdvertised(.artworkRequest, by: username)
-    }
-
-    private var isExpanded: Bool {
-        // While a filter is active the tree renders matches with their
-        // ancestor chain regardless of expansion state, so show every
-        // directory chevron as expanded for display purposes.
-        if !browseState.filterQuery.trimmingCharacters(in: .whitespaces).isEmpty {
-            return true
-        }
-        return browseState.expandedFolders.contains(file.id)
     }
 
     private var downloadStatus: Transfer.TransferStatus? {

--- a/seeleseek/Features/Browse/Views/SharesVisualizationPanel.swift
+++ b/seeleseek/Features/Browse/Views/SharesVisualizationPanel.swift
@@ -4,9 +4,8 @@ import SeeleseekCore
 struct SharesVisualizationPanel: View {
     let shares: UserShares
 
-    /// Everything the sections render, and nothing more. Holding the flat
-    /// file arrays here kept ~2 GB of structs alive in view state for
-    /// mega-shares; the arrays now live only inside the summarize pass.
+    /// Only what the sections render — never hold the flat file arrays in
+    /// view state (~2 GB on mega-shares).
     struct Summary: Sendable {
         let typeEntries: [FileTypeDistribution.Entry]
         let typeTotalSize: UInt64

--- a/seeleseek/Features/Browse/Views/SharesVisualizationPanel.swift
+++ b/seeleseek/Features/Browse/Views/SharesVisualizationPanel.swift
@@ -17,8 +17,14 @@ struct SharesVisualizationPanel: View {
         let hasFiles: Bool
     }
 
-    @State private var summary: Summary?
-    @State private var isComputing = false
+    /// Keyed by `shares.id` so switching tabs and back does not re-run the
+    /// full-tree walk. A refresh mints a new UserShares id, so stale entries
+    /// are never served; the cap bounds ids orphaned by refreshes.
+    @State private var summaryCache: [UUID: Summary] = [:]
+    @State private var computingIds: Set<UUID> = []
+
+    private var summary: Summary? { summaryCache[shares.id] }
+    private var isComputing: Bool { computingIds.contains(shares.id) }
 
     var body: some View {
         ScrollView {
@@ -58,23 +64,26 @@ struct SharesVisualizationPanel: View {
             computeStatsIfNeeded()
         }
         .onChange(of: shares.id) { _, _ in
-            summary = nil
             computeStatsIfNeeded()
         }
     }
 
     private func computeStatsIfNeeded() {
-        guard summary == nil && !isComputing else { return }
+        let id = shares.id
+        guard summaryCache[id] == nil, !computingIds.contains(id) else { return }
 
-        isComputing = true
+        computingIds.insert(id)
         let folders = shares.folders
 
         Task.detached(priority: .userInitiated) {
             let computed = Self.computeStats(from: folders)
 
             await MainActor.run {
-                summary = computed
-                isComputing = false
+                if summaryCache.count > 8 {
+                    summaryCache.removeAll(keepingCapacity: true)
+                }
+                summaryCache[id] = computed
+                computingIds.remove(id)
             }
         }
     }

--- a/seeleseek/Features/Browse/Views/SharesVisualizationPanel.swift
+++ b/seeleseek/Features/Browse/Views/SharesVisualizationPanel.swift
@@ -4,18 +4,21 @@ import SeeleseekCore
 struct SharesVisualizationPanel: View {
     let shares: UserShares
 
-    @State private var cachedAllFiles: [SharedFile]?
-    @State private var cachedAudioFiles: [SharedFile]?
-    @State private var cachedTopFiles: [(String, UInt64)]?
+    /// Everything the sections render, and nothing more. Holding the flat
+    /// file arrays here kept ~2 GB of structs alive in view state for
+    /// mega-shares; the arrays now live only inside the summarize pass.
+    struct Summary: Sendable {
+        let typeEntries: [FileTypeDistribution.Entry]
+        let typeTotalSize: UInt64
+        let bitrateBuckets: [BitrateDistribution.Bucket]
+        let hasAudio: Bool
+        let topFiles: [(String, UInt64)]
+        let treemapFiles: [SharedFile]
+        let hasFiles: Bool
+    }
+
+    @State private var summary: Summary?
     @State private var isComputing = false
-
-    private var allFiles: [SharedFile] {
-        cachedAllFiles ?? []
-    }
-
-    private var audioFiles: [SharedFile] {
-        cachedAudioFiles ?? []
-    }
 
     var body: some View {
         ScrollView {
@@ -31,20 +34,20 @@ struct SharesVisualizationPanel: View {
                             .foregroundStyle(SeeleColors.textTertiary)
                     }
                     .padding()
-                } else if cachedAllFiles != nil {
+                } else if let summary {
                     Divider().background(SeeleColors.surfaceSecondary)
-                    fileTypeSection
+                    fileTypeSection(summary)
                     Divider().background(SeeleColors.surfaceSecondary)
 
-                    if !audioFiles.isEmpty {
-                        bitrateSection
+                    if summary.hasAudio {
+                        bitrateSection(summary)
                         Divider().background(SeeleColors.surfaceSecondary)
                     }
 
-                    largestFilesSection
+                    largestFilesSection(summary)
 
-                    if !allFiles.isEmpty {
-                        treemapSection
+                    if summary.hasFiles {
+                        treemapSection(summary)
                     }
                 }
             }
@@ -55,39 +58,45 @@ struct SharesVisualizationPanel: View {
             computeStatsIfNeeded()
         }
         .onChange(of: shares.id) { _, _ in
-            cachedAllFiles = nil
-            cachedAudioFiles = nil
-            cachedTopFiles = nil
+            summary = nil
             computeStatsIfNeeded()
         }
     }
 
     private func computeStatsIfNeeded() {
-        guard cachedAllFiles == nil && !isComputing else { return }
+        guard summary == nil && !isComputing else { return }
 
         isComputing = true
         let folders = shares.folders
 
         Task.detached(priority: .userInitiated) {
-            let (files, audio, top) = Self.computeStats(from: folders)
+            let computed = Self.computeStats(from: folders)
 
             await MainActor.run {
-                cachedAllFiles = files
-                cachedAudioFiles = audio
-                cachedTopFiles = top
+                summary = computed
                 isComputing = false
             }
         }
     }
 
-    nonisolated private static func computeStats(from folders: [SharedFile]) -> (files: [SharedFile], audio: [SharedFile], top: [(String, UInt64)]) {
+    nonisolated private static func computeStats(from folders: [SharedFile]) -> Summary {
         let files = collectFilesNonRecursive(from: folders)
         let audio = files.filter { $0.isAudioFile }
         let top = files
             .sorted { $0.size > $1.size }
             .prefix(5)
             .map { ($0.displayFilename, $0.size) }
-        return (files, audio, Array(top))
+        let (typeEntries, typeTotalSize) = FileTypeDistribution.summarize(files: files)
+
+        return Summary(
+            typeEntries: typeEntries,
+            typeTotalSize: typeTotalSize,
+            bitrateBuckets: BitrateDistribution.summarize(files: audio),
+            hasAudio: !audio.isEmpty,
+            topFiles: Array(top),
+            treemapFiles: Array(files.prefix(50)),
+            hasFiles: !files.isEmpty
+        )
     }
 
     nonisolated private static func collectFilesNonRecursive(from folders: [SharedFile]) -> [SharedFile] {
@@ -126,43 +135,43 @@ struct SharesVisualizationPanel: View {
         }
     }
 
-    private var fileTypeSection: some View {
+    private func fileTypeSection(_ summary: Summary) -> some View {
         VStack(alignment: .leading, spacing: SeeleSpacing.md) {
             Text("File Types")
                 .font(SeeleTypography.headline)
                 .foregroundStyle(SeeleColors.textPrimary)
                 .accessibilityAddTraits(.isHeader)
-            FileTypeDistribution(files: allFiles)
+            FileTypeDistribution(entries: summary.typeEntries, allFilesSize: summary.typeTotalSize)
         }
     }
 
-    private var bitrateSection: some View {
+    private func bitrateSection(_ summary: Summary) -> some View {
         VStack(alignment: .leading, spacing: SeeleSpacing.md) {
             Text("Audio Quality")
                 .font(SeeleTypography.headline)
                 .foregroundStyle(SeeleColors.textPrimary)
                 .accessibilityAddTraits(.isHeader)
-            BitrateDistribution(files: audioFiles)
+            BitrateDistribution(buckets: summary.bitrateBuckets)
         }
     }
 
-    private var largestFilesSection: some View {
+    private func largestFilesSection(_ summary: Summary) -> some View {
         VStack(alignment: .leading, spacing: SeeleSpacing.md) {
             Text("Largest Files")
                 .font(SeeleTypography.headline)
                 .foregroundStyle(SeeleColors.textPrimary)
                 .accessibilityAddTraits(.isHeader)
-            SizeComparisonBars(items: cachedTopFiles ?? [])
+            SizeComparisonBars(items: summary.topFiles)
         }
     }
 
-    private var treemapSection: some View {
+    private func treemapSection(_ summary: Summary) -> some View {
         VStack(alignment: .leading, spacing: SeeleSpacing.md) {
             Text("Size Distribution")
                 .font(SeeleTypography.headline)
                 .foregroundStyle(SeeleColors.textPrimary)
                 .accessibilityAddTraits(.isHeader)
-            FileTreemap(files: Array(allFiles.prefix(50)))
+            FileTreemap(files: summary.treemapFiles)
                 .frame(height: 200)
                 .clipShape(RoundedRectangle(cornerRadius: SeeleSpacing.radiusMD, style: .continuous))
         }

--- a/seeleseekTests/BrowseFilterTests.swift
+++ b/seeleseekTests/BrowseFilterTests.swift
@@ -1,0 +1,161 @@
+import Testing
+import Foundation
+@testable import SeeleseekCore
+@testable import seeleseek
+
+@Suite("Browse filter (debounced)")
+struct BrowseFilterTests {
+
+    private func makeState() -> BrowseState {
+        let tree = SharedFile.buildTree(from: [
+            SharedFile(filename: "@@music\\Milton\\Eu Sou O Rio\\01 needle.mp3", size: 1),
+            SharedFile(filename: "@@music\\Milton\\Eu Sou O Rio\\02 other.mp3", size: 1),
+            SharedFile(filename: "@@music\\Beatles\\Abbey Road\\03 track.mp3", size: 1),
+        ])
+        let state = BrowseState()
+        state.browses = [UserShares(id: UUID(), username: "alice", folders: tree, isLoading: false)]
+        state.selectedBrowseIndex = 0
+        return state
+    }
+
+    /// The walk is debounced (250ms) and runs off-main; poll for results.
+    private func waitForResults(_ state: BrowseState, timeout: Duration = .seconds(5)) async -> [FlatTreeItem] {
+        let deadline = ContinuousClock.now.advanced(by: timeout)
+        while state.isFiltering, ContinuousClock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(20))
+        }
+        return state.filteredFlatTree
+    }
+
+    @Test("Matches inside collapsed folders surface with their ancestor chain")
+    func matchesIncludeAncestors() async {
+        let state = makeState()
+        state.filterQuery = "needle"
+
+        let rows = await waitForResults(state)
+        let names = rows.map(\.file.displayName)
+        #expect(names == ["@@music", "Milton", "Eu Sou O Rio", "01 needle.mp3"],
+                "match plus full ancestor chain, nothing else")
+        let directoriesExpanded = rows.filter(\.file.isDirectory).allSatisfy(\.isExpanded)
+        #expect(directoriesExpanded, "filter results render every ancestor directory expanded")
+        #expect(state.isFiltering == false)
+    }
+
+    @Test("Visible rows carry expansion state as a plain value")
+    func expansionCarriedOnFlatItems() {
+        let state = makeState()
+        let root = state.browses[0].folders[0]
+        #expect(state.filteredFlatTree.map(\.isExpanded) == [false])
+
+        state.toggleFolder(root.id)
+        let rows = state.filteredFlatTree
+        #expect(rows.map(\.file.displayName) == ["@@music", "Beatles", "Milton"])
+        #expect(rows.map(\.isExpanded) == [true, false, false])
+    }
+
+    @Test("Clearing the query returns the visible tree immediately")
+    func clearRestoresVisibleTree() async {
+        let state = makeState()
+        state.filterQuery = "needle"
+        _ = await waitForResults(state)
+
+        state.filterQuery = ""
+        // Synchronous: no debounce wait on the clear path.
+        let names = state.filteredFlatTree.map(\.file.displayName)
+        #expect(names == ["@@music"], "collapsed root only — no filter active")
+        #expect(state.isFiltering == false)
+    }
+
+    @Test("A superseded query never publishes over its replacement")
+    func supersededQueryDoesNotPublish() async {
+        let state = makeState()
+        state.filterQuery = "milton"
+        state.filterQuery = "abbey"
+
+        let rows = await waitForResults(state)
+        let names = rows.map(\.file.displayName)
+        #expect(names.contains("Abbey Road"))
+        #expect(!names.contains("Milton"), "results must reflect the latest query only")
+    }
+
+    @Test("No matches yields an empty list, not the full tree")
+    func noMatchesIsEmpty() async {
+        let state = makeState()
+        state.filterQuery = "zzz-not-there"
+
+        let rows = await waitForResults(state)
+        #expect(rows.isEmpty)
+    }
+}
+
+@Suite("Browse cache aggregates")
+struct BrowseCacheAggregateTests {
+
+    /// Regression: cache-loaded UserShares carried no cached totals and
+    /// rebuilt trees carried no fileCount, so every totalFiles/totalSize
+    /// access in a UI body (tab labels render per interaction) recursed the
+    /// full 2M-node tree on the main thread — the browse-tab beachball.
+    @Test("Cache round-trip preserves aggregates without tree walks")
+    func cacheRoundTripPreservesAggregates() {
+        let tree = SharedFile.buildTree(from: [
+            SharedFile(filename: "@@music\\A\\B\\1.mp3", size: 10),
+            SharedFile(filename: "@@music\\A\\B\\2.mp3", size: 20),
+            SharedFile(filename: "@@music\\C\\3.mp3", size: 5),
+        ])
+        #expect(tree[0].fileCount == 3, "precondition: buildTree aggregates")
+
+        let records = SharedFileRecord.from(tree, userSharesId: UUID())
+        let rebuilt = SharedFileRecord.toSharedFiles(from: records)
+        #expect(rebuilt[0].fileCount == 3, "fileCount must survive the cache round-trip")
+
+        let record = UserSharesRecord(
+            id: UUID().uuidString, username: "alice",
+            cachedAt: 0, totalFiles: 3, totalSize: 35
+        )
+        let shares = record.toUserShares(folders: rebuilt)
+        #expect(shares.totalFiles == 3)
+        #expect(shares.totalSize == 35)
+    }
+
+    @Test("Totals without cached stats come from root aggregates, not walks")
+    func totalsFromRootAggregates() {
+        let tree = SharedFile.buildTree(from: [
+            SharedFile(filename: "a\\x.mp3", size: 7),
+            SharedFile(filename: "b\\y.mp3", size: 9),
+        ])
+        let shares = UserShares(username: "u", folders: tree, isLoading: false)
+        #expect(shares.totalFiles == 2)
+        #expect(shares.totalSize == 16)
+    }
+}
+
+@Suite("Shares visualization summaries")
+struct SharesVisualizationSummaryTests {
+
+    /// Regression: `summarize` was inferred @MainActor (the app target
+    /// defaults to MainActor isolation) and its sort closure crashed the
+    /// panel's detached stats task with a dispatch queue assertion. Running
+    /// from a detached task pins the nonisolated contract.
+    @Test("Summaries compute off the main actor")
+    func summariesComputeOffMain() async {
+        let files = [
+            SharedFile(filename: "a\\b\\t.mp3", size: 10, bitrate: 320),
+            SharedFile(filename: "a\\b\\u.flac", size: 30, bitrate: 900),
+            SharedFile(filename: "a\\b\\v.jpg", size: 5),
+        ]
+
+        let (entries, total) = await Task.detached {
+            FileTypeDistribution.summarize(files: files)
+        }.value
+        #expect(total == 45)
+        #expect(entries.first?.type == "flac", "largest type by size sorts first")
+        #expect(entries.count == 3)
+
+        let buckets = await Task.detached {
+            BitrateDistribution.summarize(files: files)
+        }.value
+        #expect(buckets.first(where: { $0.range == "320" })?.count == 1)
+        #expect(buckets.first(where: { $0.range == "> 320" })?.count == 1)
+        #expect(buckets.map(\.count).reduce(0, +) == 2, "file without bitrate lands in no bucket")
+    }
+}

--- a/seeleseekTests/BrowseFilterTests.swift
+++ b/seeleseekTests/BrowseFilterTests.swift
@@ -91,10 +91,8 @@ struct BrowseFilterTests {
 @Suite("Browse cache aggregates")
 struct BrowseCacheAggregateTests {
 
-    /// Regression: cache-loaded UserShares carried no cached totals and
-    /// rebuilt trees carried no fileCount, so every totalFiles/totalSize
-    /// access in a UI body (tab labels render per interaction) recursed the
-    /// full 2M-node tree on the main thread — the browse-tab beachball.
+    /// Aggregates must survive the cache round-trip; without them, totals
+    /// walk the full tree inside UI bodies.
     @Test("Cache round-trip preserves aggregates without tree walks")
     func cacheRoundTripPreservesAggregates() {
         let tree = SharedFile.buildTree(from: [
@@ -132,10 +130,8 @@ struct BrowseCacheAggregateTests {
 @Suite("Shares visualization summaries")
 struct SharesVisualizationSummaryTests {
 
-    /// Regression: `summarize` was inferred @MainActor (the app target
-    /// defaults to MainActor isolation) and its sort closure crashed the
-    /// panel's detached stats task with a dispatch queue assertion. Running
-    /// from a detached task pins the nonisolated contract.
+    /// Pins summarize's nonisolated contract: the app target defaults to
+    /// MainActor, and inferred @MainActor crashes the detached stats task.
     @Test("Summaries compute off the main actor")
     func summariesComputeOffMain() async {
         let files = [

--- a/seeleseekTests/CompressionRoundTripTests.swift
+++ b/seeleseekTests/CompressionRoundTripTests.swift
@@ -12,11 +12,6 @@ import Compression
 @Suite("Compression Round-Trip Tests")
 struct CompressionRoundTripTests {
 
-    /// The exact decompression path PeerConnection uses — round-tripping
-    /// through a test-local mirror would let the two drift apart unnoticed.
-    private func decompressZlib(_ data: Data) throws -> Data {
-        try ZlibDecompression.decompress(data)
-    }
 
     /// Extract compressed payload from a built message: skip length(4) + code(4)
     private func extractCompressedPayload(_ message: Data) -> Data {
@@ -46,7 +41,7 @@ struct CompressionRoundTripTests {
         )
 
         let compressed = extractCompressedPayload(msg)
-        let decompressed = try decompressZlib(compressed)
+        let decompressed = try ZlibDecompression.decompress(compressed)
 
         // Parse decompressed payload
         var o = 0
@@ -88,7 +83,7 @@ struct CompressionRoundTripTests {
             results: []
         )
         let compressed = extractCompressedPayload(msg)
-        let decompressed = try decompressZlib(compressed)
+        let decompressed = try ZlibDecompression.decompress(compressed)
 
         var o = 0
         let (user, uLen) = decompressed.readString(at: o)!; o += uLen
@@ -108,7 +103,7 @@ struct CompressionRoundTripTests {
             queueLength: 10
         )
         let compressed = extractCompressedPayload(msg)
-        let decompressed = try decompressZlib(compressed)
+        let decompressed = try ZlibDecompression.decompress(compressed)
 
         var o = 0
         let (_, uLen) = decompressed.readString(at: o)!; o += uLen
@@ -145,7 +140,7 @@ struct CompressionRoundTripTests {
 
         let msg = MessageBuilder.sharesReplyMessage(files: dirs)
         let compressed = extractCompressedPayload(msg)
-        let decompressed = try decompressZlib(compressed)
+        let decompressed = try ZlibDecompression.decompress(compressed)
 
         var o = 0
         let dirCount = decompressed.readUInt32(at: o)!; o += 4
@@ -193,7 +188,7 @@ struct CompressionRoundTripTests {
 
         let msg = MessageBuilder.sharesReplyMessage(files: dirs)
         let compressed = extractCompressedPayload(msg)
-        let decompressed = try decompressZlib(compressed)
+        let decompressed = try ZlibDecompression.decompress(compressed)
 
         var o = 0
         let dirCount = decompressed.readUInt32(at: o)!; o += 4
@@ -219,7 +214,7 @@ struct CompressionRoundTripTests {
     func testSharesReplyEmpty() throws {
         let msg = MessageBuilder.sharesReplyMessage(files: [])
         let compressed = extractCompressedPayload(msg)
-        let decompressed = try decompressZlib(compressed)
+        let decompressed = try ZlibDecompression.decompress(compressed)
 
         var o = 0
         #expect(decompressed.readUInt32(at: o) == 0); o += 4 // 0 dirs
@@ -248,7 +243,7 @@ struct CompressionRoundTripTests {
         )
 
         let compressed = extractCompressedPayload(msg)
-        let decompressed = try decompressZlib(compressed)
+        let decompressed = try ZlibDecompression.decompress(compressed)
 
         var o = 0
         #expect(decompressed.readUInt32(at: o) == 54321); o += 4 // token
@@ -285,7 +280,7 @@ struct CompressionRoundTripTests {
         )
 
         let compressed = extractCompressedPayload(msg)
-        let decompressed = try decompressZlib(compressed)
+        let decompressed = try ZlibDecompression.decompress(compressed)
 
         var o = 0
         #expect(decompressed.readUInt32(at: o) == 11111); o += 4
@@ -307,7 +302,7 @@ struct CompressionRoundTripTests {
         corrupt.append(Data([0x00, 0x00, 0x00, 0x00])) // fake checksum
 
         do {
-            _ = try decompressZlib(corrupt)
+            _ = try ZlibDecompression.decompress(corrupt)
             Issue.record("Expected decompression to fail on corrupt data")
         } catch {
             // Expected
@@ -318,7 +313,7 @@ struct CompressionRoundTripTests {
     func testDataTooShort() {
         let short = Data([0x78, 0x9C, 0x01])
         do {
-            _ = try decompressZlib(short)
+            _ = try ZlibDecompression.decompress(short)
             Issue.record("Expected failure for data < 6 bytes")
         } catch DecompressionError.dataTooShort {
             // Expected
@@ -329,10 +324,8 @@ struct CompressionRoundTripTests {
 
     // MARK: - Large share lists
 
-    /// Regression: a 50 MiB output was both the old cap and — in
-    /// PeerConnection's since-deleted private copy — returned truncated as
-    /// success, so mega-sharers' lists parsed to 0 files. Field lists exceed
-    /// 50 MiB at barely-compressible ratios, so the cap must clear them.
+    /// Field share lists exceed 50 MiB decompressed at barely-compressible
+    /// ratios; the cap must clear them in full.
     @Test("Share lists larger than 50 MiB decompress in full")
     func testLargeShareListBeyondOldCap() throws {
         let targetSize = 56 * 1024 * 1024

--- a/seeleseekTests/CompressionRoundTripTests.swift
+++ b/seeleseekTests/CompressionRoundTripTests.swift
@@ -12,40 +12,10 @@ import Compression
 @Suite("Compression Round-Trip Tests")
 struct CompressionRoundTripTests {
 
-    // MARK: - Zlib decompression helper (mirrors PeerConnection.decompressZlib)
-
-    /// Decompress zlib-wrapped data: strip 2-byte header + 4-byte Adler32, then raw DEFLATE.
+    /// The exact decompression path PeerConnection uses — round-tripping
+    /// through a test-local mirror would let the two drift apart unnoticed.
     private func decompressZlib(_ data: Data) throws -> Data {
-        guard data.count > 6 else { throw TestError.tooShort }
-        let cmf = data[data.startIndex]
-        guard cmf & 0x0F == 8 else { throw TestError.notZlib }
-
-        let deflateData = Data(data.dropFirst(2).dropLast(4))
-        return try decompressRawDeflate(deflateData)
-    }
-
-    private func decompressRawDeflate(_ data: Data) throws -> Data {
-        let maxSize = 50 * 1024 * 1024
-        return try data.withUnsafeBytes { sourceBuffer -> Data in
-            guard let base = sourceBuffer.bindMemory(to: UInt8.self).baseAddress else {
-                throw TestError.decompressionFailed
-            }
-            var destSize = min(max(data.count * 20, 65536), maxSize)
-            var destBuffer = [UInt8](repeating: 0, count: destSize)
-            var decoded = compression_decode_buffer(&destBuffer, destSize, base, data.count, nil, COMPRESSION_ZLIB)
-
-            if decoded == 0 || decoded == destSize {
-                destSize = min(destSize * 4, maxSize)
-                destBuffer = [UInt8](repeating: 0, count: destSize)
-                decoded = compression_decode_buffer(&destBuffer, destSize, base, data.count, nil, COMPRESSION_ZLIB)
-            }
-            guard decoded > 0 && decoded < destSize else { throw TestError.decompressionFailed }
-            return Data(destBuffer.prefix(decoded))
-        }
-    }
-
-    enum TestError: Error {
-        case tooShort, notZlib, decompressionFailed
+        try ZlibDecompression.decompress(data)
     }
 
     /// Extract compressed payload from a built message: skip length(4) + code(4)
@@ -350,10 +320,42 @@ struct CompressionRoundTripTests {
         do {
             _ = try decompressZlib(short)
             Issue.record("Expected failure for data < 6 bytes")
-        } catch TestError.tooShort {
+        } catch DecompressionError.dataTooShort {
             // Expected
         } catch {
             // Also acceptable
         }
+    }
+
+    // MARK: - Large share lists
+
+    /// Regression: a 50 MiB output was both the old cap and — in
+    /// PeerConnection's since-deleted private copy — returned truncated as
+    /// success, so mega-sharers' lists parsed to 0 files. Field lists exceed
+    /// 50 MiB at barely-compressible ratios, so the cap must clear them.
+    @Test("Share lists larger than 50 MiB decompress in full")
+    func testLargeShareListBeyondOldCap() throws {
+        let targetSize = 56 * 1024 * 1024
+        var plain = Data(capacity: targetSize)
+        var i = 0
+        while plain.count < targetSize {
+            plain.append(Data("Music\\Artist \(i)\\Album \(i % 97)\\\(i) - Track title \(i).flac\n".utf8))
+            i += 1
+        }
+
+        let compressed = try plain.withUnsafeBytes { (source: UnsafeRawBufferPointer) -> Data in
+            var destination = [UInt8](repeating: 0, count: plain.count + 1024)
+            let encoded = compression_encode_buffer(
+                &destination, destination.count,
+                source.bindMemory(to: UInt8.self).baseAddress!, plain.count,
+                nil, COMPRESSION_ZLIB
+            )
+            try #require(encoded > 0, "test payload failed to compress")
+            return Data(destination.prefix(encoded))
+        }
+
+        let decompressed = try ZlibDecompression.decompressRawDeflate(compressed)
+        #expect(decompressed.count == plain.count)
+        #expect(decompressed == plain)
     }
 }

--- a/seeleseekTests/FailureTests.swift
+++ b/seeleseekTests/FailureTests.swift
@@ -989,10 +989,8 @@ struct FailureTests {
         #expect(MessageParser.parseSharesReply(payload) == nil)
     }
 
-    /// Regression: the fixed 100k `maxItemCount` cap rejected real
-    /// mega-sharers (250k+ directories seen in the field), parsing their
-    /// whole list to nil and caching an empty browse. Size-bounded lists
-    /// are now guarded by payload plausibility instead.
+    /// Real mega-sharers exceed the old fixed 100k cap (250k+ directories);
+    /// size-bounded lists must not reject them.
     @Test("SharesReply with more directories than the old fixed cap parses fully")
     func testSharesReplyMegaShareParses() {
         let dirCount = Int(MessageParser.maxItemCount) + 50_000

--- a/seeleseekTests/FailureTests.swift
+++ b/seeleseekTests/FailureTests.swift
@@ -982,11 +982,38 @@ struct FailureTests {
         #expect(MessageParser.parseSharesReply(Data()) == nil)
     }
 
-    @Test("SharesReply with dir count exceeding limit")
+    @Test("SharesReply with dir count the payload cannot hold is rejected")
     func testSharesReplyDirCountExceedsLimit() {
         var payload = Data()
         payload.appendUInt32(MessageParser.maxItemCount + 1)
         #expect(MessageParser.parseSharesReply(payload) == nil)
+    }
+
+    /// Regression: the fixed 100k `maxItemCount` cap rejected real
+    /// mega-sharers (250k+ directories seen in the field), parsing their
+    /// whole list to nil and caching an empty browse. Size-bounded lists
+    /// are now guarded by payload plausibility instead.
+    @Test("SharesReply with more directories than the old fixed cap parses fully")
+    func testSharesReplyMegaShareParses() {
+        let dirCount = Int(MessageParser.maxItemCount) + 50_000
+        var payload = Data()
+        payload.appendUInt32(UInt32(dirCount))
+        // First directory carries one file; the rest are empty but real.
+        payload.appendString("Music\\A")
+        payload.appendUInt32(1)
+        payload.appendUInt8(1)
+        payload.appendString("01 track.mp3")
+        payload.appendUInt64(1_000_000)
+        payload.appendString("mp3")
+        payload.appendUInt32(0) // no attributes
+        for i in 1..<dirCount {
+            payload.appendString("d\(i)")
+            payload.appendUInt32(0)
+        }
+
+        let parsed = MessageParser.parseSharesReply(payload)
+        #expect(parsed?.files.count == 1)
+        #expect(parsed?.files.first?.filename == "Music\\A\\01 track.mp3")
     }
 
     @Test("SharesReply with dir count but truncated dir name")

--- a/seeleseekTests/SharedFileTreeTests.swift
+++ b/seeleseekTests/SharedFileTreeTests.swift
@@ -1,0 +1,77 @@
+import Testing
+import Foundation
+@testable import SeeleseekCore
+
+@Suite("SharedFile tree building")
+struct SharedFileTreeTests {
+
+    private func file(_ path: String, size: UInt64 = 1, isPrivate: Bool = false) -> SharedFile {
+        SharedFile(filename: path, size: size, isPrivate: isPrivate)
+    }
+
+    @Test("Nested paths build the expected hierarchy with aggregated stats")
+    func nestedHierarchy() {
+        let tree = SharedFile.buildTree(from: [
+            file("@@music\\Artist\\Album\\01.mp3", size: 10),
+            file("@@music\\Artist\\Album\\02.mp3", size: 20),
+            file("@@music\\Artist\\cover.jpg", size: 5),
+            file("@@video\\clip.mp4", size: 40),
+        ])
+
+        #expect(tree.map(\.filename) == ["@@music", "@@video"], "roots sort alphabetically")
+        let music = tree[0]
+        #expect(music.isDirectory)
+        #expect(music.fileCount == 3)
+        #expect(music.size == 35)
+
+        let artist = music.children?.first
+        #expect(artist?.filename == "@@music\\Artist")
+        // Folders sort before files within a directory.
+        #expect(artist?.children?.map(\.displayName) == ["Album", "cover.jpg"])
+        let album = artist?.children?.first
+        #expect(album?.fileCount == 2)
+        #expect(album?.size == 30)
+        #expect(album?.children?.map(\.displayName) == ["01.mp3", "02.mp3"])
+    }
+
+    @Test("Folder is private only when every descendant is")
+    func privatePropagation() {
+        let tree = SharedFile.buildTree(from: [
+            file("root\\locked\\a.mp3", isPrivate: true),
+            file("root\\locked\\b.mp3", isPrivate: true),
+            file("root\\open.mp3"),
+        ])
+        #expect(tree[0].isPrivate == false)
+        #expect(tree[0].children?.first?.isPrivate == true)
+    }
+
+    @Test("Root-level file surfaces as an empty folder (legacy behavior)")
+    func rootLevelFile() {
+        let tree = SharedFile.buildTree(from: [file("loose.mp3")])
+        #expect(tree.count == 1)
+        #expect(tree[0].isDirectory)
+        #expect(tree[0].children?.isEmpty == true)
+    }
+
+    /// Regression: `buildFolder` used to scan every known folder to find each
+    /// folder's children — O(folders²). Real shares reach 250k+ folders
+    /// (2M+ files), which burned minutes of CPU while the browse tab sat on
+    /// its spinner. The adjacency-map rewrite is linear; the old
+    /// implementation cannot finish this case inside the limit.
+    @Test("Mega-share tree builds within the time limit", .timeLimit(.minutes(1)))
+    func megaShareScales() {
+        var flat: [SharedFile] = []
+        flat.reserveCapacity(120_000)
+        for artist in 0..<20_000 {
+            for album in 0..<2 {
+                for track in 0..<3 {
+                    flat.append(file("@@music\\artist \(artist)\\album \(album)\\\(track).mp3"))
+                }
+            }
+        }
+
+        let tree = SharedFile.buildTree(from: flat)
+        #expect(tree.count == 1)
+        #expect(tree[0].fileCount == 120_000)
+    }
+}

--- a/seeleseekTests/SharedFileTreeTests.swift
+++ b/seeleseekTests/SharedFileTreeTests.swift
@@ -53,11 +53,8 @@ struct SharedFileTreeTests {
         #expect(tree[0].children?.isEmpty == true)
     }
 
-    /// Regression: `buildFolder` used to scan every known folder to find each
-    /// folder's children — O(folders²). Real shares reach 250k+ folders
-    /// (2M+ files), which burned minutes of CPU while the browse tab sat on
-    /// its spinner. The adjacency-map rewrite is linear; the old
-    /// implementation cannot finish this case inside the limit.
+    /// buildTree must stay linear: O(folders²) child scans burn minutes of
+    /// CPU on real 250k-folder shares.
     @Test("Mega-share tree builds within the time limit", .timeLimit(.minutes(1)))
     func megaShareScales() {
         var flat: [SharedFile] = []


### PR DESCRIPTION
### Description

This PR contains significant performance and scalability improvements for handling very large share lists and folder structures, as well as security and correctness enhancements for decompression and message parsing. The changes ensure the code can efficiently process "mega-shares" (hundreds of thousands of folders, millions of files) without excessive CPU or memory usage, and without rejecting legitimate large data sets.

### Performance and Scalability Improvements

* Rewrote `SharedFile.buildTree(from:)` to precompute folder adjacency and avoid O(N²) scans, making tree-building fast even for millions of files/folders. Sorting and aggregation are now optimized, and root-level files are handled efficiently. [[1]](diffhunk://#diff-0bfcac578e434584c9ca123f4b5695eadeb95e9718bdb0c0da7e690eea732c42R85-L156) [[2]](diffhunk://#diff-0bfcac578e434584c9ca123f4b5695eadeb95e9718bdb0c0da7e690eea732c42L169-R156) [[3]](diffhunk://#diff-0bfcac578e434584c9ca123f4b5695eadeb95e9718bdb0c0da7e690eea732c42L179-R166)
* Updated `UserShares` to cache aggregate file counts and sizes at the root level, ensuring UI queries are O(roots) instead of recursively traversing the entire tree. Added parameters to set these aggregates directly and optimized their computation.

### Security and Correctness

* Increased the maximum allowed decompressed size in `ZlibDecompression` to 256 MiB to accommodate legitimate large share lists while still bounding decompression bombs.
* Replaced the custom zlib/deflate decompression logic in `PeerConnection` with a reusable, testable utility (`ZlibDecompression`), reducing code duplication and improving maintainability. [[1]](diffhunk://#diff-d706c86a469135e21918307a668b2a2cf738f80364802caea506c4ed865fbf8dL4) [[2]](diffhunk://#diff-d706c86a469135e21918307a668b2a2cf738f80364802caea506c4ed865fbf8dL1746-R1745) [[3]](diffhunk://#diff-d706c86a469135e21918307a668b2a2cf738f80364802caea506c4ed865fbf8dL1782-R1781) [[4]](diffhunk://#diff-d706c86a469135e21918307a668b2a2cf738f80364802caea506c4ed865fbf8dL1948-R1947) [[5]](diffhunk://#diff-d706c86a469135e21918307a668b2a2cf738f80364802caea506c4ed865fbf8dL1993-L2101)

### Robustness in Message Parsing

* Improved share list and folder contents parsing in `MessageParser` by replacing hard item count caps with a plausibility check based on remaining payload size, allowing the code to accept legitimate mega-shares while still rejecting malformed or malicious messages. [[1]](diffhunk://#diff-ac931950a4c9976b1a7b760ef9cf0fcf4072a9e7d33a034c20ff464577dec7cdR16-R27) [[2]](diffhunk://#diff-ac931950a4c9976b1a7b760ef9cf0fcf4072a9e7d33a034c20ff464577dec7cdL567-R587) [[3]](diffhunk://#diff-ac931950a4c9976b1a7b760ef9cf0fcf4072a9e7d33a034c20ff464577dec7cdL593-R613) [[4]](diffhunk://#diff-ac931950a4c9976b1a7b760ef9cf0fcf4072a9e7d33a034c20ff464577dec7cdL630-R643) [[5]](diffhunk://#diff-ac931950a4c9976b1a7b760ef9cf0fcf4072a9e7d33a034c20ff464577dec7cdL641-R655)
<!--
### Future work
A place to describe changes that can or will be done in follow-up PRs
-->

### How to test

- Ensure all checks pass

### Author checklist

This PR:

- [x] Satisfies a goal that is specific & clearly motivated
- [x] Adds value in isolation (whether user-facing or sustainability-related)
- [x] Contains a concise & easy-to-understand title + description
- [x] Adheres to [SRP](https://en.wikipedia.org/wiki/Single-responsibility_principle) by default
- [x] Presents the best possible implementation to meet its goal, given constraints at hand
