### PR TITLE
clean up search filter persistence, #87 followup

### DIFF
--- a/seeleseek/App/AppState.swift
+++ b/seeleseek/App/AppState.swift
@@ -119,7 +119,6 @@ final class AppState {
             }
         }
 
-        searchState.settings = settings
         searchState.setupCallbacks(client: client)
         chatState.setupCallbacks(client: client)
         browseState.configure(networkClient: client)
@@ -482,8 +481,8 @@ final class AppState {
 
         // Load persisted settings from UserDefaults initially (will migrate to DB)
         settings.load()
-        // Wire before anything touches `networkClient` so the search tab
-        // restores grouping + filters on first paint.
+        // Sole wiring point; must follow settings.load() or the search tab
+        // starts with empty grouping + filters.
         searchState.settings = settings
 
         // Sync launch-at-login state from system (user may toggle in System Settings)

--- a/seeleseek/Features/Search/SearchState.swift
+++ b/seeleseek/Features/Search/SearchState.swift
@@ -80,9 +80,7 @@ final class SearchState {
         didSet { syncPersistedSettings() }
     }
 
-    /// Pull grouping + filter prefs from `settings`. Fired whenever settings
-    /// is (re)assigned — including from `AppState.configure()` after load.
-    func syncPersistedSettings() {
+    private func syncPersistedSettings() {
         isGrouped = settings?.groupSearchResults ?? false
         applyPersistedFilters(settings?.searchFilters ?? .empty)
     }

--- a/seeleseek/Features/Settings/SettingsState.swift
+++ b/seeleseek/Features/Settings/SettingsState.swift
@@ -75,6 +75,8 @@ enum DownloadFolderFormat: String, CaseIterable {
 
 /// Search-result filter prefs that survive relaunch. Kept separate from
 /// `SearchState` so Settings can load them before the search tab wires up.
+/// New fields must be optional: synthesized Codable ignores the defaults
+/// below, so blobs from older builds would fail to decode and reset to .empty.
 struct PersistedSearchFilters: Equatable, Codable, Sendable {
     var minBitrate: Int? = nil
     var minSampleRate: Int? = nil

--- a/seeleseekTests/PersistedSearchFiltersTests.swift
+++ b/seeleseekTests/PersistedSearchFiltersTests.swift
@@ -1,0 +1,48 @@
+import Foundation
+import Testing
+@testable import seeleseek
+
+@Suite("Persisted search filters")
+struct PersistedSearchFiltersTests {
+
+    @Test("Round-trips with every field populated")
+    func roundTripFull() throws {
+        let filters = PersistedSearchFilters(
+            minBitrate: 320,
+            minSampleRate: 44_100,
+            minBitDepth: 16,
+            minSize: 1_048_576,
+            maxSize: 5_000_000_000,
+            extensions: ["flac", "mp3"],
+            freeSlotOnly: true
+        )
+        let data = try JSONEncoder().encode(filters)
+        let decoded = try JSONDecoder().decode(PersistedSearchFilters.self, from: data)
+        #expect(decoded == filters)
+    }
+
+    @Test("Round-trips empty (the Clear case)")
+    func roundTripEmpty() throws {
+        let data = try JSONEncoder().encode(PersistedSearchFilters.empty)
+        let decoded = try JSONDecoder().decode(PersistedSearchFilters.self, from: data)
+        #expect(decoded == .empty)
+        #expect(decoded.minBitrate == nil)
+        #expect(decoded.extensions.isEmpty)
+        #expect(!decoded.freeSlotOnly)
+    }
+
+    @Test("Optional fields tolerate absent keys in stored blobs")
+    func decodeMissingOptionalKeys() throws {
+        let json = Data(#"{"extensions":[],"freeSlotOnly":false}"#.utf8)
+        let decoded = try JSONDecoder().decode(PersistedSearchFilters.self, from: json)
+        #expect(decoded == .empty)
+    }
+
+    @Test("Missing non-optional key fails to decode")
+    func decodeMissingRequiredKeyFails() {
+        let json = Data(#"{"extensions":[]}"#.utf8)
+        #expect(throws: DecodingError.self) {
+            try JSONDecoder().decode(PersistedSearchFilters.self, from: json)
+        }
+    }
+}


### PR DESCRIPTION
### Description

This PR improves the handling and testing of persisted search filter settings, focusing on safer decoding and better test coverage. It refines the wiring of settings within the app state, and adds comprehensive tests for encoding and decoding filter settings.

**Persisted Search Filters Improvements:**

* Added a new test suite `PersistedSearchFiltersTests` to verify round-trip encoding/decoding, handling of missing optional keys, and decoding failures for missing required keys.

**App State and Settings Wiring:**

* Made the `syncPersistedSettings()` method in `SearchState` private, encapsulating the logic for syncing filter preferences from settings.

<!--
### Future work
A place to describe changes that can or will be done in follow-up PRs
-->

### How to test

- Ensure all checks pass

### Author checklist

This PR:

- [x] Satisfies a goal that is specific & clearly motivated
- [x] Adds value in isolation (whether user-facing or sustainability-related)
- [x] Contains a concise & easy-to-understand title + description
- [x] Adheres to [SRP](https://en.wikipedia.org/wiki/Single-responsibility_principle) by default
- [x] Presents the best possible implementation to meet its goal, given constraints at hand
