### PR TITLE
Add minimize-to-menu-bar setting to hide Dock when closed.

### DIFF
--- a/seeleseek/App/AppState.swift
+++ b/seeleseek/App/AppState.swift
@@ -486,6 +486,10 @@ final class AppState {
         // Sync launch-at-login state from system (user may toggle in System Settings)
         settings.syncLaunchAtLoginState()
 
+        #if os(macOS)
+        DockIconPolicy.start(settings: settings)
+        #endif
+
         // Register activity logger with the package
         ActivityLogger.shared = ActivityLog.shared
 

--- a/seeleseek/App/DockIconPolicy.swift
+++ b/seeleseek/App/DockIconPolicy.swift
@@ -1,0 +1,88 @@
+#if os(macOS)
+import AppKit
+
+/// Keeps `NSApp` activation policy in sync with **Minimize to menu bar**.
+///
+/// When that setting is on (and the menu bar extra is present), closing the
+/// last titled window switches to `.accessory` so the Dock icon disappears.
+/// Any titled window (main, Settings, update prompt) — including a
+/// miniaturized one — restores `.regular`.
+@MainActor
+enum DockIconPolicy {
+    private static var isObserving = false
+    private static weak var settings: SettingsState?
+
+    static func start(settings: SettingsState) {
+        self.settings = settings
+        settings.onDockPolicyRelevantChange = {
+            refresh()
+        }
+        startObservingWindowsIfNeeded()
+        refresh()
+    }
+
+    static func refresh() {
+        guard !SeeleSeekApp.isRunningTests else { return }
+        guard let settings else { return }
+
+        let hideDock = settings.minimizeToMenuBar
+            && settings.showInMenuBar
+            && !hasPresentableWindows
+
+        let policy: NSApplication.ActivationPolicy = hideDock ? .accessory : .regular
+        guard NSApp.activationPolicy() != policy else { return }
+        NSApp.setActivationPolicy(policy)
+    }
+
+    /// Switch to a normal Docked app and activate so a window can come forward.
+    static func prepareToPresentWindow() {
+        if NSApp.activationPolicy() != .regular {
+            NSApp.setActivationPolicy(.regular)
+        }
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    /// Existing main `WindowGroup` window, if any (not Settings / panels).
+    static var mainWindow: NSWindow? {
+        NSApp.windows.first { window in
+            guard window.styleMask.contains(.titled), window.canBecomeMain else { return false }
+            return window.isVisible || window.isMiniaturized
+        }
+    }
+
+    // MARK: - Private
+
+    private static func startObservingWindowsIfNeeded() {
+        guard !isObserving else { return }
+        isObserving = true
+
+        let center = NotificationCenter.default
+        let names: [Notification.Name] = [
+            NSWindow.didBecomeKeyNotification,
+            NSWindow.didBecomeMainNotification,
+            NSWindow.didChangeOcclusionStateNotification,
+            NSWindow.willCloseNotification,
+            NSWindow.didMiniaturizeNotification,
+            NSWindow.didDeminiaturizeNotification,
+        ]
+        for name in names {
+            center.addObserver(forName: name, object: nil, queue: .main) { _ in
+                // willClose still reports the window as visible; defer so the
+                // window list matches post-close reality.
+                Task { @MainActor in
+                    refresh()
+                }
+            }
+        }
+    }
+
+    /// Titled app windows only — menu-bar extras and status items are excluded
+    /// so opening the menu while Dock-hidden does not flash a Dock icon.
+    private static var hasPresentableWindows: Bool {
+        NSApp.windows.contains { window in
+            guard window.styleMask.contains(.titled) else { return false }
+            return window.isVisible || window.isMiniaturized
+        }
+    }
+}
+#endif

--- a/seeleseek/App/DockIconPolicy.swift
+++ b/seeleseek/App/DockIconPolicy.swift
@@ -11,6 +11,10 @@ import AppKit
 enum DockIconPolicy {
     private static var isObserving = false
     private static weak var settings: SettingsState?
+    /// `activate()` / accessory→regular can ask SwiftUI to reopen a window.
+    /// Menu-bar Open/Settings already create the window they want; a second
+    /// one from reopen is the duplicate-instance bug.
+    private static var suppressAutomaticReopen = false
 
     static func start(settings: SettingsState) {
         self.settings = settings
@@ -36,18 +40,41 @@ enum DockIconPolicy {
 
     /// Switch to a normal Docked app and activate so a window can come forward.
     static func prepareToPresentWindow() {
+        suppressAutomaticReopen = true
         if NSApp.activationPolicy() != .regular {
             NSApp.setActivationPolicy(.regular)
         }
         NSApp.activate(ignoringOtherApps: true)
+        Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(150))
+            suppressAutomaticReopen = false
+            discardExtraMainWindows()
+        }
     }
 
-    /// Existing main `WindowGroup` window, if any (not Settings / panels).
+    /// Existing main scene window, if any (not Settings / panels).
+    /// Includes a not-yet-visible window so Open does not spawn a second one.
     static var mainWindow: NSWindow? {
-        NSApp.windows.first { window in
-            guard window.styleMask.contains(.titled), window.canBecomeMain else { return false }
-            return window.isVisible || window.isMiniaturized
+        let windows = NSApp.windows
+        if let named = windows.first(where: { $0.identifier?.rawValue == "main" }) {
+            return named
         }
+        return windows.first(where: isLikelyMainWindow)
+    }
+
+    /// Dock click / Cmd-Tab reopen. Return `true` only when SwiftUI should
+    /// create the main window; `false` when we already showed one (or the
+    /// menu-bar path is about to).
+    static func handleReopen(hasVisibleWindows: Bool) -> Bool {
+        if suppressAutomaticReopen { return false }
+        if let window = mainWindow {
+            if window.isMiniaturized {
+                window.deminiaturize(nil)
+            }
+            window.makeKeyAndOrderFront(nil)
+            return false
+        }
+        return !hasVisibleWindows
     }
 
     // MARK: - Private
@@ -82,6 +109,35 @@ enum DockIconPolicy {
         NSApp.windows.contains { window in
             guard window.styleMask.contains(.titled) else { return false }
             return window.isVisible || window.isMiniaturized
+        }
+    }
+
+    private static func isLikelyMainWindow(_ window: NSWindow) -> Bool {
+        guard window.styleMask.contains(.titled), window.canBecomeMain else { return false }
+        let id = window.identifier?.rawValue ?? ""
+        if id == "update-prompt" { return false }
+        if id.localizedCaseInsensitiveContains("settings") { return false }
+        let title = window.title
+        if title == "Update Available" || title == "Settings" { return false }
+        return window.isVisible || window.isMiniaturized
+    }
+
+    private static func isMainSceneWindow(_ window: NSWindow) -> Bool {
+        if window.identifier?.rawValue == "main" { return true }
+        return isLikelyMainWindow(window)
+    }
+
+    /// Accessory→regular plus `openWindow` can both materialize a main window.
+    /// Keep the frontmost one.
+    private static func discardExtraMainWindows() {
+        let mains = NSApp.windows.filter(isMainSceneWindow)
+        guard mains.count > 1 else { return }
+        let keeper = mains.first(where: \.isKeyWindow)
+            ?? mains.first(where: \.isMainWindow)
+            ?? mains.first(where: \.isVisible)
+            ?? mains[0]
+        for window in mains where window !== keeper {
+            window.close()
         }
     }
 }

--- a/seeleseek/Features/MenuBar/MenuBarView.swift
+++ b/seeleseek/Features/MenuBar/MenuBarView.swift
@@ -3,6 +3,8 @@ import SeeleseekCore
 
 struct MenuBarView: View {
     @Environment(\.appState) private var appState
+    @Environment(\.openWindow) private var openWindow
+    @Environment(\.openSettings) private var openSettings
 
     private var status: ConnectionStatus {
         appState.connection.connectionStatus
@@ -90,14 +92,19 @@ struct MenuBarView: View {
         Divider()
 
         Button {
-            NSApplication.shared.activate()
+            openMainWindow()
         } label: {
             Label("Open SeeleSeek", systemImage: "macwindow")
         }
         .keyboardShortcut("o")
 
         // No shortcut: ⌘, is the system Settings equivalent already.
-        SettingsLink {
+        Button {
+            #if os(macOS)
+            DockIconPolicy.prepareToPresentWindow()
+            #endif
+            openSettings()
+        } label: {
             Label("Settings…", systemImage: "gear")
         }
 
@@ -141,7 +148,23 @@ struct MenuBarView: View {
 
     private func open(_ item: SidebarItem) {
         appState.sidebarSelection = item
+        openMainWindow()
+    }
+
+    private func openMainWindow() {
+        #if os(macOS)
+        DockIconPolicy.prepareToPresentWindow()
+        if let window = DockIconPolicy.mainWindow {
+            if window.isMiniaturized {
+                window.deminiaturize(nil)
+            }
+            window.makeKeyAndOrderFront(nil)
+        } else {
+            openWindow(id: "main")
+        }
+        #else
         NSApplication.shared.activate()
+        #endif
     }
 
     private var headerAccessibilityLabel: String {

--- a/seeleseek/Features/Settings/SettingsState.swift
+++ b/seeleseek/Features/Settings/SettingsState.swift
@@ -92,6 +92,7 @@ final class SettingsState: DownloadSettingsProviding {
     private let downloadDefaultsMigratedKey = "settingsDownloadDefaultsMigratedV2"
     private let launchAtLoginKey = "settingsLaunchAtLogin"
     private let showInMenuBarKey = "settingsShowInMenuBar"
+    private let minimizeToMenuBarKey = "settingsMinimizeToMenuBar"
     private let notifyDownloadsKey = "settingsNotifyDownloads"
     private let notifyUploadsKey = "settingsNotifyUploads"
     private let notifyPrivateMessagesKey = "settingsNotifyPrivateMessages"
@@ -159,9 +160,33 @@ final class SettingsState: DownloadSettingsProviding {
     var showInMenuBar: Bool = true {
         didSet {
             guard !isLoading else { return }
+            // Dock-hide requires the menu bar icon; clear it when the icon goes away.
+            if !showInMenuBar && minimizeToMenuBar {
+                minimizeToMenuBar = false
+            }
             save()
+            onDockPolicyRelevantChange?()
         }
     }
+    /// When on, closing the last titled window hides the Dock icon (accessory
+    /// policy) while the menu bar extra keeps the process alive.
+    var minimizeToMenuBar: Bool = false {
+        didSet {
+            guard !isLoading else { return }
+            if minimizeToMenuBar && !showInMenuBar {
+                isLoading = true
+                minimizeToMenuBar = false
+                isLoading = false
+                return
+            }
+            save()
+            onDockPolicyRelevantChange?()
+        }
+    }
+
+    /// Fired when menu-bar / dock-hide prefs change so AppKit activation
+    /// policy can catch up. Wired by `AppState.configure()`.
+    @ObservationIgnored var onDockPolicyRelevantChange: (() -> Void)?
 
     // MARK: - Network Settings
     var listenPort: Int = 2234 {
@@ -369,6 +394,7 @@ final class SettingsState: DownloadSettingsProviding {
         downloadFolderTemplate = SettingsState.defaultDownloadFolderTemplate
         launchAtLogin = false
         showInMenuBar = true
+        minimizeToMenuBar = false
         listenPort = 2234
         enableUPnP = true
         maxDownloadSlots = 5
@@ -448,6 +474,7 @@ final class SettingsState: DownloadSettingsProviding {
         UserDefaults.standard.set(downloadFolderTemplate, forKey: downloadFolderTemplateKey)
         UserDefaults.standard.set(launchAtLogin, forKey: launchAtLoginKey)
         UserDefaults.standard.set(showInMenuBar, forKey: showInMenuBarKey)
+        UserDefaults.standard.set(minimizeToMenuBar, forKey: minimizeToMenuBarKey)
         UserDefaults.standard.set(notifyDownloads, forKey: notifyDownloadsKey)
         UserDefaults.standard.set(notifyUploads, forKey: notifyUploadsKey)
         UserDefaults.standard.set(notifyPrivateMessages, forKey: notifyPrivateMessagesKey)
@@ -534,6 +561,12 @@ final class SettingsState: DownloadSettingsProviding {
         migrateDownloadDefaultsIfNeeded()
         if UserDefaults.standard.object(forKey: showInMenuBarKey) != nil {
             showInMenuBar = UserDefaults.standard.bool(forKey: showInMenuBarKey)
+        }
+        if UserDefaults.standard.object(forKey: minimizeToMenuBarKey) != nil {
+            minimizeToMenuBar = UserDefaults.standard.bool(forKey: minimizeToMenuBarKey)
+        }
+        if !showInMenuBar {
+            minimizeToMenuBar = false
         }
         if UserDefaults.standard.object(forKey: notifyDownloadsKey) != nil {
             notifyDownloads = UserDefaults.standard.bool(forKey: notifyDownloadsKey)

--- a/seeleseek/Features/Settings/Views/GeneralSettingsSection.swift
+++ b/seeleseek/Features/Settings/Views/GeneralSettingsSection.swift
@@ -97,6 +97,8 @@ struct GeneralSettingsSection: View {
             settingsGroup("Startup") {
                 settingsToggle("Launch at login", isOn: $settings.launchAtLogin)
                 settingsToggle("Show in menu bar", isOn: $settings.showInMenuBar)
+                settingsToggle("Minimize to menu bar", isOn: $settings.minimizeToMenuBar)
+                    .disabled(!settings.showInMenuBar)
             }
 
             settingsGroup("Import") {

--- a/seeleseek/seeleseekApp.swift
+++ b/seeleseek/seeleseekApp.swift
@@ -37,7 +37,9 @@ struct SeeleSeekApp: App {
     #endif
 
     var body: some Scene {
-        WindowGroup(id: "main") {
+        // `Window` (not `WindowGroup`): one main scene. Group + menu-bar Open
+        // after accessory→regular spawned a second instance.
+        Window("SeeleSeek", id: "main") {
             if Self.isRunningTests {
                 Text("seeleseek test host — closing this window is fine")
                     .foregroundStyle(.secondary)
@@ -63,6 +65,7 @@ struct SeeleSeekApp: App {
         #if os(macOS)
         .windowStyle(.hiddenTitleBar)
         .defaultSize(width: 1200, height: 800)
+        .defaultLaunchBehavior(.presented)
         .commands {
             CommandGroup(replacing: .newItem) {}
             TabNavigationCommands()
@@ -187,6 +190,12 @@ final class TestHostSafeAppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
         false  // Only consulted under tests — see responds(to:).
+    }
+
+    func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
+        MainActor.assumeIsolated {
+            DockIconPolicy.handleReopen(hasVisibleWindows: flag)
+        }
     }
 }
 #endif

--- a/seeleseek/seeleseekApp.swift
+++ b/seeleseek/seeleseekApp.swift
@@ -37,7 +37,7 @@ struct SeeleSeekApp: App {
     #endif
 
     var body: some Scene {
-        WindowGroup {
+        WindowGroup(id: "main") {
             if Self.isRunningTests {
                 Text("seeleseek test host — closing this window is fine")
                     .foregroundStyle(.secondary)

--- a/site/src/content/docs/guide/connecting.md
+++ b/site/src/content/docs/guide/connecting.md
@@ -51,4 +51,4 @@ If **Show in menu bar** is on in Settings > General, seeleseek adds an icon to t
 - **Open** — Opens the main window.
 - **Quit** — Stops the app.
 
-The icon stays in the menu bar when you close the main window.
+The icon stays in the menu bar when you close the main window. With **Minimize to menu bar** also on, closing the last window hides the Dock icon until you open a window again.

--- a/site/src/content/docs/guide/settings.md
+++ b/site/src/content/docs/guide/settings.md
@@ -30,6 +30,7 @@ Configure the profile that other users see:
 ### Startup
 - **Launch at login** — Starts seeleseek when you log in to macOS.
 - **Show in menu bar** — Adds an icon to the menu bar. The default is on.
+- **Minimize to menu bar** — When the last window is closed, hides the Dock icon and keeps the app in the menu bar only. Requires **Show in menu bar**. The default is off.
 
 ## Network
 


### PR DESCRIPTION
### Description

Lets the app stay menu-bar-only after the last window closes while still restoring the Dock when any window is open again.

### How to test

- [ ] Enable the minimize-to-menu-bar setting in General settings
- [ ] Close the last window — Dock icon should hide and the app should remain available from the menu bar
- [ ] Open a window again from the menu bar — Dock icon should restore
- [ ] Disable the setting, close the last window — Dock behavior should return to normal

### Author checklist

This PR:

- [x] Satisfies a goal that is specific & clearly motivated
- [x] Adds value in isolation (whether user-facing or sustainability-related)
- [x] Contains a concise & easy-to-understand title + description
- [x] Adheres to [SRP](https://en.wikipedia.org/wiki/Single-responsibility_principle) by default
- [x] Presents the best possible implementation to meet its goal, given constraints at hand