### PR TITLE
Persist search filters across relaunch.

### DIFF
--- a/seeleseek/App/AppState.swift
+++ b/seeleseek/App/AppState.swift
@@ -482,6 +482,9 @@ final class AppState {
 
         // Load persisted settings from UserDefaults initially (will migrate to DB)
         settings.load()
+        // Wire before anything touches `networkClient` so the search tab
+        // restores grouping + filters on first paint.
+        searchState.settings = settings
 
         // Sync launch-at-login state from system (user may toggle in System Settings)
         settings.syncLaunchAtLoginState()

--- a/seeleseek/Features/Search/SearchState.swift
+++ b/seeleseek/Features/Search/SearchState.swift
@@ -77,7 +77,14 @@ final class SearchState {
 
     // MARK: - Settings Reference
     weak var settings: SettingsState? {
-        didSet { isGrouped = settings?.groupSearchResults ?? false }
+        didSet { syncPersistedSettings() }
+    }
+
+    /// Pull grouping + filter prefs from `settings`. Fired whenever settings
+    /// is (re)assigned — including from `AppState.configure()` after load.
+    func syncPersistedSettings() {
+        isGrouped = settings?.groupSearchResults ?? false
+        applyPersistedFilters(settings?.searchFilters ?? .empty)
     }
 
     // MARK: - Shared Activity Tracker
@@ -184,31 +191,94 @@ final class SearchState {
     // computed version was re-running filter + sort on every SearchView
     // body eval — and each streaming-result batch triggered several evals,
     // so with 500 rows we were doing tens of thousands of ops/sec.
+    // Filter values also write through to `settings.searchFilters` (see
+    // `persistFiltersIfNeeded`); sort order and `showFilters` stay session-only.
+    @ObservationIgnored private var suppressFilterPersist = false
+
     var filterMinBitrate: Int? = nil {
-        didSet { if filterMinBitrate != oldValue { recomputeFilteredResults() } }
+        didSet {
+            guard filterMinBitrate != oldValue else { return }
+            recomputeFilteredResults()
+            persistFiltersIfNeeded()
+        }
     }
     var filterMinSampleRate: Int? = nil {
-        didSet { if filterMinSampleRate != oldValue { recomputeFilteredResults() } }
+        didSet {
+            guard filterMinSampleRate != oldValue else { return }
+            recomputeFilteredResults()
+            persistFiltersIfNeeded()
+        }
     }
     var filterMinBitDepth: Int? = nil {
-        didSet { if filterMinBitDepth != oldValue { recomputeFilteredResults() } }
+        didSet {
+            guard filterMinBitDepth != oldValue else { return }
+            recomputeFilteredResults()
+            persistFiltersIfNeeded()
+        }
     }
     var filterMinSize: Int64? = nil {
-        didSet { if filterMinSize != oldValue { recomputeFilteredResults() } }
+        didSet {
+            guard filterMinSize != oldValue else { return }
+            recomputeFilteredResults()
+            persistFiltersIfNeeded()
+        }
     }
     var filterMaxSize: Int64? = nil {
-        didSet { if filterMaxSize != oldValue { recomputeFilteredResults() } }
+        didSet {
+            guard filterMaxSize != oldValue else { return }
+            recomputeFilteredResults()
+            persistFiltersIfNeeded()
+        }
     }
     var filterExtensions: Set<String> = [] {
-        didSet { if filterExtensions != oldValue { recomputeFilteredResults() } }
+        didSet {
+            guard filterExtensions != oldValue else { return }
+            recomputeFilteredResults()
+            persistFiltersIfNeeded()
+        }
     }
     var filterFreeSlotOnly: Bool = false {
-        didSet { if filterFreeSlotOnly != oldValue { recomputeFilteredResults() } }
+        didSet {
+            guard filterFreeSlotOnly != oldValue else { return }
+            recomputeFilteredResults()
+            persistFiltersIfNeeded()
+        }
     }
     var sortOrder: SortOrder = .relevance {
         didSet { if sortOrder != oldValue { recomputeFilteredResults() } }
     }
     var showFilters: Bool = false
+
+    private var currentPersistedFilters: PersistedSearchFilters {
+        PersistedSearchFilters(
+            minBitrate: filterMinBitrate,
+            minSampleRate: filterMinSampleRate,
+            minBitDepth: filterMinBitDepth,
+            minSize: filterMinSize,
+            maxSize: filterMaxSize,
+            extensions: filterExtensions,
+            freeSlotOnly: filterFreeSlotOnly
+        )
+    }
+
+    private func applyPersistedFilters(_ prefs: PersistedSearchFilters) {
+        suppressFilterPersist = true
+        defer { suppressFilterPersist = false }
+        filterMinBitrate = prefs.minBitrate
+        filterMinSampleRate = prefs.minSampleRate
+        filterMinBitDepth = prefs.minBitDepth
+        filterMinSize = prefs.minSize
+        filterMaxSize = prefs.maxSize
+        filterExtensions = prefs.extensions
+        filterFreeSlotOnly = prefs.freeSlotOnly
+    }
+
+    private func persistFiltersIfNeeded() {
+        guard !suppressFilterPersist, let settings else { return }
+        let prefs = currentPersistedFilters
+        guard settings.searchFilters != prefs else { return }
+        settings.searchFilters = prefs
+    }
 
     var hasActiveFilters: Bool {
         filterMinBitrate != nil ||

--- a/seeleseek/Features/Settings/SettingsState.swift
+++ b/seeleseek/Features/Settings/SettingsState.swift
@@ -73,6 +73,20 @@ enum DownloadFolderFormat: String, CaseIterable {
 
 }
 
+/// Search-result filter prefs that survive relaunch. Kept separate from
+/// `SearchState` so Settings can load them before the search tab wires up.
+struct PersistedSearchFilters: Equatable, Codable, Sendable {
+    var minBitrate: Int? = nil
+    var minSampleRate: Int? = nil
+    var minBitDepth: Int? = nil
+    var minSize: Int64? = nil
+    var maxSize: Int64? = nil
+    var extensions: Set<String> = []
+    var freeSlotOnly: Bool = false
+
+    static let empty = PersistedSearchFilters()
+}
+
 @Observable
 @MainActor
 final class SettingsState: DownloadSettingsProviding {
@@ -85,6 +99,7 @@ final class SettingsState: DownloadSettingsProviding {
     private let downloadSpeedLimitKey = "settingsDownloadSpeedLimit"
     private let maxSearchResultsKey = "settingsMaxSearchResults"
     private let groupSearchResultsKey = "settingsGroupSearchResults"
+    private let searchFiltersKey = "settingsSearchFilters"
     private let downloadLocationKey = "settingsDownloadLocation"
     private let incompleteLocationKey = "settingsIncompleteLocation"
     private let downloadFolderFormatKey = "settingsDownloadFolderFormat"
@@ -228,6 +243,15 @@ final class SettingsState: DownloadSettingsProviding {
     var groupSearchResults: Bool = false {
         didSet {
             guard !isLoading, groupSearchResults != oldValue else { return }
+            save()
+        }
+    }
+    /// Mirrors `SearchState` quality/format filters. Sort order and panel
+    /// open state stay session-only. Written back on every filter edit
+    /// (including Clear → empty).
+    var searchFilters: PersistedSearchFilters = .empty {
+        didSet {
+            guard !isLoading, searchFilters != oldValue else { return }
             save()
         }
     }
@@ -377,6 +401,7 @@ final class SettingsState: DownloadSettingsProviding {
         downloadSpeedLimit = 0
         maxSearchResults = 500
         groupSearchResults = false
+        searchFilters = .empty
         respondToSearches = true
         minSearchQueryLength = 3
         maxSearchResponseResults = 50
@@ -442,6 +467,9 @@ final class SettingsState: DownloadSettingsProviding {
         UserDefaults.standard.set(downloadSpeedLimit, forKey: downloadSpeedLimitKey)
         UserDefaults.standard.set(maxSearchResults, forKey: maxSearchResultsKey)
         UserDefaults.standard.set(groupSearchResults, forKey: groupSearchResultsKey)
+        if let data = try? JSONEncoder().encode(searchFilters) {
+            UserDefaults.standard.set(data, forKey: searchFiltersKey)
+        }
         UserDefaults.standard.set(downloadLocation.path, forKey: downloadLocationKey)
         UserDefaults.standard.set(incompleteLocation.path, forKey: incompleteLocationKey)
         UserDefaults.standard.set(downloadFolderFormat.rawValue, forKey: downloadFolderFormatKey)
@@ -517,6 +545,10 @@ final class SettingsState: DownloadSettingsProviding {
         }
         if UserDefaults.standard.object(forKey: groupSearchResultsKey) != nil {
             groupSearchResults = UserDefaults.standard.bool(forKey: groupSearchResultsKey)
+        }
+        if let data = UserDefaults.standard.data(forKey: searchFiltersKey),
+           let filters = try? JSONDecoder().decode(PersistedSearchFilters.self, from: data) {
+            searchFilters = filters
         }
         if let downloadPath = UserDefaults.standard.string(forKey: downloadLocationKey) {
             downloadLocation = URL(fileURLWithPath: downloadPath)


### PR DESCRIPTION
### Description

Match grouping/folder prefs so format, bitrate, and related filters survive quit; Clear writes empty prefs too.

### How to test

- [x] Set search filters (format, bitrate, and related options), quit the app fully, relaunch — filters should still be applied
- [x] Change grouping/folder prefs, quit and relaunch — those prefs should still match prior behavior and coexist with the new filter persistence
- [x] Use Clear on search filters, quit and relaunch — cleared/empty prefs should remain empty (not restore old values)

### Author checklist

This PR:

- [x] Satisfies a goal that is specific & clearly motivated
- [x] Adds value in isolation (whether user-facing or sustainability-related)
- [x] Contains a concise & easy-to-understand title + description
- [x] Adheres to [SRP](https://en.wikipedia.org/wiki/Single-responsibility_principle) by default
- [x] Presents the best possible implementation to meet its goal, given constraints at hand
