### PR TITLE
search results table

### DIFF
--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Models/SearchResult.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Models/SearchResult.swift
@@ -15,6 +15,13 @@ public struct SearchResult: Identifiable, Hashable, Sendable {
     public let queueLength: UInt32
     public let isPrivate: Bool  // Buddy-only / locked file
 
+    // Derived once at init, not computed: each is read several times per
+    // search-row body, and the repeated path splits were measurable in
+    // Instruments while scrolling.
+    public let displayFilename: String
+    public let folderPath: String
+    public let fileExtension: String
+
     public nonisolated init(
         id: UUID = UUID(),
         username: String,
@@ -43,23 +50,15 @@ public struct SearchResult: Identifiable, Hashable, Sendable {
         self.uploadSpeed = uploadSpeed
         self.queueLength = queueLength
         self.isPrivate = isPrivate
-    }
 
-    public var displayFilename: String {
-        // Extract just the filename from the full path
-        if let lastComponent = filename.split(separator: "\\").last {
-            return String(lastComponent)
-        }
-        return filename
-    }
-
-    public var folderPath: String {
-        // Get the folder path without the filename
         let components = filename.split(separator: "\\")
-        if components.count > 1 {
-            return components.dropLast().joined(separator: "\\")
-        }
-        return ""
+        let display = components.last.map(String.init) ?? filename
+        self.displayFilename = display
+        self.folderPath = components.count > 1
+            ? components.dropLast().joined(separator: "\\")
+            : ""
+        let dot = display.split(separator: ".")
+        self.fileExtension = dot.count > 1 ? String(dot[dot.count - 1]).lowercased() : ""
     }
 
     public var formattedSize: String {
@@ -101,14 +100,6 @@ public struct SearchResult: Identifiable, Hashable, Sendable {
     public var formattedBitDepth: String? {
         guard let bitDepth, bitDepth > 0 else { return nil }
         return "\(bitDepth)-bit"
-    }
-
-    public var fileExtension: String {
-        let components = displayFilename.split(separator: ".")
-        if components.count > 1, let ext = components.last {
-            return String(ext).lowercased()
-        }
-        return ""
     }
 
     public var isAudioFile: Bool { FileTypes.isAudio(fileExtension) }

--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Models/SearchResult.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Models/SearchResult.swift
@@ -15,9 +15,7 @@ public struct SearchResult: Identifiable, Hashable, Sendable {
     public let queueLength: UInt32
     public let isPrivate: Bool  // Buddy-only / locked file
 
-    // Derived once at init, not computed: each is read several times per
-    // search-row body, and the repeated path splits were measurable in
-    // Instruments while scrolling.
+    // Stored, not computed: each is read several times per search-row body.
     public let displayFilename: String
     public let folderPath: String
     public let fileExtension: String

--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Utilities/Formatters.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Utilities/Formatters.swift
@@ -2,11 +2,9 @@ import Foundation
 
 // MARK: - Byte counts
 
-// `ByteCountFormatter` is ~10x cheaper per call than
-// `formatted(.byteCount)`, which builds an AttributedString internally.
-// Search rows format sizes and peer speeds in `body`, so this runs
-// thousands of times per scroll. NSFormatter is not documented
-// thread-safe; Core callers can be off-main, hence the lock.
+// Not `formatted(.byteCount)`: that builds an AttributedString per call
+// and search rows format sizes in `body`. NSFormatter is not documented
+// thread-safe and Core callers can be off-main, hence the lock.
 nonisolated(unsafe) private let byteCountFormatter: ByteCountFormatter = {
     let f = ByteCountFormatter()
     f.countStyle = .file

--- a/Packages/SeeleseekCore/Sources/SeeleseekCore/Utilities/Formatters.swift
+++ b/Packages/SeeleseekCore/Sources/SeeleseekCore/Utilities/Formatters.swift
@@ -2,10 +2,24 @@ import Foundation
 
 // MARK: - Byte counts
 
+// `ByteCountFormatter` is ~10x cheaper per call than
+// `formatted(.byteCount)`, which builds an AttributedString internally.
+// Search rows format sizes and peer speeds in `body`, so this runs
+// thousands of times per scroll. NSFormatter is not documented
+// thread-safe; Core callers can be off-main, hence the lock.
+nonisolated(unsafe) private let byteCountFormatter: ByteCountFormatter = {
+    let f = ByteCountFormatter()
+    f.countStyle = .file
+    return f
+}()
+private let byteCountLock = NSLock()
+
 public extension Int64 {
     var formattedBytes: String {
         guard self > 0 else { return "0 KB" }
-        return formatted(.byteCount(style: .file))
+        byteCountLock.lock()
+        defer { byteCountLock.unlock() }
+        return byteCountFormatter.string(fromByteCount: self)
     }
     var formattedSpeed: String { formattedBytes + "/s" }
 }

--- a/seeleseek/Debug/SyntheticSearchDriver.swift
+++ b/seeleseek/Debug/SyntheticSearchDriver.swift
@@ -28,16 +28,6 @@ enum SyntheticSearchDriver {
         CommandLine.arguments.contains("--synth-search")
     }
 
-    /// LIVE mode: the app logs in and searches the real SoulSeek network
-    /// (normal `configure()` path), while the driver supplies the same
-    /// measurement rig — pacer, auto-scroll, cursor parking. This is the
-    /// only mode that exercises the real control plane: server messages,
-    /// peer-connection churn, pool bookkeeping, GeoIP — the load the
-    /// in-process synthetic stream bypasses entirely.
-    static var isLiveEnabled: Bool {
-        CommandLine.arguments.contains("--synth-live")
-    }
-
     private static var autoScroll: Bool {
         CommandLine.arguments.contains("--synth-scroll")
     }
@@ -170,88 +160,6 @@ enum SyntheticSearchDriver {
         window.sendEvent(event)
     }
 
-#if false
-    /// LIVE mode — see `isLiveEnabled`. The caller has already run the
-    /// normal `appState.configure()`; this waits for the real login, then
-    /// runs endless real search cycles with the same stream/hold phase
-    /// cadence as the synthetic mode so PACE lines stay comparable.
-    static func startLive(appState: AppState) {
-        lineBufferStdout()
-        appState.sidebarSelection = .search
-        NSApp.activate(ignoringOtherApps: true)
-        NSApp.windows.first?.makeKeyAndOrderFront(nil)
-        moveWindowToFastestScreenAfterRestore()
-        startHangMonitor()
-        if autoScroll {
-            Task { await runAutoScroll() }
-        }
-        startCursorParkingIfRequested()
-        Task { await liveSearchForever(appState: appState) }
-    }
-
-#endif
-#if false
-    private static func liveSearchForever(appState: AppState) async {
-        // There is no auto-connect in the app — LoginView's button does
-        // this. Replicate its flow with the saved credentials.
-        // NOTE: SoulSeek permits one session per account; this kicks any
-        // other running client on the same account.
-        try? await Task.sleep(for: .seconds(3))  // let configure()'s async setup land
-        guard let credentials = CredentialStorage.load() else {
-            synthLog("LIVE: no saved credentials in keychain — cannot log in")
-            return
-        }
-        appState.connection.loginUsername = credentials.username
-        appState.connection.loginPassword = credentials.password
-        appState.connection.setConnecting()
-        await appState.networkClient.setAcceptDistributedChildrenPreference(appState.settings.respondToSearches)
-        await appState.networkClient.connect(
-            server: ServerConnection.defaultHost,
-            port: ServerConnection.defaultPort,
-            username: credentials.username,
-            password: credentials.password,
-            preferredListenPort: UInt16(appState.settings.listenPort)
-        )
-
-        var waited = 0
-        while appState.connection.connectionStatus != .connected {
-            guard waited < 30 else {
-                synthLog("LIVE: gave up waiting for login after \(waited)s (error: \(appState.networkClient.status.connectionError ?? "none"))")
-                return
-            }
-            try? await Task.sleep(for: .seconds(1))
-            waited += 1
-        }
-        synthLog("LIVE: connected after \(waited)s")
-        try? await Task.sleep(for: .seconds(2))
-
-        let queries = ["mozart flac", "aphex twin", "beatles", "ambient flac", "miles davis", "radiohead"]
-        var cycle = 0
-        while true {
-            let query = queries[cycle % queries.count]
-            cycle += 1
-            appState.searchState.searchQuery = query
-            let token = UInt32.random(in: 1..<0x8000_0000)
-            appState.searchState.startSearch(token: token)
-            phase = "stream"
-            synthLog("LIVE: cycle \(cycle) query '\(query)'")
-            do {
-                try await appState.networkClient.search(query: query, token: token)
-            } catch {
-                synthLog("LIVE: search send failed: \(error)")
-            }
-            // Real searches stream on the server's schedule; give them the
-            // same 25s stream + 10s hold cadence the synthetic mode uses.
-            try? await Task.sleep(for: .seconds(25))
-            phase = "hold"
-            try? await Task.sleep(for: .seconds(10))
-            if let index = appState.searchState.searches.firstIndex(where: { $0.token == token }) {
-                appState.searchState.closeSearch(at: index)
-            }
-        }
-    }
-
-#endif
     private static func startCursorParkingIfRequested() {
         if CommandLine.arguments.contains("--synth-cursor") {
             // Park the real cursor over the results list. Cursor-in-window
@@ -344,14 +252,10 @@ enum SyntheticSearchDriver {
 
     // MARK: - Result streaming
 
-    /// Batches sized like real peer replies (a few files from one or two
-    /// folders per peer), with jittered arrival, until ~500 results — the
-    /// default `maxSearchResults`. Each peer also runs the country
-    /// pipeline the way a real reply does: `registerIP` (async GeoIP task
-    /// + `onCountryResolved` into SocialState) plus a seeded ISO code so
-    /// every row deterministically renders its flag-emoji Text — real rows
-    /// carry that color-emoji glyph and the first harness versions never
-    /// created it at all.
+    /// Batches sized like real peer replies, with jittered arrival, until
+    /// ~500 results (the default `maxSearchResults`). Each peer also runs
+    /// the country pipeline plus a seeded ISO code so every row renders its
+    /// flag-emoji Text, which real rows carry and which is not free.
     private static func stream(into state: SearchState, token: UInt32, appState: AppState) async {
         let cache = appState.networkClient.userInfoCache
         var total = 0
@@ -382,10 +286,8 @@ enum SyntheticSearchDriver {
     ]
 
     private static func peerBatch(peer: Int) -> [SearchResult] {
-        // Realistic identities: SoulSeek paths routinely run 150–250
-        // characters with unicode, and the row middle-truncates them —
-        // which costs a full-string text measurement per row. Short toy
-        // paths understate row cost.
+        // Real SoulSeek paths run 150–250 unicode characters and the row
+        // middle-truncates them; short toy paths understate row cost.
         let username = "MusicArchivist_\(["lossless", "vinyl_rips", "shared_library", "collection"][peer % 4])_\(1980 + peer % 45)_\(peer)"
         let artist = artists[peer % artists.count]
         let lossless = peer % 3 != 0
@@ -467,17 +369,14 @@ enum SyntheticSearchDriver {
                 stuckTicks = 0
                 synthLog("SYNTH: wheel polarity flipped")
             }
-            // Constant-VELOCITY scrolling: scale each event's delta by the
-            // actual elapsed time, so a busy main thread gets fewer but
-            // larger events and every run sweeps at the same pt/s. The
-            // earlier fixed-delta-per-iteration form scrolled faster when
-            // the main thread was freer, which made CPU comparisons
-            // between builds meaningless (faster sweep = more work/s).
+            // Delta scales with elapsed time so every run sweeps at the same
+            // pt/s regardless of main-thread load; a fixed delta per
+            // iteration made CPU comparisons between builds meaningless.
             let targetSpeed: CGFloat = 3000  // pt/s
-            let now2 = ContinuousClock.now
-            let dt = min(0.1, Double((now2 - lastTick).components.attoseconds) / 1e18
-                + Double((now2 - lastTick).components.seconds))
-            lastTick = now2
+            let now = ContinuousClock.now
+            let elapsed = (now - lastTick).components
+            let dt = min(0.1, Double(elapsed.seconds) + Double(elapsed.attoseconds) / 1e18)
+            lastTick = now
             let magnitude = min(300, targetSpeed * CGFloat(dt))
             let delta = Int32((sign * (goingDown ? -magnitude : magnitude)).rounded())
             guard let cg = CGEvent(
@@ -492,11 +391,8 @@ enum SyntheticSearchDriver {
         }
     }
 
-    /// The scroll view with the tallest DOCUMENT across all windows —
-    /// with 500 results the list document is tens of thousands of points,
-    /// while every other scroll view (sidebar, tab strip) is a few
-    /// hundred. Picking by scroll-view frame height instead selected one
-    /// of those and silently scrolled nothing.
+    /// Tallest DOCUMENT across all windows, not tallest scroll-view frame:
+    /// the latter picked the sidebar and silently scrolled nothing.
     private static func resultsScrollView() -> NSScrollView? {
         var found: [NSScrollView] = []
         for window in NSApp.windows {

--- a/seeleseek/Debug/SyntheticSearchDriver.swift
+++ b/seeleseek/Debug/SyntheticSearchDriver.swift
@@ -1,0 +1,580 @@
+#if DEBUG
+import Foundation
+import SeeleseekCore
+import AppKit
+
+/// Deterministic reproduction of "scroll the results list while a search
+/// streams in" — the scenario behind the search scroll-hitching reports —
+/// without needing a server login or live peers.
+///
+/// Launch with `--synth-search` (optionally `--synth-scroll`):
+///   - streams ~500 synthetic results in peer-sized batches over ~30s
+///   - `--synth-scroll` sweeps the results scroll view up and down
+///   - a main-actor pacer logs `PACE` lines (dropped-frame buckets per 5s)
+///     so variants can be compared by numbers instead of eyeballing
+/// Profile with `sample <pid>` while it runs.
+/// `SEELE_LOG_CHANGES=1` turns on per-view invalidation logging (see the
+/// `Self._printChanges()` probes in the search view cascade): each body
+/// re-evaluation prints which dependency changed, so observable-churn
+/// storms can be attributed to their source instead of guessed at.
+enum SynthDiag {
+    nonisolated static let logChanges =
+        ProcessInfo.processInfo.environment["SEELE_LOG_CHANGES"] != nil
+}
+
+@MainActor
+enum SyntheticSearchDriver {
+    static var isEnabled: Bool {
+        CommandLine.arguments.contains("--synth-search")
+    }
+
+    /// LIVE mode: the app logs in and searches the real SoulSeek network
+    /// (normal `configure()` path), while the driver supplies the same
+    /// measurement rig — pacer, auto-scroll, cursor parking. This is the
+    /// only mode that exercises the real control plane: server messages,
+    /// peer-connection churn, pool bookkeeping, GeoIP — the load the
+    /// in-process synthetic stream bypasses entirely.
+    static var isLiveEnabled: Bool {
+        CommandLine.arguments.contains("--synth-live")
+    }
+
+    private static var autoScroll: Bool {
+        CommandLine.arguments.contains("--synth-scroll")
+    }
+
+    /// PROBE mode: instead of load generation, verify the search-row
+    /// action cluster end to end — warp the real cursor over each button
+    /// (so tracking areas engage hover), synthesize a click through the
+    /// window's event pipeline, and log which app action actually fired.
+    private static var probe: Bool {
+        CommandLine.arguments.contains("--synth-probe")
+    }
+
+    /// `_printChanges` goes through `print` → stdout, which is block-
+    /// buffered when redirected to a file; a killed process drops the
+    /// unflushed tail. Line-buffer it so change logs survive.
+    private static func lineBufferStdout() {
+        setvbuf(stdout, nil, _IOLBF, 0)
+    }
+
+    static func start(appState: AppState) {
+        lineBufferStdout()
+        appState.connection.setConnected(
+            username: "demo_user",
+            ip: "192.0.2.42",
+            greeting: ""
+        )
+        appState.sidebarSelection = .search
+
+        // Launched from a terminal the app starts in the background, where
+        // the window is occluded and nothing renders — the repro needs
+        // live drawing.
+        NSApp.activate(ignoringOtherApps: true)
+        NSApp.windows.first?.makeKeyAndOrderFront(nil)
+        moveWindowToFastestScreenAfterRestore()
+
+        startHangMonitor()
+        Task { await streamForever(appState: appState) }
+        if autoScroll {
+            Task { await runAutoScroll() }
+        }
+        startCursorParkingIfRequested()
+        if probe {
+            Task { await runClusterProbe(appState: appState) }
+        }
+    }
+
+    // MARK: - Cluster probe
+
+    /// Hover + click each button of a search row's trailing cluster and
+    /// log the app state that changes, so click-target accuracy can be
+    /// verified from the log alone. Run with SEELE_LOG_CHANGES=1 to also
+    /// see hover engagement (the cluster re-prints on the env flip).
+    private static func runClusterProbe(appState: AppState) async {
+        try? await Task.sleep(for: .seconds(8))
+        guard let scrollView = resultsScrollView(),
+              scrollView.documentView != nil,
+              scrollView.window != nil else {
+            synthLog("PROBE: results scroll view not found")
+            return
+        }
+
+        // Document coords are authoritative: converting from the document
+        // view sidesteps content insets, scroll offset, and flippedness.
+        // Row pitch = rowHeight 58 + divider 1; probe row 3's center.
+        let rowCenterDocY = 3 * 59.0 + 29.0
+        // From the row's trailing edge (doc right): padding 16, download
+        // 32 wide, gap 2, person 28, gap 2, folder 28.
+        let targets: [(name: String, xFromRight: CGFloat)] = [
+            ("person(view-profile)", 64),   // 16 + 32 + 2 + 14
+            ("folder(browse-folder)", 94), // 16 + 32 + 2 + 28 + 2 + 14
+        ]
+
+        for target in targets {
+            appState.socialState.showProfileSheet = false
+            appState.sidebarSelection = .search
+            try? await Task.sleep(for: .seconds(1))
+            guard let sv = resultsScrollView(), let d = sv.documentView,
+                  let win = sv.window else { break }
+            let docPoint = NSPoint(x: d.bounds.maxX - target.xFromRight, y: rowCenterDocY)
+            let winPoint = d.convert(docPoint, to: nil)
+
+            // Real-cursor warp so tracking areas fire mouseEntered, plus
+            // a synthesized move so SwiftUI sees the position.
+            let screenPoint = win.convertPoint(toScreen: winPoint)
+            if let screenHeight = NSScreen.screens.first?.frame.height {
+                CGWarpMouseCursorPosition(CGPoint(x: screenPoint.x, y: screenHeight - screenPoint.y))
+            }
+            sendMouse(.mouseMoved, at: winPoint, in: win)
+            try? await Task.sleep(for: .milliseconds(700))
+
+            let before = probeStateSnapshot(appState)
+            sendMouse(.leftMouseDown, at: winPoint, in: win, clickCount: 1)
+            try? await Task.sleep(for: .milliseconds(80))
+            sendMouse(.leftMouseUp, at: winPoint, in: win, clickCount: 1)
+            try? await Task.sleep(for: .milliseconds(1200))
+            let after = probeStateSnapshot(appState)
+            synthLog("PROBE: \(target.name) @doc(\(Int(docPoint.x)),\(Int(docPoint.y)))")
+            synthLog("PROBE:   before \(before)")
+            synthLog("PROBE:   after  \(after)")
+        }
+        synthLog("PROBE: done")
+    }
+
+    private static func probeStateSnapshot(_ appState: AppState) -> String {
+        let sidebar = String(describing: appState.sidebarSelection)
+        let folder = appState.browseState.currentFolderPath ?? "nil"
+        let profile = appState.socialState.viewingProfile?.username ?? "nil"
+        return "sidebar=\(sidebar) browseUser='\(appState.browseState.currentUser)' folder='\(folder)' profileSheet=\(appState.socialState.showProfileSheet):\(profile)"
+    }
+
+    private static var probeEventNumber = 1000
+    private static func sendMouse(
+        _ type: NSEvent.EventType,
+        at point: NSPoint,
+        in window: NSWindow,
+        clickCount: Int = 0
+    ) {
+        probeEventNumber += 1
+        guard let event = NSEvent.mouseEvent(
+            with: type,
+            location: point,
+            modifierFlags: [],
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: window.windowNumber,
+            context: nil,
+            eventNumber: probeEventNumber,
+            clickCount: clickCount,
+            pressure: type == .leftMouseDown ? 1 : 0
+        ) else { return }
+        window.sendEvent(event)
+    }
+
+#if false
+    /// LIVE mode — see `isLiveEnabled`. The caller has already run the
+    /// normal `appState.configure()`; this waits for the real login, then
+    /// runs endless real search cycles with the same stream/hold phase
+    /// cadence as the synthetic mode so PACE lines stay comparable.
+    static func startLive(appState: AppState) {
+        lineBufferStdout()
+        appState.sidebarSelection = .search
+        NSApp.activate(ignoringOtherApps: true)
+        NSApp.windows.first?.makeKeyAndOrderFront(nil)
+        moveWindowToFastestScreenAfterRestore()
+        startHangMonitor()
+        if autoScroll {
+            Task { await runAutoScroll() }
+        }
+        startCursorParkingIfRequested()
+        Task { await liveSearchForever(appState: appState) }
+    }
+
+#endif
+#if false
+    private static func liveSearchForever(appState: AppState) async {
+        // There is no auto-connect in the app — LoginView's button does
+        // this. Replicate its flow with the saved credentials.
+        // NOTE: SoulSeek permits one session per account; this kicks any
+        // other running client on the same account.
+        try? await Task.sleep(for: .seconds(3))  // let configure()'s async setup land
+        guard let credentials = CredentialStorage.load() else {
+            synthLog("LIVE: no saved credentials in keychain — cannot log in")
+            return
+        }
+        appState.connection.loginUsername = credentials.username
+        appState.connection.loginPassword = credentials.password
+        appState.connection.setConnecting()
+        await appState.networkClient.setAcceptDistributedChildrenPreference(appState.settings.respondToSearches)
+        await appState.networkClient.connect(
+            server: ServerConnection.defaultHost,
+            port: ServerConnection.defaultPort,
+            username: credentials.username,
+            password: credentials.password,
+            preferredListenPort: UInt16(appState.settings.listenPort)
+        )
+
+        var waited = 0
+        while appState.connection.connectionStatus != .connected {
+            guard waited < 30 else {
+                synthLog("LIVE: gave up waiting for login after \(waited)s (error: \(appState.networkClient.status.connectionError ?? "none"))")
+                return
+            }
+            try? await Task.sleep(for: .seconds(1))
+            waited += 1
+        }
+        synthLog("LIVE: connected after \(waited)s")
+        try? await Task.sleep(for: .seconds(2))
+
+        let queries = ["mozart flac", "aphex twin", "beatles", "ambient flac", "miles davis", "radiohead"]
+        var cycle = 0
+        while true {
+            let query = queries[cycle % queries.count]
+            cycle += 1
+            appState.searchState.searchQuery = query
+            let token = UInt32.random(in: 1..<0x8000_0000)
+            appState.searchState.startSearch(token: token)
+            phase = "stream"
+            synthLog("LIVE: cycle \(cycle) query '\(query)'")
+            do {
+                try await appState.networkClient.search(query: query, token: token)
+            } catch {
+                synthLog("LIVE: search send failed: \(error)")
+            }
+            // Real searches stream on the server's schedule; give them the
+            // same 25s stream + 10s hold cadence the synthetic mode uses.
+            try? await Task.sleep(for: .seconds(25))
+            phase = "hold"
+            try? await Task.sleep(for: .seconds(10))
+            if let index = appState.searchState.searches.firstIndex(where: { $0.token == token }) {
+                appState.searchState.closeSearch(at: index)
+            }
+        }
+    }
+
+#endif
+    private static func startCursorParkingIfRequested() {
+        if CommandLine.arguments.contains("--synth-cursor") {
+            // Park the real cursor over the results list. Cursor-in-window
+            // is a distinct performance regime: AppKit/SwiftUI re-evaluate
+            // hover targets against the moving rows every frame. Warped
+            // periodically so a user nudge doesn't silently end the regime.
+            Task {
+                var lastWarp = ContinuousClock.now - .seconds(10)
+                while true {
+                    try? await Task.sleep(for: .milliseconds(50))
+                    guard let scrollView = resultsScrollView(),
+                          let window = scrollView.window else { continue }
+                    let local = scrollView.convert(
+                        NSPoint(x: scrollView.bounds.midX, y: scrollView.bounds.midY),
+                        to: nil
+                    )
+                    if ContinuousClock.now - lastWarp > .seconds(2) {
+                        lastWarp = .now
+                        let screen = window.convertPoint(toScreen: local)
+                        if let screenHeight = NSScreen.screens.first?.frame.height {
+                            CGWarpMouseCursorPosition(CGPoint(x: screen.x, y: screenHeight - screen.y))
+                        }
+                    }
+                    // Warping alone fires no events, so hover/tracking would
+                    // stay dormant; a synthesized in-window mouseMoved at the
+                    // parked position runs the real pipeline each tick.
+                    if let move = NSEvent.mouseEvent(
+                        with: .mouseMoved,
+                        location: local,
+                        modifierFlags: [],
+                        timestamp: ProcessInfo.processInfo.systemUptime,
+                        windowNumber: window.windowNumber,
+                        context: nil,
+                        eventNumber: 0,
+                        clickCount: 0,
+                        pressure: 0
+                    ) {
+                        window.sendEvent(move)
+                    }
+                }
+            }
+        }
+    }
+
+    /// Which repro phase is running, for per-phase scroll stats:
+    /// "stream" while results land, "hold" after the search completes.
+    private static var phase = "stream"
+
+    /// Endless repro cycles: stream a full search, hold 10s (the
+    /// "completed search" scroll phase), close the tab, start over.
+    private static func streamForever(appState: AppState) async {
+        let state = appState.searchState
+        var cycle: UInt32 = 0
+        while true {
+            cycle += 1
+            state.searchQuery = "synthetic stress \(cycle)"
+            let token = 0x5EED_0000 + cycle
+            state.startSearch(token: token)
+            phase = "stream"
+            synthLog("SYNTH: cycle \(cycle) streaming")
+            await stream(into: state, token: token, appState: appState)
+            phase = "hold"
+            try? await Task.sleep(for: .seconds(10))
+            if let index = state.searches.firstIndex(where: { $0.token == token }) {
+                state.closeSearch(at: index)
+            }
+        }
+    }
+
+    /// `print` to a redirected stdout is block-buffered; stderr is not.
+    /// Lines are also mirrored to `SEELE_SYNTH_LOG`, or to
+    /// `seele_synth.log` in the app's own temp directory if no override is
+    /// provided. UI-test-launched instances often swallow stderr, so the
+    /// file copy is the stable way to inspect pacing data after a run.
+    private static let logFile: FileHandle? = {
+        let requested = ProcessInfo.processInfo.environment["SEELE_SYNTH_LOG"]
+        for path in [requested, NSTemporaryDirectory() + "seele_synth.log"].compactMap({ $0 }) {
+            FileManager.default.createFile(atPath: path, contents: nil)
+            if let handle = FileHandle(forWritingAtPath: path) { return handle }
+        }
+        return nil
+    }()
+
+    private static func synthLog(_ message: String) {
+        let stamp = String(format: "%.1f", ProcessInfo.processInfo.systemUptime)
+        let data = Data(("[\(stamp)] " + message + "\n").utf8)
+        FileHandle.standardError.write(data)
+        logFile?.write(data)
+    }
+
+    // MARK: - Result streaming
+
+    /// Batches sized like real peer replies (a few files from one or two
+    /// folders per peer), with jittered arrival, until ~500 results — the
+    /// default `maxSearchResults`. Each peer also runs the country
+    /// pipeline the way a real reply does: `registerIP` (async GeoIP task
+    /// + `onCountryResolved` into SocialState) plus a seeded ISO code so
+    /// every row deterministically renders its flag-emoji Text — real rows
+    /// carry that color-emoji glyph and the first harness versions never
+    /// created it at all.
+    private static func stream(into state: SearchState, token: UInt32, appState: AppState) async {
+        let cache = appState.networkClient.userInfoCache
+        var total = 0
+        var peer = 0
+        while total < 500 {
+            try? await Task.sleep(for: .milliseconds(UInt64.random(in: 30...140)))
+            peer += 1
+            let batch = peerBatch(peer: peer)
+            if let username = batch.first?.username {
+                cache.registerIP("81.2.\(peer % 250).\(peer % 200 + 1)", for: username)
+                cache.seedCountry(Self.countryCodes[peer % Self.countryCodes.count], for: username)
+            }
+            state.addResults(batch, forToken: token)
+            total += batch.count
+        }
+        synthLog("SYNTH: streaming done, \(total) results sent")
+    }
+
+    private static let countryCodes = [
+        "US", "DE", "GB", "FR", "NL", "SE", "PL", "BR",
+        "JP", "AU", "CA", "FI", "IT", "ES", "CZ", "NO",
+    ]
+
+    private static let artists = [
+        "Radiohead", "Boards of Canada", "Aphex Twin", "Cindy Lee",
+        "My Bloody Valentine", "Slowdive", "Fennesz", "Burial",
+        "Björk", "Sigur Rós", "坂本龍一", "Broadcast",
+    ]
+
+    private static func peerBatch(peer: Int) -> [SearchResult] {
+        // Realistic identities: SoulSeek paths routinely run 150–250
+        // characters with unicode, and the row middle-truncates them —
+        // which costs a full-string text measurement per row. Short toy
+        // paths understate row cost.
+        let username = "MusicArchivist_\(["lossless", "vinyl_rips", "shared_library", "collection"][peer % 4])_\(1980 + peer % 45)_\(peer)"
+        let artist = artists[peer % artists.count]
+        let lossless = peer % 3 != 0
+        let ext = lossless ? "flac" : "mp3"
+        let year = 1988 + peer % 38
+        let edition = lossless
+            ? "[FLAC] [\(peer % 2 == 0 ? "16bit-44.1kHz" : "24bit-96kHz")] {\(peer % 2 == 0 ? "Deluxe Remastered Edition" : "Original Press")}"
+            : "[MP3 320 CBR] {Web Rip}"
+        let folder = "@@shares\\Music Library (sorted by genre)\\Electronic & Experimental\\\(artist)\\\(artist) - Album Number \(peer) — The Extended Anniversary Collection (\(year)) \(edition)"
+        let count = Int.random(in: 2...12)
+        let free = peer % 5 != 0
+        return (1...count).map { track in
+            SearchResult(
+                username: username,
+                filename: "\(folder)\\\(String(format: "%02d", track)) - \(artist) - A Fairly Long Descriptive Track Title (Original Extended Mix) [Explicit] feat. Someone Else.\(ext)",
+                size: UInt64.random(in: 3_000_000...60_000_000),
+                bitrate: lossless ? UInt32.random(in: 700...1100) : 320,
+                duration: UInt32.random(in: 90...600),
+                sampleRate: lossless ? 44100 : nil,
+                bitDepth: lossless ? 16 : nil,
+                isVBR: !lossless && peer % 7 == 0,
+                freeSlots: free,
+                uploadSpeed: UInt32.random(in: 50_000...8_000_000),
+                queueLength: free ? 0 : UInt32.random(in: 1...20),
+                isPrivate: peer % 11 == 0
+            )
+        }
+    }
+
+    // MARK: - Auto scroll
+
+    /// Sweeps the results list bottom-to-top-to-bottom continuously by
+    /// injecting REAL pixel-unit `scrollWheel` events at ~125Hz into the
+    /// scroll view — the genuine wheel-handling path (smooth scrolling,
+    /// tracking invalidation), at hard-flick speed (~7500 pt/s), and
+    /// visibly fast on screen. Driving the clip view directly or posting
+    /// per-event XCUI scrolls both understate real scrolling.
+    private static func runAutoScroll() async {
+        try? await Task.sleep(for: .seconds(3))
+        var goingDown = true
+        // Wheel polarity differs across system scroll settings; if events
+        // stop moving the list mid-range, flip the sign.
+        var sign: CGFloat = 1
+        var lastY: CGFloat = -1
+        var stuckTicks = 0
+        // Proof of motion: total distance traveled per report window. A
+        // stationary list produces clean pacer numbers that mean nothing.
+        var traveled: CGFloat = 0
+        var lastTravelReport = ContinuousClock.now
+        var lastTick = ContinuousClock.now
+        while true {
+            try? await Task.sleep(for: .milliseconds(8))
+            if ContinuousClock.now - lastTravelReport > .seconds(5) {
+                let windows = NSApp.windows.count
+                let sv = resultsScrollView()
+                let docH = Int(sv?.documentView?.frame.height ?? -1)
+                let cap = ProcessInfo.processInfo.environment["SEELE_SCROLL_RANGE"] ?? "none"
+                synthLog("TRAVEL: \(Int(traveled)) pt in 5s (y=\(Int(lastY)), windows=\(windows), scrollView=\(sv != nil), docH=\(docH), cap=\(cap))")
+                traveled = 0
+                lastTravelReport = .now
+            }
+            guard let scrollView = resultsScrollView(),
+                  let doc = scrollView.documentView else { continue }
+            let clip = scrollView.contentView
+            // SEELE_SCROLL_RANGE caps how deep the sweep goes — for
+            // measuring how cost scales with materialized-row count.
+            let rangeCap = ProcessInfo.processInfo.environment["SEELE_SCROLL_RANGE"]
+                .flatMap(Double.init).map { CGFloat($0) } ?? .infinity
+            let maxY = min(rangeCap, max(0, doc.frame.height - clip.bounds.height))
+            guard maxY > 0 else { continue }
+            let y = clip.bounds.origin.y
+            if goingDown && y >= maxY - 1 { goingDown = false }
+            if !goingDown && y <= 1 { goingDown = true }
+            if abs(y - lastY) < 0.5 { stuckTicks += 1 } else { stuckTicks = 0 }
+            if lastY >= 0 { traveled += abs(y - lastY) }
+            lastY = y
+            if stuckTicks > 30, y > 1, y < maxY - 1 {
+                sign = -sign
+                stuckTicks = 0
+                synthLog("SYNTH: wheel polarity flipped")
+            }
+            // Constant-VELOCITY scrolling: scale each event's delta by the
+            // actual elapsed time, so a busy main thread gets fewer but
+            // larger events and every run sweeps at the same pt/s. The
+            // earlier fixed-delta-per-iteration form scrolled faster when
+            // the main thread was freer, which made CPU comparisons
+            // between builds meaningless (faster sweep = more work/s).
+            let targetSpeed: CGFloat = 3000  // pt/s
+            let now2 = ContinuousClock.now
+            let dt = min(0.1, Double((now2 - lastTick).components.attoseconds) / 1e18
+                + Double((now2 - lastTick).components.seconds))
+            lastTick = now2
+            let magnitude = min(300, targetSpeed * CGFloat(dt))
+            let delta = Int32((sign * (goingDown ? -magnitude : magnitude)).rounded())
+            guard let cg = CGEvent(
+                scrollWheelEvent2Source: nil,
+                units: .pixel,
+                wheelCount: 1,
+                wheel1: delta,
+                wheel2: 0,
+                wheel3: 0
+            ), let event = NSEvent(cgEvent: cg) else { continue }
+            scrollView.scrollWheel(with: event)
+        }
+    }
+
+    /// The scroll view with the tallest DOCUMENT across all windows —
+    /// with 500 results the list document is tens of thousands of points,
+    /// while every other scroll view (sidebar, tab strip) is a few
+    /// hundred. Picking by scroll-view frame height instead selected one
+    /// of those and silently scrolled nothing.
+    private static func resultsScrollView() -> NSScrollView? {
+        var found: [NSScrollView] = []
+        for window in NSApp.windows {
+            guard let root = window.contentView else { continue }
+            var queue: [NSView] = [root]
+            while let view = queue.popLast() {
+                if let sv = view as? NSScrollView { found.append(sv) }
+                queue.append(contentsOf: view.subviews)
+            }
+        }
+        return found.max {
+            ($0.documentView?.frame.height ?? 0) < ($1.documentView?.frame.height ?? 0)
+        }
+    }
+
+    // MARK: - Hang monitor
+
+    /// Main-actor pacer: 8ms ticks, resume gaps bucketed in frames of the
+    /// panel the app window is on (`maximumFramesPerSecond`: 120 on
+    /// ProMotion). A fixed 33ms threshold hid every 120Hz drop — one frame
+    /// there is 8.3ms. Buckets: >2 frames dropped, >4 frames visible jank,
+    /// >150ms stall. At 60Hz these equal the old 33/66/150ms lines, so
+    /// earlier logs stay comparable; `hz=` on each line says which.
+    private static func startHangMonitor() {
+        Task { @MainActor in
+            var last = ContinuousClock.now
+            var lastReport = last
+            var ticks = 0, dropped = 0, jank = 0, stalls = 0
+            var maxGap: Duration = .zero
+            var statsPhase = phase
+            var hz = displayHz()
+            var frame = Duration.seconds(1) / hz
+            while true {
+                try? await Task.sleep(for: .milliseconds(8))
+                let now = ContinuousClock.now
+                let gap = now - last
+                last = now
+                ticks += 1
+                if gap > frame * 2 { dropped += 1 }
+                if gap > frame * 4 { jank += 1 }
+                if gap > .milliseconds(150) { stalls += 1 }
+                if gap > maxGap { maxGap = gap }
+                if phase != statsPhase || now - lastReport > .seconds(5) {
+                    synthLog("PACE[\(statsPhase)]: hz=\(hz) ticks=\(ticks) >2f=\(dropped) >4f=\(jank) >150ms=\(stalls) max=\(maxGap) active=\(NSApp.isActive)")
+                    ticks = 0; dropped = 0; jank = 0; stalls = 0; maxGap = .zero
+                    statsPhase = phase
+                    lastReport = now
+                    hz = displayHz()
+                    frame = Duration.seconds(1) / hz
+                }
+            }
+        }
+    }
+
+    /// A restored window frame can land on a slower external display;
+    /// pacing must be measured on the fastest panel (ProMotion = 120Hz).
+    /// Delayed: SwiftUI applies the restored frame after the first
+    /// appearance, undoing a move made from `.task`.
+    private static func moveWindowToFastestScreenAfterRestore() {
+        Task {
+            try? await Task.sleep(for: .seconds(1))
+            moveWindowToFastestScreen()
+        }
+    }
+
+    private static func moveWindowToFastestScreen() {
+        guard let window = NSApp.windows.first,
+              let target = NSScreen.screens.max(by: { $0.maximumFramesPerSecond < $1.maximumFramesPerSecond }),
+              window.screen != target else { return }
+        let size = window.frame.size
+        let visible = target.visibleFrame
+        let origin = NSPoint(x: visible.midX - size.width / 2, y: visible.midY - size.height / 2)
+        window.setFrame(NSRect(origin: origin, size: size).intersection(visible), display: true)
+    }
+
+    private static func displayHz() -> Int {
+        let screen = NSApp.keyWindow?.screen ?? NSApp.windows.first?.screen ?? NSScreen.main
+        return max(screen?.maximumFramesPerSecond ?? 60, 1)
+    }
+}
+#endif

--- a/seeleseek/DesignSystem/Components/Layout/FolderPathLabel.swift
+++ b/seeleseek/DesignSystem/Components/Layout/FolderPathLabel.swift
@@ -25,7 +25,7 @@ struct FolderPathLabel: View {
                 .foregroundStyle(SeeleColors.textTertiary)
                 .lineLimit(1)
                 .truncationMode(.middle)
-                .help(help ?? text)
+                .rowHelp(help ?? text)
         }
     }
 }

--- a/seeleseek/DesignSystem/Components/Layout/RowIconButton.swift
+++ b/seeleseek/DesignSystem/Components/Layout/RowIconButton.swift
@@ -22,12 +22,9 @@ struct RowIconButton: View {
         isProminent ? SeeleSpacing.iconSizeXL : SeeleSpacing.buttonHeight
     }
 
-    // Not a SwiftUI `Button`. Measured on a 120Hz panel (500-row search,
-    // 3000pt/s wheel, cursor over rows): with one `Button` per live row
-    // the list dropped ~160 frames per 5s; as a tap-gesture glyph, ~30.
-    // `.focusable(false)` and `.focusEffectDisabled()` on the Button do
-    // not help. Cost: no Tab focus on row actions — VoiceOver keeps the
-    // label, button trait and activation.
+    // Not a SwiftUI `Button`: one per live row cost ~160 dropped frames
+    // per 5s at 120Hz vs ~30 for a tap-gesture glyph, and `.focusable(false)`
+    // / `.focusEffectDisabled()` do not help. Cost: no Tab focus on row actions.
     var body: some View {
         Image(systemName: systemName)
             .font(.system(size: glyphSize, weight: weight))

--- a/seeleseek/DesignSystem/Components/Layout/RowIconButton.swift
+++ b/seeleseek/DesignSystem/Components/Layout/RowIconButton.swift
@@ -22,16 +22,22 @@ struct RowIconButton: View {
         isProminent ? SeeleSpacing.iconSizeXL : SeeleSpacing.buttonHeight
     }
 
+    // Not a SwiftUI `Button`. Measured on a 120Hz panel (500-row search,
+    // 3000pt/s wheel, cursor over rows): with one `Button` per live row
+    // the list dropped ~160 frames per 5s; as a tap-gesture glyph, ~30.
+    // `.focusable(false)` and `.focusEffectDisabled()` on the Button do
+    // not help. Cost: no Tab focus on row actions — VoiceOver keeps the
+    // label, button trait and activation.
     var body: some View {
-        Button(action: action) {
-            Image(systemName: systemName)
-                .font(.system(size: glyphSize, weight: weight))
-                .foregroundStyle(tint)
-                .frame(width: hitTarget, height: hitTarget)
-                .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .help(help)
-        .accessibilityLabel(help)
+        Image(systemName: systemName)
+            .font(.system(size: glyphSize, weight: weight))
+            .foregroundStyle(tint)
+            .frame(width: hitTarget, height: hitTarget)
+            .contentShape(Rectangle())
+            .onTapGesture(perform: action)
+            .rowHelp(help)
+            .accessibilityLabel(help)
+            .accessibilityAddTraits(.isButton)
+            .accessibilityAction { action() }
     }
 }

--- a/seeleseek/DesignSystem/Components/Layout/StandardListRow.swift
+++ b/seeleseek/DesignSystem/Components/Layout/StandardListRow.swift
@@ -1,12 +1,25 @@
 import SwiftUI
 import SeeleseekCore
 
-/// Consistent list row with hover support
+/// Consistent list row with hover support.
+///
+/// Hover is published to `content` via `\.isRowHovered`. Read it in the
+/// smallest leaf view that needs it, not in the row's own `body`: a
+/// `@State` flipped through `onHoverChanged` re-evaluates the entire row
+/// on every enter/leave, and with the cursor over a 500-row search list
+/// that was the dominant hitch source in Instruments.
 struct StandardListRow<Content: View>: View {
     let content: Content
     let onHoverChanged: ((Bool) -> Void)?
     @State private var isHovered = false
+    /// Where the pointer actually is, including enters dropped during
+    /// suppression. A reference box so per-row enter/exit churn during
+    /// scroll never invalidates the row.
+    @State private var pointer = PointerBox()
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.rowHoverSuppressed) private var hoverSuppressed
+
+    private final class PointerBox { var inside = false }
 
     init(@ViewBuilder content: () -> Content) {
         self.onHoverChanged = nil
@@ -23,16 +36,49 @@ struct StandardListRow<Content: View>: View {
             .padding(.horizontal, SeeleSpacing.lg)
             .padding(.vertical, SeeleSpacing.md)
             .background(isHovered ? SeeleColors.surfaceSecondary : SeeleColors.surface)
+            .environment(\.isRowHovered, isHovered)
             .onHover { hovering in
-                let animation: Animation? = reduceMotion
-                    ? nil
-                    : .easeInOut(duration: SeeleSpacing.animationFast)
-                withAnimation(animation) {
-                    isHovered = hovering
+                // While the list scrolls, rows stream under a stationary
+                // cursor and AppKit fires enter/exit per row. Engaging
+                // hover for each one re-animated and re-evaluated every
+                // passing row — the dominant fast-scroll jank source.
+                // Enters are dropped during scroll; exits always land so
+                // no row is left stuck highlighted.
+                pointer.inside = hovering
+                if hovering && hoverSuppressed { return }
+                setHovered(hovering)
+            }
+            .onChange(of: hoverSuppressed) { _, suppressed in
+                // Replay an enter dropped during suppression: AppKit does
+                // not re-send one for the row already under the cursor
+                // when the scroll settles, so without this the row stays
+                // visually cold (no highlight, hidden action cluster)
+                // until the mouse physically moves.
+                if !suppressed && pointer.inside != isHovered {
+                    setHovered(pointer.inside)
                 }
-                onHoverChanged?(hovering)
             }
     }
+
+    private func setHovered(_ hovering: Bool) {
+        let animation: Animation? = reduceMotion
+            ? nil
+            : .easeInOut(duration: SeeleSpacing.animationFast)
+        withAnimation(animation) {
+            isHovered = hovering
+        }
+        onHoverChanged?(hovering)
+    }
+}
+
+extension EnvironmentValues {
+    /// True while the pointer is over the enclosing `StandardListRow`.
+    @Entry var isRowHovered = false
+
+    /// Set by a scrolling container to stop rows from ENGAGING hover
+    /// while content is in motion (exits still process). See the
+    /// `onHover` note in `StandardListRow`.
+    @Entry var rowHoverSuppressed = false
 }
 
 #Preview {
@@ -55,4 +101,33 @@ struct StandardListRow<Content: View>: View {
         }
     }
     .background(SeeleColors.background)
+}
+
+/// `help()` installs an AppKit tracking area per call. Rows carry several
+/// tooltips each, and hundreds of rows stay live in a lazy stack, so the
+/// tooltips alone were a measurable share of scroll layout cost. Only the
+/// hovered row can show a tooltip; only it pays for one.
+private struct RowHelp: ViewModifier {
+    @Environment(\.isRowHovered) private var isRowHovered
+    let text: String
+
+    func body(content: Content) -> some View {
+        // The conditional must never wrap `content` itself: an if/else
+        // branch switch on hover gives the wrapped control a new
+        // structural identity, tearing down the live button under the
+        // cursor (lost clicks, cold hover state). The tooltip rides a
+        // background so only that passive subtree changes on hover.
+        content.background {
+            if isRowHovered {
+                Color.clear.help(text)
+            }
+        }
+    }
+}
+
+extension View {
+    /// `help()` that exists only while the enclosing `StandardListRow` is hovered.
+    func rowHelp(_ text: String) -> some View {
+        modifier(RowHelp(text: text))
+    }
 }

--- a/seeleseek/DesignSystem/Components/Layout/StandardListRow.swift
+++ b/seeleseek/DesignSystem/Components/Layout/StandardListRow.swift
@@ -4,22 +4,13 @@ import SeeleseekCore
 /// Consistent list row with hover support.
 ///
 /// Hover is published to `content` via `\.isRowHovered`. Read it in the
-/// smallest leaf view that needs it, not in the row's own `body`: a
-/// `@State` flipped through `onHoverChanged` re-evaluates the entire row
-/// on every enter/leave, and with the cursor over a 500-row search list
-/// that was the dominant hitch source in Instruments.
+/// smallest leaf that needs it: a `@State` flipped through `onHoverChanged`
+/// re-evaluates the entire row on every enter/leave.
 struct StandardListRow<Content: View>: View {
     let content: Content
     let onHoverChanged: ((Bool) -> Void)?
     @State private var isHovered = false
-    /// Where the pointer actually is, including enters dropped during
-    /// suppression. A reference box so per-row enter/exit churn during
-    /// scroll never invalidates the row.
-    @State private var pointer = PointerBox()
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    @Environment(\.rowHoverSuppressed) private var hoverSuppressed
-
-    private final class PointerBox { var inside = false }
 
     init(@ViewBuilder content: () -> Content) {
         self.onHoverChanged = nil
@@ -38,47 +29,20 @@ struct StandardListRow<Content: View>: View {
             .background(isHovered ? SeeleColors.surfaceSecondary : SeeleColors.surface)
             .environment(\.isRowHovered, isHovered)
             .onHover { hovering in
-                // While the list scrolls, rows stream under a stationary
-                // cursor and AppKit fires enter/exit per row. Engaging
-                // hover for each one re-animated and re-evaluated every
-                // passing row — the dominant fast-scroll jank source.
-                // Enters are dropped during scroll; exits always land so
-                // no row is left stuck highlighted.
-                pointer.inside = hovering
-                if hovering && hoverSuppressed { return }
-                setHovered(hovering)
-            }
-            .onChange(of: hoverSuppressed) { _, suppressed in
-                // Replay an enter dropped during suppression: AppKit does
-                // not re-send one for the row already under the cursor
-                // when the scroll settles, so without this the row stays
-                // visually cold (no highlight, hidden action cluster)
-                // until the mouse physically moves.
-                if !suppressed && pointer.inside != isHovered {
-                    setHovered(pointer.inside)
+                let animation: Animation? = reduceMotion
+                    ? nil
+                    : .easeInOut(duration: SeeleSpacing.animationFast)
+                withAnimation(animation) {
+                    isHovered = hovering
                 }
+                onHoverChanged?(hovering)
             }
-    }
-
-    private func setHovered(_ hovering: Bool) {
-        let animation: Animation? = reduceMotion
-            ? nil
-            : .easeInOut(duration: SeeleSpacing.animationFast)
-        withAnimation(animation) {
-            isHovered = hovering
-        }
-        onHoverChanged?(hovering)
     }
 }
 
 extension EnvironmentValues {
     /// True while the pointer is over the enclosing `StandardListRow`.
     @Entry var isRowHovered = false
-
-    /// Set by a scrolling container to stop rows from ENGAGING hover
-    /// while content is in motion (exits still process). See the
-    /// `onHover` note in `StandardListRow`.
-    @Entry var rowHoverSuppressed = false
 }
 
 #Preview {
@@ -103,20 +67,15 @@ extension EnvironmentValues {
     .background(SeeleColors.background)
 }
 
-/// `help()` installs an AppKit tracking area per call. Rows carry several
-/// tooltips each, and hundreds of rows stay live in a lazy stack, so the
-/// tooltips alone were a measurable share of scroll layout cost. Only the
-/// hovered row can show a tooltip; only it pays for one.
+/// `help()` installs an AppKit tracking area per call, and live rows carry
+/// several each. Only the hovered row can show a tooltip; only it pays for one.
 private struct RowHelp: ViewModifier {
     @Environment(\.isRowHovered) private var isRowHovered
     let text: String
 
     func body(content: Content) -> some View {
-        // The conditional must never wrap `content` itself: an if/else
-        // branch switch on hover gives the wrapped control a new
-        // structural identity, tearing down the live button under the
-        // cursor (lost clicks, cold hover state). The tooltip rides a
-        // background so only that passive subtree changes on hover.
+        // Never branch around `content` itself: switching branches on hover
+        // gives the control a new identity and tears it down under the cursor.
         content.background {
             if isRowHovered {
                 Color.clear.help(text)

--- a/seeleseek/Features/Connection/Views/LoginView.swift
+++ b/seeleseek/Features/Connection/Views/LoginView.swift
@@ -134,6 +134,11 @@ struct LoginView: View {
     }
 
     private func loadSavedCredentials() {
+        #if DEBUG
+        // The synthetic driver never logs in, and a rebuilt binary's
+        // Keychain prompt blocks the main thread here before it starts.
+        if SyntheticSearchDriver.isEnabled { return }
+        #endif
         // Only prefill when both fields are empty — the view re-appears
         // (e.g. after a failed attempt) and reloading would clobber
         // whatever the user has typed.

--- a/seeleseek/Features/Search/SearchState.swift
+++ b/seeleseek/Features/Search/SearchState.swift
@@ -94,9 +94,8 @@ final class SearchState {
     private let logger = Logger(subsystem: "com.seeleseek", category: "SearchState")
 
     // MARK: - Setup
-    // Search results arrive via AppState's search-domain event consumer,
-    // which routes wishlist tokens away and calls `addResults` for the
-    // rest — see `AppState.wireNetworkClient`.
+    // Results are not subscribed here: `AppState.wireNetworkClient` routes
+    // wishlist tokens away and calls `addResults` for the rest.
     func setupCallbacks(client: NetworkClient) {
         self.networkClient = client
 
@@ -675,64 +674,29 @@ final class SearchState {
         }
     }
 
-    // Every peer reply lands as its own `addResults` call. Appending
-    // straight to `searches[i].results` invalidates `SearchView` (it
-    // reads `searches` for the tab strip) and rebuilds every live result
-    // row per reply — measured at ~11k row bodies for one 500-result
-    // search, the original scroll hitching. Replies stage in this
-    // non-observed buffer and land once per window. Filter/sort changes
-    // still call `recomputeFilteredResults()` directly.
+    // Every peer reply is its own `addResults` call; appending straight to
+    // `searches[i].results` invalidated `SearchView` and every live row per
+    // reply (~11k row bodies for one 500-result search). Replies stage here
+    // and land once per window.
     @ObservationIgnored private var pendingResults: [UInt32: [SearchResult]] = [:]
     @ObservationIgnored private var flushTask: Task<Void, Never>?
     private static let flushInterval: Duration = .milliseconds(250)
 
-    /// Landing a batch re-places the entire lazy results list, which
-    /// costs a visible frame drop when it happens mid-scroll (measured:
-    /// the only dropped frames in an auto-scroll harness were the ones
-    /// coinciding with a flush). SearchView reports scroll movement
-    /// here; a scheduled flush that finds the list moved within
-    /// `scrollQuietWindow` re-arms instead of landing — bounded by
-    /// `maxFlushDeferral` so a continuous scroller still sees results.
+    /// Landing a batch mid-scroll drops frames (the only drops seen in the
+    /// auto-scroll harness coincided with flushes), so a flush that finds
+    /// the list moved within `scrollQuietWindow` re-arms instead, up to
+    /// `maxFlushDeferral`.
     @ObservationIgnored private var lastScrollActivity: ContinuousClock.Instant?
     @ObservationIgnored private var oldestPendingArrival: ContinuousClock.Instant?
     private static let scrollQuietWindow: Duration = .milliseconds(200)
-    /// Ceiling on scroll-deferred flushes. 4s, not lower: on a REAL
-    /// search (sustained multi-peer arrivals, unlike the synthetic
-    /// harness's bounded bursts) a 2s ceiling force-landed a full list
-    /// restructure mid-scroll every 2s — measured 33–69 ticks >33ms per
-    /// 5s while scrolling during streaming; 4s brings that to 0–5,
-    /// indistinguishable from 8s. Only bites during continuous motion —
-    /// a 200ms pause lands results immediately.
+    /// 4s, not 2s: on a real search a 2s ceiling force-landed a list
+    /// restructure mid-scroll every 2s (33–69 ticks >33ms per 5s); 4s gives
+    /// 0–5, indistinguishable from 8s.
     private static let maxFlushDeferral: Duration = .seconds(4)
 
-    /// True while the results list is in motion; false ~150ms after it
-    /// settles. `SearchView` feeds it into `\.rowHoverSuppressed`: rows
-    /// sliding under a parked cursor otherwise fire hover enter/exit per
-    /// row, each animating a background flip. Flips are edge-triggered so
-    /// the per-frame scroll callback never touches observable state.
-    private(set) var isListScrolling = false
-    @ObservationIgnored private var scrollSettleTask: Task<Void, Never>?
-    private static let hoverResumeQuiet: Duration = .milliseconds(150)
-
+    /// Called per scroll frame; must not touch observable state.
     func noteResultsScrollActivity() {
         lastScrollActivity = .now
-        guard scrollSettleTask == nil else { return }
-        // Called from the scroll geometry callback. An observable write
-        // there re-enters the same frame ("tried to update multiple
-        // times per frame"), so the flip lands on the next turn.
-        scrollSettleTask = Task { [weak self] in
-            guard let self else { return }
-            self.isListScrolling = true
-            while !Task.isCancelled {
-                try? await Task.sleep(for: .milliseconds(120))
-                if let last = self.lastScrollActivity,
-                   ContinuousClock.now - last > Self.hoverResumeQuiet {
-                    break
-                }
-            }
-            self.isListScrolling = false
-            self.scrollSettleTask = nil
-        }
     }
 
     private func scheduleFlush() {
@@ -744,10 +708,8 @@ final class SearchState {
         }
     }
 
-    /// Land staged replies into their searches in one observable write
-    /// per search, then rebuild the visible list if it was affected.
-    /// `force` skips the mid-scroll deferral — completion and tab-close
-    /// paths must land immediately regardless of scroll state.
+    /// `force` skips the mid-scroll deferral; completion and tab-close paths
+    /// must land immediately.
     private func flushPendingResults(force: Bool = false) {
         flushTask?.cancel()
         flushTask = nil
@@ -778,8 +740,6 @@ final class SearchState {
         cancelInactivityTimer(token: token)
         guard let index = tokenToSearchIndex[token], index < searches.count else { return }
 
-        // Land the final staged batch before announcing/persisting so
-        // both see the full result count.
         flushPendingResults(force: true)
 
         let wasSearching = searches[index].isSearching
@@ -835,8 +795,7 @@ final class SearchState {
     func closeSearch(at index: Int) {
         guard index >= 0, index < searches.count else { return }
 
-        // Land staged replies so the persisted cache is complete, and so
-        // none can flush into the wrong tab after indices shift below.
+        // Before indices shift below, or a later flush lands in the wrong tab.
         flushPendingResults(force: true)
         let search = searches[index]
 

--- a/seeleseek/Features/Search/SearchState.swift
+++ b/seeleseek/Features/Search/SearchState.swift
@@ -94,6 +94,9 @@ final class SearchState {
     private let logger = Logger(subsystem: "com.seeleseek", category: "SearchState")
 
     // MARK: - Setup
+    // Search results arrive via AppState's search-domain event consumer,
+    // which routes wishlist tokens away and calls `addResults` for the
+    // rest — see `AppState.wireNetworkClient`.
     func setupCallbacks(client: NetworkClient) {
         self.networkClient = client
 
@@ -184,11 +187,8 @@ final class SearchState {
     }
 
     // MARK: - Filters
-    // Each filter mutator calls `recomputeFilteredResults()` via didSet so
-    // the stored `filteredResults` cache stays in sync. Without this, the
-    // computed version was re-running filter + sort on every SearchView
-    // body eval — and each streaming-result batch triggered several evals,
-    // so with 500 rows we were doing tens of thousands of ops/sec.
+    // Every filter mutator must call `recomputeFilteredResults()` via
+    // didSet: `filteredResults` is a stored cache, never computed in body.
     // Filter values also write through to `settings.searchFilters` (see
     // `persistFiltersIfNeeded`); sort order and `showFilters` stay session-only.
     @ObservationIgnored private var suppressFilterPersist = false
@@ -402,8 +402,9 @@ final class SearchState {
 
     private(set) var resultGroups: [SearchResultGroup] = []
 
-    /// The flattened list the view renders. Derived from `resultGroups` plus
-    /// `expandedGroups`; see `SearchListItem` for why the view must not do
+    /// The flattened list the view renders: every filtered result as
+    /// `.loose` when ungrouped, otherwise derived from `resultGroups` plus
+    /// `expandedGroups`. See `SearchListItem` for why the view must not do
     /// this flattening itself.
     private(set) var displayItems: [SearchListItem] = []
 
@@ -532,7 +533,7 @@ final class SearchState {
             rebuildDisplayItems()
         } else {
             resultGroups = []
-            displayItems = []
+            displayItems = results.map(SearchListItem.loose)
         }
     }
 
@@ -627,7 +628,7 @@ final class SearchState {
         }
 
         let maxResults = settings?.maxSearchResults ?? 500
-        let currentCount = searches[index].results.count
+        let currentCount = searches[index].results.count + (pendingResults[token]?.count ?? 0)
 
         // Check if we've already reached the limit
         if maxResults > 0 && currentCount >= maxResults {
@@ -656,28 +657,130 @@ final class SearchState {
             }
         }
 
-        searches[index].results.append(contentsOf: resultsToAdd)
-        if index == selectedSearchIndex {
-            recomputeFilteredResults()
-        }
-        logger.info("Added \(resultsToAdd.count) results to '\(self.searches[index].query)' (total: \(self.searches[index].results.count))")
+        if oldestPendingArrival == nil { oldestPendingArrival = .now }
+        pendingResults[token, default: []].append(contentsOf: resultsToAdd)
+        scheduleFlush()
+        logger.info("Staged \(resultsToAdd.count) results for '\(self.searches[index].query)' (total: \(currentCount + resultsToAdd.count))")
 
         // Record results count in activity tracker
         SearchState.activityTracker.recordSearchResults(query: searches[index].query, count: resultsToAdd.count)
 
         // Check if we've now reached the limit
-        if maxResults > 0 && searches[index].results.count >= maxResults {
+        if maxResults > 0 && currentCount + resultsToAdd.count >= maxResults {
             logger.info("Search '\(self.searches[index].query)' reached limit of \(maxResults) results, stopping")
+            flushPendingResults(force: true)
             searches[index].isSearching = false
             cancelInactivityTimer(token: token)
             announceSearchComplete(searches[index])
         }
     }
 
+    // Every peer reply lands as its own `addResults` call. Appending
+    // straight to `searches[i].results` invalidates `SearchView` (it
+    // reads `searches` for the tab strip) and rebuilds every live result
+    // row per reply — measured at ~11k row bodies for one 500-result
+    // search, the original scroll hitching. Replies stage in this
+    // non-observed buffer and land once per window. Filter/sort changes
+    // still call `recomputeFilteredResults()` directly.
+    @ObservationIgnored private var pendingResults: [UInt32: [SearchResult]] = [:]
+    @ObservationIgnored private var flushTask: Task<Void, Never>?
+    private static let flushInterval: Duration = .milliseconds(250)
+
+    /// Landing a batch re-places the entire lazy results list, which
+    /// costs a visible frame drop when it happens mid-scroll (measured:
+    /// the only dropped frames in an auto-scroll harness were the ones
+    /// coinciding with a flush). SearchView reports scroll movement
+    /// here; a scheduled flush that finds the list moved within
+    /// `scrollQuietWindow` re-arms instead of landing — bounded by
+    /// `maxFlushDeferral` so a continuous scroller still sees results.
+    @ObservationIgnored private var lastScrollActivity: ContinuousClock.Instant?
+    @ObservationIgnored private var oldestPendingArrival: ContinuousClock.Instant?
+    private static let scrollQuietWindow: Duration = .milliseconds(200)
+    /// Ceiling on scroll-deferred flushes. 4s, not lower: on a REAL
+    /// search (sustained multi-peer arrivals, unlike the synthetic
+    /// harness's bounded bursts) a 2s ceiling force-landed a full list
+    /// restructure mid-scroll every 2s — measured 33–69 ticks >33ms per
+    /// 5s while scrolling during streaming; 4s brings that to 0–5,
+    /// indistinguishable from 8s. Only bites during continuous motion —
+    /// a 200ms pause lands results immediately.
+    private static let maxFlushDeferral: Duration = .seconds(4)
+
+    /// True while the results list is in motion; false ~150ms after it
+    /// settles. `SearchView` feeds it into `\.rowHoverSuppressed`: rows
+    /// sliding under a parked cursor otherwise fire hover enter/exit per
+    /// row, each animating a background flip. Flips are edge-triggered so
+    /// the per-frame scroll callback never touches observable state.
+    private(set) var isListScrolling = false
+    @ObservationIgnored private var scrollSettleTask: Task<Void, Never>?
+    private static let hoverResumeQuiet: Duration = .milliseconds(150)
+
+    func noteResultsScrollActivity() {
+        lastScrollActivity = .now
+        guard scrollSettleTask == nil else { return }
+        // Called from the scroll geometry callback. An observable write
+        // there re-enters the same frame ("tried to update multiple
+        // times per frame"), so the flip lands on the next turn.
+        scrollSettleTask = Task { [weak self] in
+            guard let self else { return }
+            self.isListScrolling = true
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .milliseconds(120))
+                if let last = self.lastScrollActivity,
+                   ContinuousClock.now - last > Self.hoverResumeQuiet {
+                    break
+                }
+            }
+            self.isListScrolling = false
+            self.scrollSettleTask = nil
+        }
+    }
+
+    private func scheduleFlush() {
+        guard flushTask == nil else { return }
+        flushTask = Task { [weak self] in
+            try? await Task.sleep(for: Self.flushInterval)
+            guard !Task.isCancelled, let self else { return }
+            self.flushPendingResults()
+        }
+    }
+
+    /// Land staged replies into their searches in one observable write
+    /// per search, then rebuild the visible list if it was affected.
+    /// `force` skips the mid-scroll deferral — completion and tab-close
+    /// paths must land immediately regardless of scroll state.
+    private func flushPendingResults(force: Bool = false) {
+        flushTask?.cancel()
+        flushTask = nil
+        guard !pendingResults.isEmpty else { return }
+
+        if !force,
+           let lastScroll = lastScrollActivity,
+           ContinuousClock.now - lastScroll < Self.scrollQuietWindow,
+           let oldest = oldestPendingArrival,
+           ContinuousClock.now - oldest < Self.maxFlushDeferral {
+            scheduleFlush()
+            return
+        }
+        oldestPendingArrival = nil
+
+        var touchedSelected = false
+        for (token, results) in pendingResults {
+            guard let index = tokenToSearchIndex[token], index < searches.count else { continue }
+            searches[index].results.append(contentsOf: results)
+            if index == selectedSearchIndex { touchedSelected = true }
+        }
+        pendingResults.removeAll(keepingCapacity: true)
+        if touchedSelected { recomputeFilteredResults() }
+    }
+
     /// Mark a search as complete (no longer receiving results)
     func markSearchComplete(token: UInt32) {
         cancelInactivityTimer(token: token)
         guard let index = tokenToSearchIndex[token], index < searches.count else { return }
+
+        // Land the final staged batch before announcing/persisting so
+        // both see the full result count.
+        flushPendingResults(force: true)
 
         let wasSearching = searches[index].isSearching
         searches[index].isSearching = false
@@ -732,6 +835,9 @@ final class SearchState {
     func closeSearch(at index: Int) {
         guard index >= 0, index < searches.count else { return }
 
+        // Land staged replies so the persisted cache is complete, and so
+        // none can flush into the wrong tab after indices shift below.
+        flushPendingResults(force: true)
         let search = searches[index]
 
         // Persist search results before closing if it has results

--- a/seeleseek/Features/Search/Views/FolderRequestIndicator.swift
+++ b/seeleseek/Features/Search/Views/FolderRequestIndicator.swift
@@ -12,14 +12,14 @@ struct FolderRequestIndicator: View {
                 .progressViewStyle(.circular)
                 .scaleEffect(SeeleSpacing.scaleSmall)
                 .frame(width: SeeleSpacing.buttonHeight, height: SeeleSpacing.buttonHeight)
-                .help("Getting folder contents from \(username)...")
+                .rowHelp("Getting folder contents from \(username)...")
                 .accessibilityLabel("Getting folder contents from \(username)")
         case .failed(let reason):
             Image(systemName: "exclamationmark.triangle.fill")
                 .font(.system(size: SeeleSpacing.iconSizeSmall))
                 .foregroundStyle(SeeleColors.warning)
                 .frame(width: SeeleSpacing.buttonHeight, height: SeeleSpacing.buttonHeight)
-                .help(reason)
+                .rowHelp(reason)
                 .accessibilityLabel("Folder download failed. \(reason)")
         }
     }

--- a/seeleseek/Features/Search/Views/SearchGroupDownloadButton.swift
+++ b/seeleseek/Features/Search/Views/SearchGroupDownloadButton.swift
@@ -13,7 +13,7 @@ struct SearchGroupDownloadButton: View {
     @Environment(\.appState) private var appState
 
     let group: SearchResultGroup
-    var isHovered: Bool = false
+    @Environment(\.isRowHovered) private var isHovered
 
     /// Any member identifies the folder; the request keys on username+folder.
     private var representative: SearchResult? { group.results.first }

--- a/seeleseek/Features/Search/Views/SearchResultActionCluster.swift
+++ b/seeleseek/Features/Search/Views/SearchResultActionCluster.swift
@@ -21,11 +21,9 @@ struct SearchResultActionCluster: View {
             // (via the row's named actions) can reach these actions.
             HStack(spacing: SeeleSpacing.xxs) {
                 folderSlot(folderRequestState)
-                // `person.crop.circle` is the profile glyph everywhere
-                // else in the app (context menu "View profile"), so this
-                // button must open the profile — wiring it to browse
-                // reads as a broken profile button. Browsing the full
-                // share list stays in the context menu.
+                // `person.crop.circle` is the profile glyph app-wide, so
+                // this must open the profile, not browse. Browse stays in
+                // the context menu.
                 RowIconButton(
                     systemName: "person.crop.circle",
                     help: "View \(result.username)'s profile",

--- a/seeleseek/Features/Search/Views/SearchResultActionCluster.swift
+++ b/seeleseek/Features/Search/Views/SearchResultActionCluster.swift
@@ -1,0 +1,90 @@
+import SwiftUI
+import SeeleseekCore
+
+/// Trailing cluster of a search row: two hover-revealed secondary actions
+/// plus the primary download action. Reads transfer status, folder-request
+/// state and hover here so they invalidate only this cluster.
+struct SearchResultActionCluster: View {
+    @Environment(\.appState) private var appState
+    @Environment(\.isRowHovered) private var isHovered
+
+    let result: SearchResult
+    let actions: SearchResultActions
+
+    var body: some View {
+        #if DEBUG
+        let _ = { if SynthDiag.logChanges { Self._printChanges() } }()
+        #endif
+        let folderRequestState = appState.folderRequestState(for: result)
+        HStack(spacing: SeeleSpacing.xxs) {
+            // Hit-testing stays on at opacity 0 so the VoiceOver rotor
+            // (via the row's named actions) can reach these actions.
+            HStack(spacing: SeeleSpacing.xxs) {
+                folderSlot(folderRequestState)
+                // `person.crop.circle` is the profile glyph everywhere
+                // else in the app (context menu "View profile"), so this
+                // button must open the profile — wiring it to browse
+                // reads as a broken profile button. Browsing the full
+                // share list stays in the context menu.
+                RowIconButton(
+                    systemName: "person.crop.circle",
+                    help: "View \(result.username)'s profile",
+                    action: actions.viewProfile
+                )
+            }
+            .opacity(isHovered || folderRequestState != nil ? 1 : 0)
+            .frame(width: RowLayout.secondaryActionsWidth(2), alignment: .trailing)
+
+            primaryAction
+        }
+        .frame(width: SearchResultRowLayout.trailingClusterWidth, alignment: .trailing)
+    }
+
+    /// Deliberately not on the download button: a request can run for a
+    /// minute, and that button must stay usable for single files.
+    @ViewBuilder
+    private func folderSlot(_ state: AppState.FolderRequestState?) -> some View {
+        if let state {
+            FolderRequestIndicator(state: state, username: result.username)
+        } else {
+            RowIconButton(
+                systemName: "folder.badge.questionmark",
+                help: "Browse this folder",
+                action: actions.browseFolder
+            )
+        }
+    }
+
+    private var primaryAction: some View {
+        let status = actions.downloadStatus
+        let ignored = actions.isIgnored
+        return RowIconButton(
+            systemName: Self.actionIcon(status),
+            help: actions.actionHelp,
+            tint: actionColor(status, ignored: ignored),
+            weight: .semibold,
+            isProminent: true,
+            action: actions.download
+        )
+        .disabled(actions.isQueued || ignored)
+    }
+
+    private static func actionIcon(_ status: Transfer.TransferStatus?) -> String {
+        switch status {
+        case .completed: "checkmark.circle.fill"
+        case .transferring, .queued, .waiting, .connecting: "arrow.down.circle.fill"
+        case .failed, .cancelled: "arrow.clockwise.circle"
+        case .none: "arrow.down.circle"
+        }
+    }
+
+    private func actionColor(_ status: Transfer.TransferStatus?, ignored: Bool) -> Color {
+        if ignored { return SeeleColors.textTertiary }
+        return switch status {
+        case .completed: SeeleColors.success
+        case .transferring, .queued, .waiting, .connecting: SeeleColors.accent
+        case .failed, .cancelled: SeeleColors.warning
+        case .none: isHovered ? SeeleColors.accent : SeeleColors.textSecondary
+        }
+    }
+}

--- a/seeleseek/Features/Search/Views/SearchResultActions.swift
+++ b/seeleseek/Features/Search/Views/SearchResultActions.swift
@@ -1,0 +1,78 @@
+import SwiftUI
+import SeeleseekCore
+
+/// Row-level actions and the live state they gate on. `downloadStatus` and
+/// `isIgnored` read observables at the call site, so only the view whose
+/// body calls them subscribes — the row shell must not.
+struct SearchResultActions: Equatable {
+    let result: SearchResult
+    private let appState: AppState
+
+    init(result: SearchResult, appState: AppState) {
+        self.result = result
+        self.appState = appState
+    }
+
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.result == rhs.result && lhs.appState === rhs.appState
+    }
+
+    var downloadStatus: Transfer.TransferStatus? {
+        appState.transferState.downloadStatus(for: result.filename, from: result.username)
+    }
+
+    var isIgnored: Bool {
+        appState.socialState.isIgnored(result.username)
+    }
+
+    var isQueued: Bool {
+        guard let s = downloadStatus else { return false }
+        return s != .completed && s != .cancelled && s != .failed
+    }
+
+    var actionHelp: String {
+        if isIgnored { return "User is ignored" }
+        return switch downloadStatus {
+        case .completed: "Already downloaded"
+        case .transferring: "Downloading…"
+        case .queued, .waiting, .connecting: "In queue"
+        case .failed, .cancelled: "Retry download"
+        case .none: "Download"
+        }
+    }
+
+    func download() {
+        guard !isQueued, !isIgnored else { return }
+        Task { await appState.downloadManager.queueDownload(from: result) }
+    }
+
+    func browseUser() {
+        appState.browseState.browseUser(result.username)
+        appState.sidebarSelection = .browse
+    }
+
+    func viewProfile() {
+        Task { await appState.socialState.loadProfile(for: result.username) }
+    }
+
+    func browseFolder() {
+        appState.browseState.browseUser(result.username, targetPath: result.filename)
+        appState.sidebarSelection = .browse
+    }
+
+    func downloadContainingFolder() {
+        Task { await appState.downloadContainingFolder(of: result) }
+    }
+
+    func toggleSelection() {
+        appState.searchState.toggleSelection(result.id)
+    }
+
+    func copyFilename() {
+        result.displayFilename.copyToPasteboard()
+    }
+
+    func copyPath() {
+        result.filename.copyToPasteboard()
+    }
+}

--- a/seeleseek/Features/Search/Views/SearchResultGroupHeader.swift
+++ b/seeleseek/Features/Search/Views/SearchResultGroupHeader.swift
@@ -15,13 +15,11 @@ struct SearchResultGroupHeader: View {
 
     let group: SearchResultGroup
 
-    @State private var isHovered = false
-
     private var searchState: SearchState { appState.searchState }
     private var isExpanded: Bool { searchState.isExpanded(group) }
 
     var body: some View {
-        StandardListRow(onHoverChanged: { isHovered = $0 }) {
+        StandardListRow {
             HStack(alignment: .center, spacing: SeeleSpacing.sm) {
                 if searchState.isSelectionMode {
                     SearchGroupSelectionToggle(group: group)
@@ -32,7 +30,7 @@ struct SearchResultGroupHeader: View {
                 infoColumn
                     .frame(maxWidth: .infinity, alignment: .leading)
 
-                SearchGroupDownloadButton(group: group, isHovered: isHovered)
+                SearchGroupDownloadButton(group: group)
                     .frame(width: SearchResultRowLayout.trailingClusterWidth, alignment: .trailing)
             }
         }

--- a/seeleseek/Features/Search/Views/SearchResultInfoColumn.swift
+++ b/seeleseek/Features/Search/Views/SearchResultInfoColumn.swift
@@ -1,0 +1,85 @@
+import SwiftUI
+import SeeleseekCore
+
+/// Left (flex) column of a search row: filename over the peer/folder
+/// context line. The ignore list is read here, not in the row, so an
+/// ignore-list change re-evaluates this column and not the row's layout.
+struct SearchResultInfoColumn: View {
+    @Environment(\.appState) private var appState
+    let result: SearchResult
+    let isNestedInGroup: Bool
+    let peerStatus: BuddyStatus?
+
+    var body: some View {
+        let isIgnored = appState.socialState.isIgnored(result.username)
+        VStack(alignment: .leading, spacing: SeeleSpacing.xxs) {
+            Text(result.displayFilename)
+                .font(SeeleTypography.body)
+                .foregroundStyle(isIgnored ? SeeleColors.textTertiary : SeeleColors.textPrimary)
+                .strikethrough(isIgnored, color: SeeleColors.textTertiary)
+                .lineLimit(1)
+                .truncationMode(.middle)
+
+            if !isNestedInGroup {
+                contextLine
+            }
+        }
+    }
+
+    private var contextLine: some View {
+        HStack(spacing: 0) {
+            peerCell
+                .frame(width: RowLayout.peerCellWidth, alignment: .leading)
+
+            if !result.folderPath.isEmpty {
+                FolderPathLabel(
+                    FolderPathLabel.compact(result.folderPath),
+                    help: result.folderPath.replacingOccurrences(of: "\\", with: "/")
+                )
+            }
+
+            Spacer(minLength: 0)
+        }
+    }
+
+    private var peerCell: some View {
+        HStack(spacing: 0) {
+            // Username sub-cell — fixed width so peer speed lands at the
+            // same X on every row.
+            PeerUsernameLabel(
+                iconName: "arrow.up",
+                username: result.username,
+                width: RowLayout.peerUsernameWidth,
+                peerStatus: peerStatus
+            )
+
+            Text(peerSpeedText)
+                .font(SeeleTypography.monoSmall)
+                .foregroundStyle(peerSpeedColor)
+                .monospacedDigit()
+                .lineLimit(1)
+
+            Spacer(minLength: 0)
+        }
+    }
+
+    /// Peer's reported upload speed. In SoulSeek this is the rate at which
+    /// *they* serve files, which is usually more predictive of download
+    /// time than the file size alone.
+    private var peerSpeedText: String {
+        result.uploadSpeed > 0 ? result.uploadSpeed.formattedSpeed : "unknown"
+    }
+
+    /// Tinted by peer quality tier.
+    ///   ≥ 1 MB/s: success (fast peer)
+    ///   ≥ 200 KB/s: info (decent peer)
+    ///   < 200 KB/s: warning (slow peer)
+    ///   unknown: tertiary (no signal)
+    private var peerSpeedColor: Color {
+        let bps = result.uploadSpeed
+        if bps == 0 { return SeeleColors.textTertiary }
+        if bps >= 1_000_000 { return SeeleColors.success }
+        if bps >= 200_000 { return SeeleColors.info }
+        return SeeleColors.warning
+    }
+}

--- a/seeleseek/Features/Search/Views/SearchResultListItemView.swift
+++ b/seeleseek/Features/Search/Views/SearchResultListItemView.swift
@@ -3,7 +3,7 @@ import SeeleseekCore
 
 /// Renders exactly one `SearchListItem`. Every branch must emit a single
 /// view — see `SearchListItem` for why a variable subview count is unsound
-/// inside the results `LazyVStack`.
+/// inside the results list.
 struct SearchResultListItemView: View {
     @Environment(\.appState) private var appState
 
@@ -42,8 +42,7 @@ struct SearchResultListItemView: View {
             result: result,
             isNestedInGroup: nested,
             isSelectionMode: searchState.isSelectionMode,
-            isSelected: searchState.selectedResults.contains(result.id),
-            onToggleSelection: { searchState.toggleSelection(result.id) }
+            isSelected: searchState.selectedResults.contains(result.id)
         )
     }
 }

--- a/seeleseek/Features/Search/Views/SearchResultMetadataColumn.swift
+++ b/seeleseek/Features/Search/Views/SearchResultMetadataColumn.swift
@@ -1,0 +1,113 @@
+import SwiftUI
+import SeeleseekCore
+
+/// Right (fixed-width) column of a search row: quality chip, tech-spec
+/// columns, and the peer-state line. Depends only on `result`.
+struct SearchResultMetadataColumn: View {
+    let result: SearchResult
+
+    var body: some View {
+        let tier = QualityScale.tier(for: result)
+        VStack(alignment: .trailing, spacing: SeeleSpacing.xxs) {
+            HStack(spacing: SeeleSpacing.sm) {
+                StandardMetadataBadge(tier.label, color: tier.color)
+                    .rowHelp(tier.helpText)
+                    .frame(width: SearchResultRowLayout.qualityChipSlotWidth, alignment: .trailing)
+                    .accessibilityLabel(tier.helpText)
+
+                techSpecColumns
+            }
+
+            secondaryMetadata
+        }
+    }
+
+    private var techSpecColumns: some View {
+        HStack(spacing: SeeleSpacing.xs) {
+            statCell(
+                width: SearchResultStatColumn.formatBitrate.width,
+                text: formatBitrateText,
+                color: SeeleColors.textSecondary
+            )
+            statCell(
+                width: SearchResultStatColumn.sampleBitDepth.width,
+                text: sampleBitDepthText,
+                color: SeeleColors.textTertiary
+            )
+            statCell(
+                width: SearchResultStatColumn.duration.width,
+                text: result.formattedDuration ?? "",
+                color: SeeleColors.textTertiary
+            )
+            statCell(
+                width: SearchResultStatColumn.size.width,
+                text: result.formattedSize,
+                color: SeeleColors.textTertiary
+            )
+        }
+    }
+
+    private func statCell(width: CGFloat, text: String, color: Color) -> some View {
+        Text(text.isEmpty ? "—" : text)
+            .font(SeeleTypography.monoSmall)
+            .foregroundStyle(text.isEmpty ? SeeleColors.textTertiary : color)
+            .monospacedDigit()
+            .lineLimit(1)
+            .frame(width: width, alignment: .trailing)
+    }
+
+    private var formatBitrateText: String {
+        let ext = result.fileExtension.uppercased()
+        if let bitrate = result.bitrate, bitrate > 0 {
+            return "\(ext) \(bitrate)"
+        }
+        return ext
+    }
+
+    private var sampleBitDepthText: String {
+        guard let sampleRate = result.sampleRate, sampleRate > 0 else { return "" }
+        let khz = Double(sampleRate) / 1000.0
+        let base = khz == khz.rounded() ? "\(Int(khz))" : String(format: "%.1f", khz)
+        if let bd = result.bitDepth, bd > 0 { return "\(base)/\(bd)" }
+        return "\(base) kHz"
+    }
+
+    /// Line 2 of the metadata column. Real peer state — no estimates.
+    @ViewBuilder
+    private var secondaryMetadata: some View {
+        if !result.freeSlots {
+            HStack(spacing: SeeleSpacing.xxs) {
+                Image(systemName: "hourglass")
+                    .font(.system(size: SeeleSpacing.iconSizeXS))
+                Text("Queue \(result.queueLength)")
+                    .font(SeeleTypography.caption)
+                    .monospacedDigit()
+            }
+            .foregroundStyle(SeeleColors.warning)
+        } else if !result.isPrivate {
+            HStack(spacing: SeeleSpacing.xxs) {
+                Circle()
+                    .fill(SeeleColors.success)
+                    .frame(
+                        width: SeeleSpacing.statusDotSmall,
+                        height: SeeleSpacing.statusDotSmall
+                    )
+                Text("Available")
+                    .font(SeeleTypography.caption)
+            }
+            .foregroundStyle(SeeleColors.success)
+        } else {
+            HStack(spacing: SeeleSpacing.xxs) {
+                Circle()
+                    .fill(SeeleColors.warning)
+                    .frame(
+                        width: SeeleSpacing.statusDotSmall,
+                        height: SeeleSpacing.statusDotSmall
+                    )
+                Text("Private")
+                    .font(SeeleTypography.caption)
+            }
+            .foregroundStyle(SeeleColors.warning)
+        }
+    }
+}

--- a/seeleseek/Features/Search/Views/SearchResultRow.swift
+++ b/seeleseek/Features/Search/Views/SearchResultRow.swift
@@ -1,7 +1,4 @@
 import SwiftUI
-#if os(macOS)
-import AppKit
-#endif
 import SeeleseekCore
 
 // MARK: - Row
@@ -69,8 +66,7 @@ struct SearchResultRow: View {
                 SearchResultActionCluster(result: result, actions: actions)
             }
         }
-        // Fixed height so the lazy stack places the row without measuring
-        // its content — per-row measurement was the dominant scroll cost.
+        // Fixed height: the hosting table must never measure row content.
         .frame(height: SearchResultRowLayout.rowHeight)
         .background(selectionOverlay)
         .contentShape(Rectangle())

--- a/seeleseek/Features/Search/Views/SearchResultRow.swift
+++ b/seeleseek/Features/Search/Views/SearchResultRow.swift
@@ -26,6 +26,11 @@ import SeeleseekCore
 //   - The trailing cluster is fixed-width regardless of hover so the
 //     tech-spec anchors never shift.
 
+/// Layout shell only. Every stored property is Equatable so the row is
+/// skipped when its inputs are unchanged, and nothing in `body` reads an
+/// observable: transfer status, ignore list, folder-request state and
+/// hover are read by the leaf that renders them, so hundreds of live rows
+/// do not re-body when any of those change elsewhere in the app.
 struct SearchResultRow: View {
     @Environment(\.appState) private var appState
     let result: SearchResult
@@ -34,104 +39,59 @@ struct SearchResultRow: View {
     var isNestedInGroup: Bool = false
     var isSelectionMode: Bool = false
     var isSelected: Bool = false
-    var onToggleSelection: (() -> Void)? = nil
 
-    @State private var isHovered = false
-
-    private var downloadStatus: Transfer.TransferStatus? {
-        appState.transferState.downloadStatus(for: result.filename, from: result.username)
-    }
-
-    private var isQueued: Bool {
-        guard let s = downloadStatus else { return false }
-        return s != .completed && s != .cancelled && s != .failed
-    }
-
-    private var isIgnored: Bool { appState.socialState.isIgnored(result.username) }
-
-    /// Peer status captured at row appear rather than read live from
-    /// `SocialState.peerStatuses`. Reading the dict live would invalidate
-    /// every visible search row on every unrelated peer's status arriving
-    /// — with a 500-row result list this dominated the macOS 15 re-render
-    /// storm. Accepts minor staleness if this user's status changes after
-    /// the row is on screen (rare for search-result rows, which are
-    /// typically strangers rather than actively-watched peers).
+    /// Captured on appear: reading `SocialState.peerStatuses` live would
+    /// invalidate every visible row on every unrelated peer's status.
     @State private var peerStatus: BuddyStatus?
 
-    private func refreshPeerStatus() {
-        peerStatus = appState.socialState.peerStatus(for: result.username)
-    }
-
     var body: some View {
-        StandardListRow(onHoverChanged: { isHovered = $0 }) {
+        #if DEBUG
+        let _ = { if SynthDiag.logChanges { Self._printChanges() } }()
+        #endif
+        let actions = SearchResultActions(result: result, appState: appState)
+        StandardListRow {
             HStack(alignment: .top, spacing: SeeleSpacing.sm) {
                 if isSelectionMode {
-                    selectionCheckbox
+                    selectionCheckbox(actions)
                 }
 
                 fileGlyph
 
-                infoColumn
-                    .frame(maxWidth: .infinity, alignment: .leading)
+                SearchResultInfoColumn(
+                    result: result,
+                    isNestedInGroup: isNestedInGroup,
+                    peerStatus: peerStatus
+                )
+                .frame(maxWidth: .infinity, alignment: .leading)
 
-                metadataColumn
+                SearchResultMetadataColumn(result: result)
 
-                trailingCluster
+                SearchResultActionCluster(result: result, actions: actions)
             }
         }
+        // Fixed height so the lazy stack places the row without measuring
+        // its content — per-row measurement was the dominant scroll cost.
+        .frame(height: SearchResultRowLayout.rowHeight)
         .background(selectionOverlay)
         .contentShape(Rectangle())
-        .onTapGesture(count: 2) { download() }
-        .contextMenu { contextMenu }
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel(accessibilityLabel)
-        .accessibilityValue(accessibilityValue)
-        .accessibilityAddTraits(accessibilityTraits)
-        // The double tap gesture does not become an AXPress action on
-        // the combined element. Supply the default action explicitly.
-        .accessibilityAction { download() }
-        .accessibilityActions {
-            if isSelectionMode {
-                Button(isSelected ? "Deselect" : "Select") { onToggleSelection?() }
-            }
-            if !isQueued, !isIgnored {
-                Button("Download", action: download)
-            }
-            if !isIgnored {
-                Button("Download entire folder", action: downloadContainingFolder)
-            }
-            Button("Browse folder", action: browseFolder)
-            Button("Browse \(result.username)", action: browseUser)
-            Button("View profile") {
-                Task { await appState.socialState.loadProfile(for: result.username) }
-            }
-            if isIgnored {
-                Button("Unignore user") {
-                    Task { await appState.socialState.unignoreUser(result.username) }
-                }
-            } else {
-                Button("Ignore user") {
-                    Task { await appState.socialState.ignoreUser(result.username) }
-                }
-            }
-            Button("Copy filename", action: copyFilename)
-            Button("Copy full path", action: copyPath)
-        }
-        .onAppear { refreshPeerStatus() }
-        .onChange(of: result.username) { _, _ in refreshPeerStatus() }
+        .modifier(SearchResultRowInteractions(
+            actions: actions,
+            isSelectionMode: isSelectionMode,
+            isSelected: isSelected
+        ))
+        .onAppear { peerStatus = appState.socialState.peerStatus(for: result.username) }
     }
 
     // MARK: - Selection checkbox
 
-    private var selectionCheckbox: some View {
+    private func selectionCheckbox(_ actions: SearchResultActions) -> some View {
         Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
             .font(.system(size: SeeleSpacing.iconSize))
             .foregroundStyle(isSelected ? SeeleColors.accent : SeeleColors.textTertiary)
             .frame(width: SeeleSpacing.iconSizeXL, height: SeeleSpacing.iconSizeXL)
             .contentShape(Rectangle())
-            .onTapGesture { onToggleSelection?() }
-            // The combined row exposes the selected state and a rotor
-            // action. Hide the checkbox so the row label stays short.
+            .onTapGesture { actions.toggleSelection() }
+            // The row element exposes selection state and a rotor action.
             .accessibilityHidden(true)
     }
 
@@ -172,293 +132,50 @@ struct SearchResultRow: View {
         if result.isAudioFile { return SeeleColors.accent }
         return SeeleColors.textTertiary
     }
+}
 
-    // MARK: - Info column (flex)
+// MARK: - Interactions
 
-    private var infoColumn: some View {
-        VStack(alignment: .leading, spacing: SeeleSpacing.xxs) {
-            Text(result.displayFilename)
-                .font(SeeleTypography.body)
-                .foregroundStyle(isIgnored ? SeeleColors.textTertiary : SeeleColors.textPrimary)
-                .strikethrough(isIgnored, color: SeeleColors.textTertiary)
-                .lineLimit(1)
-                .truncationMode(.middle)
+/// Double-click, context menu and accessibility for a row. A ViewModifier's
+/// body is its own invalidation scope, so the transfer-status, ignore-list
+/// and folder-request reads below re-evaluate this node, not the row.
+private struct SearchResultRowInteractions: ViewModifier {
+    @Environment(\.appState) private var appState
+    let actions: SearchResultActions
+    let isSelectionMode: Bool
+    let isSelected: Bool
 
-            if !isNestedInGroup {
-                contextLine
+    private var result: SearchResult { actions.result }
+
+    func body(content: Content) -> some View {
+        let status = actions.downloadStatus
+        let isIgnored = actions.isIgnored
+        let isQueued = actions.isQueued
+        content
+            .onTapGesture(count: 2) { actions.download() }
+            .contextMenu { contextMenu(isQueued: isQueued, isIgnored: isIgnored) }
+            // `.ignore`, not `.combine`: the row supplies its own label and
+            // value, and combining would traverse the subtree per update.
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(accessibilityLabel(isIgnored: isIgnored))
+            .accessibilityValue(accessibilityValue(status: status))
+            .accessibilityAddTraits(accessibilityTraits(isQueued: isQueued))
+            // The double-tap gesture does not become an AXPress action.
+            .accessibilityAction { actions.download() }
+            // Named actions, not `accessibilityActions { Button… }`: each
+            // Button there is a live view per row.
+            .accessibilityAction(named: "Download entire folder", actions.downloadContainingFolder)
+            .accessibilityAction(named: "Browse folder", actions.browseFolder)
+            .accessibilityAction(named: "Browse \(result.username)", actions.browseUser)
+            .accessibilityAction(named: "View profile", actions.viewProfile)
+            .accessibilityActions {
+                if isSelectionMode {
+                    Button(isSelected ? "Deselect" : "Select") { actions.toggleSelection() }
+                }
             }
-        }
     }
 
-    private var contextLine: some View {
-        HStack(spacing: 0) {
-            peerCell
-                .frame(width: RowLayout.peerCellWidth, alignment: .leading)
-
-            if !result.folderPath.isEmpty {
-                folderCell
-            }
-
-            Spacer(minLength: 0)
-        }
-    }
-
-    private var peerCell: some View {
-        HStack(spacing: 0) {
-            // Username sub-cell — fixed width so peer speed lands at the
-            // same X on every row.
-            PeerUsernameLabel(
-                iconName: "arrow.up",
-                username: result.username,
-                width: RowLayout.peerUsernameWidth,
-                peerStatus: peerStatus
-            )
-
-            Text(peerSpeedText)
-                .font(SeeleTypography.monoSmall)
-                .foregroundStyle(peerSpeedColor)
-                .monospacedDigit()
-                .lineLimit(1)
-
-            Spacer(minLength: 0)
-        }
-    }
-
-    private var folderCell: some View {
-        FolderPathLabel(
-            FolderPathLabel.compact(result.folderPath),
-            help: result.folderPath.replacingOccurrences(of: "\\", with: "/")
-        )
-    }
-
-    // MARK: - Metadata column (right)
-
-    private var metadataColumn: some View {
-        VStack(alignment: .trailing, spacing: SeeleSpacing.xxs) {
-            HStack(spacing: SeeleSpacing.sm) {
-                qualityChip
-                    .frame(width: SearchResultRowLayout.qualityChipSlotWidth, alignment: .trailing)
-                    .accessibilityLabel(QualityScale.tier(for: result).helpText)
-
-                techSpecColumns
-            }
-
-            secondaryMetadata
-        }
-    }
-
-    private var qualityChip: some View {
-        let tier = QualityScale.tier(for: result)
-        return StandardMetadataBadge(tier.label, color: tier.color)
-            .help(tier.helpText)
-    }
-
-    private var techSpecColumns: some View {
-        HStack(spacing: SeeleSpacing.xs) {
-            statCell(
-                width: SearchResultStatColumn.formatBitrate.width,
-                text: formatBitrateText,
-                color: SeeleColors.textSecondary
-            )
-            statCell(
-                width: SearchResultStatColumn.sampleBitDepth.width,
-                text: sampleBitDepthText,
-                color: SeeleColors.textTertiary
-            )
-            statCell(
-                width: SearchResultStatColumn.duration.width,
-                text: result.formattedDuration ?? "",
-                color: SeeleColors.textTertiary
-            )
-            statCell(
-                width: SearchResultStatColumn.size.width,
-                text: result.formattedSize,
-                color: SeeleColors.textTertiary
-            )
-        }
-    }
-
-    private func statCell(width: CGFloat, text: String, color: Color) -> some View {
-        Text(text.isEmpty ? "—" : text)
-            .font(SeeleTypography.monoSmall)
-            .foregroundStyle(text.isEmpty ? SeeleColors.textTertiary : color)
-            .monospacedDigit()
-            .lineLimit(1)
-            .frame(width: width, alignment: .trailing)
-    }
-
-    private var formatBitrateText: String {
-        let ext = result.fileExtension.uppercased()
-        if let bitrate = result.bitrate, bitrate > 0 {
-            return "\(ext) \(bitrate)"
-        }
-        return ext
-    }
-
-    private var sampleBitDepthText: String {
-        guard let sampleRate = result.sampleRate, sampleRate > 0 else { return "" }
-        return sampleRateCompact(sampleRate)
-    }
-
-    private func sampleRateCompact(_ hz: UInt32) -> String {
-        let khz = Double(hz) / 1000.0
-        let base = khz == khz.rounded() ? "\(Int(khz))" : String(format: "%.1f", khz)
-        if let bd = result.bitDepth, bd > 0 { return "\(base)/\(bd)" }
-        return "\(base) kHz"
-    }
-
-    /// Line 2 of the metadata column. Real peer state — no estimates.
-    @ViewBuilder
-    private var secondaryMetadata: some View {
-        if !result.freeSlots {
-            HStack(spacing: SeeleSpacing.xxs) {
-                Image(systemName: "hourglass")
-                    .font(.system(size: SeeleSpacing.iconSizeXS))
-                Text("Queue \(result.queueLength)")
-                    .font(SeeleTypography.caption)
-                    .monospacedDigit()
-            }
-            .foregroundStyle(SeeleColors.warning)
-        } else if !result.isPrivate {
-            HStack(spacing: SeeleSpacing.xxs) {
-                Circle()
-                    .fill(SeeleColors.success)
-                    .frame(
-                        width: SeeleSpacing.statusDotSmall,
-                        height: SeeleSpacing.statusDotSmall
-                    )
-                Text("Available")
-                    .font(SeeleTypography.caption)
-            }
-            .foregroundStyle(SeeleColors.success)
-        } else {
-            HStack(spacing: SeeleSpacing.xxs) {
-                Circle()
-                    .fill(SeeleColors.warning)
-                    .frame(
-                        width: SeeleSpacing.statusDotSmall,
-                        height: SeeleSpacing.statusDotSmall
-                    )
-                Text("Private")
-                    .font(SeeleTypography.caption)
-            }
-            .foregroundStyle(SeeleColors.warning)
-        }
-    }
-
-    // MARK: - Trailing cluster (hover-revealed secondary actions + primary action)
-
-    private var secondaryActionsWidth: CGFloat { RowLayout.secondaryActionsWidth(2) }
-
-    private var trailingCluster: some View {
-        HStack(spacing: SeeleSpacing.xxs) {
-            secondaryActions
-            primaryAction
-        }
-        .frame(width: SearchResultRowLayout.trailingClusterWidth, alignment: .trailing)
-    }
-
-    private var secondaryActions: some View {
-        let folderRequestState = appState.folderRequestState(for: result)
-        // Hit-testing stays on even at opacity 0 so Tab focus (and, via
-        // `accessibilityAction` below, VoiceOver rotor) can reach these
-        // actions. The invisible focus ring is an accepted tradeoff.
-        return HStack(spacing: SeeleSpacing.xxs) {
-            folderSlot(folderRequestState)
-            RowIconButton(
-                systemName: "person.crop.circle",
-                help: "Browse \(result.username)'s files",
-                action: browseUser
-            )
-        }
-        .opacity(isHovered || folderRequestState != nil ? 1 : 0)
-        .frame(width: secondaryActionsWidth, alignment: .trailing)
-    }
-
-    /// Deliberately not on the download button: a request can run for a
-    /// minute, and that button must stay usable for single files.
-    @ViewBuilder
-    private func folderSlot(_ state: AppState.FolderRequestState?) -> some View {
-        if let state {
-            FolderRequestIndicator(state: state, username: result.username)
-        } else {
-            RowIconButton(
-                systemName: "folder.badge.questionmark",
-                help: "Browse this folder",
-                action: browseFolder
-            )
-        }
-    }
-
-    private var primaryAction: some View {
-        RowIconButton(
-            systemName: actionIcon,
-            help: actionHelp,
-            tint: actionColor,
-            weight: .semibold,
-            isProminent: true,
-            action: download
-        )
-        .disabled(isQueued || isIgnored)
-    }
-
-    private var actionIcon: String {
-        switch downloadStatus {
-        case .completed: "checkmark.circle.fill"
-        case .transferring, .queued, .waiting, .connecting: "arrow.down.circle.fill"
-        case .failed, .cancelled: "arrow.clockwise.circle"
-        case .none: "arrow.down.circle"
-        }
-    }
-
-    private var actionColor: Color {
-        if isIgnored { return SeeleColors.textTertiary }
-        return switch downloadStatus {
-        case .completed: SeeleColors.success
-        case .transferring, .queued, .waiting, .connecting: SeeleColors.accent
-        case .failed, .cancelled: SeeleColors.warning
-        case .none: isHovered ? SeeleColors.accent : SeeleColors.textSecondary
-        }
-    }
-
-    private var actionHelp: String {
-        if isIgnored { return "User is ignored" }
-        return switch downloadStatus {
-        case .completed: "Already downloaded"
-        case .transferring: "Downloading…"
-        case .queued, .waiting, .connecting: "In queue"
-        case .failed, .cancelled: "Retry download"
-        case .none: "Download"
-        }
-    }
-
-    // MARK: - Peer speed formatting
-
-    /// Peer's reported upload speed. In SoulSeek this is the rate at which
-    /// *they* serve files, which is usually more predictive of download
-    /// time than the file size alone.
-    private var peerSpeedText: String {
-        let bytesPerSecond = UInt64(result.uploadSpeed)
-        guard bytesPerSecond > 0 else { return "unknown" }
-        return bytesPerSecond.formattedBytes + "/s"
-    }
-
-    /// Tinted by peer quality tier.
-    ///   ≥ 1 MB/s: success (fast peer)
-    ///   ≥ 200 KB/s: info (decent peer)
-    ///   < 200 KB/s: warning (slow peer)
-    ///   unknown: tertiary (no signal)
-    private var peerSpeedColor: Color {
-        let bps = result.uploadSpeed
-        if bps == 0 { return SeeleColors.textTertiary }
-        if bps >= 1_000_000 { return SeeleColors.success }
-        if bps >= 200_000 { return SeeleColors.info }
-        return SeeleColors.warning
-    }
-
-    // MARK: - Accessibility
-
-    private var accessibilityLabel: String {
+    private func accessibilityLabel(isIgnored: Bool) -> String {
         var parts: [String] = [result.displayFilename]
         parts.append("from \(result.username)")
         parts.append(QualityScale.tier(for: result).label.lowercased())
@@ -471,17 +188,16 @@ struct SearchResultRow: View {
         return parts.joined(separator: ", ")
     }
 
-    private var accessibilityValue: String {
+    private func accessibilityValue(status: Transfer.TransferStatus?) -> String {
         var parts: [String] = []
         if isSelectionMode {
             parts.append(isSelected ? "selected" : "not selected")
         }
-        if downloadStatus != nil {
-            parts.append(actionHelp)
+        if status != nil {
+            parts.append(actions.actionHelp)
         }
-        // The row is a combined element with an explicit label, which
-        // overrides FolderRequestIndicator's own label — so the request
-        // state has to be surfaced here or VoiceOver never hears it.
+        // The row's explicit label overrides FolderRequestIndicator's own,
+        // so the request state must be spoken here.
         switch appState.folderRequestState(for: result) {
         case .fetching:
             parts.append("getting folder contents")
@@ -493,7 +209,7 @@ struct SearchResultRow: View {
         return parts.joined(separator: ", ")
     }
 
-    private var accessibilityTraits: AccessibilityTraits {
+    private func accessibilityTraits(isQueued: Bool) -> AccessibilityTraits {
         var traits: AccessibilityTraits = []
         if !isQueued {
             traits.insert(.isButton)
@@ -504,31 +220,27 @@ struct SearchResultRow: View {
         return traits
     }
 
-    // MARK: - Context menu
-
     @ViewBuilder
-    private var contextMenu: some View {
-        Button(action: download) {
+    private func contextMenu(isQueued: Bool, isIgnored: Bool) -> some View {
+        Button(action: actions.download) {
             Label(isQueued ? "Downloading…" : "Download", systemImage: "arrow.down.circle")
         }
         .disabled(isQueued || isIgnored)
 
-        Button(action: downloadContainingFolder) {
+        Button(action: actions.downloadContainingFolder) {
             Label("Download entire folder", systemImage: "arrow.down.square.fill")
         }
         .disabled(isIgnored)
 
-        Button(action: browseFolder) {
+        Button(action: actions.browseFolder) {
             Label("Browse folder", systemImage: "folder.badge.questionmark")
         }
 
-        Button(action: browseUser) {
+        Button(action: actions.browseUser) {
             Label("Browse \(result.username)", systemImage: "folder")
         }
 
-        Button {
-            Task { await appState.socialState.loadProfile(for: result.username) }
-        } label: {
+        Button(action: actions.viewProfile) {
             Label("View profile", systemImage: "person.crop.circle")
         }
 
@@ -550,42 +262,13 @@ struct SearchResultRow: View {
 
         Divider()
 
-        Button(action: copyFilename) {
+        Button(action: actions.copyFilename) {
             Label("Copy filename", systemImage: "doc.on.doc")
         }
 
-        Button(action: copyPath) {
+        Button(action: actions.copyPath) {
             Label("Copy full path", systemImage: "link")
         }
-    }
-
-    // MARK: - Actions
-
-    private func download() {
-        guard !isQueued, !isIgnored else { return }
-        appState.downloadManager.queueDownload(from: result)
-    }
-
-    private func browseUser() {
-        appState.browseState.browseUser(result.username)
-        appState.sidebarSelection = .browse
-    }
-
-    private func browseFolder() {
-        appState.browseState.browseUser(result.username, targetPath: result.filename)
-        appState.sidebarSelection = .browse
-    }
-
-    private func downloadContainingFolder() {
-        Task { await appState.downloadContainingFolder(of: result) }
-    }
-
-    private func copyFilename() {
-        result.displayFilename.copyToPasteboard()
-    }
-
-    private func copyPath() {
-        result.filename.copyToPasteboard()
     }
 }
 
@@ -594,6 +277,10 @@ struct SearchResultRow: View {
 /// Search-only columns. Peer anchors live in `RowLayout`, shared with the
 /// transfer and history rows.
 enum SearchResultRowLayout {
+    /// Every search row is exactly this tall (see the `frame(height:)`
+    /// note in `SearchResultRow.body`).
+    static let rowHeight: CGFloat = 58
+
     /// Chip slot width — tuned for the longest tier label (`LOSSLESS`).
     static let qualityChipSlotWidth: CGFloat = 62
 

--- a/seeleseek/Features/Search/Views/SearchResultsHostedTableView.swift
+++ b/seeleseek/Features/Search/Views/SearchResultsHostedTableView.swift
@@ -1,0 +1,130 @@
+import SwiftUI
+import AppKit
+import SeeleseekCore
+
+/// NSTableView we own (fixed row height, cell reuse, no SwiftUI delegate
+/// measurement) whose cells host the real SwiftUI rows. The table only
+/// scrolls and recycles; every row is still `SearchResultListItemView`.
+/// Hover suppression during scroll is not pushed into the hosted cells:
+/// re-setting ~20 root views on every scroll start costs more than the
+/// hover churn it would prevent with this few live rows.
+struct SearchResultsHostedTableView: NSViewRepresentable {
+    @Environment(\.appState) private var appState
+    let items: [SearchListItem]
+    let bottomInset: CGFloat
+
+    static let rowHeight = SearchResultRowLayout.rowHeight + SeeleSpacing.dividerSpacing
+    static let groupEndHeight: CGFloat = 9
+
+    func makeCoordinator() -> Coordinator { Coordinator(appState: appState) }
+
+    func makeNSView(context: Context) -> NSScrollView {
+        let scrollView = NSScrollView()
+        scrollView.hasVerticalScroller = true
+        scrollView.autohidesScrollers = true
+        scrollView.borderType = .noBorder
+        scrollView.drawsBackground = false
+        scrollView.automaticallyAdjustsContentInsets = false
+
+        let table = NSTableView()
+        table.headerView = nil
+        table.rowHeight = Self.rowHeight
+        table.usesAutomaticRowHeights = false
+        table.intercellSpacing = .zero
+        table.selectionHighlightStyle = .none
+        table.backgroundColor = .clear
+        table.style = .plain
+        table.gridStyleMask = []
+        let column = NSTableColumn(identifier: .init("row"))
+        column.resizingMask = .autoresizingMask
+        table.addTableColumn(column)
+        table.columnAutoresizingStyle = .firstColumnOnlyAutoresizingStyle
+        table.dataSource = context.coordinator
+        table.delegate = context.coordinator
+        scrollView.documentView = table
+        context.coordinator.table = table
+
+        scrollView.contentView.postsBoundsChangedNotifications = true
+        NotificationCenter.default.addObserver(
+            context.coordinator,
+            selector: #selector(Coordinator.boundsChanged),
+            name: NSView.boundsDidChangeNotification,
+            object: scrollView.contentView
+        )
+        return scrollView
+    }
+
+    func updateNSView(_ scrollView: NSScrollView, context: Context) {
+        context.coordinator.appState = appState
+        scrollView.contentInsets = NSEdgeInsets(top: 0, left: 0, bottom: bottomInset, right: 0)
+        context.coordinator.apply(items)
+    }
+
+    final class Coordinator: NSObject, NSTableViewDataSource, NSTableViewDelegate {
+        var appState: AppState
+        weak var table: NSTableView?
+        private(set) var items: [SearchListItem] = []
+        private var ids: [String] = []
+
+        init(appState: AppState) { self.appState = appState }
+
+        func apply(_ newItems: [SearchListItem]) {
+            guard let table else { items = newItems; return }
+            let newIDs = newItems.map(\.id)
+            if newIDs == ids { items = newItems; return }
+            if newIDs.count > ids.count, Array(newIDs.prefix(ids.count)) == ids {
+                items = newItems
+                table.insertRows(at: IndexSet(ids.count..<newIDs.count), withAnimation: [])
+                ids = newIDs
+                return
+            }
+            items = newItems
+            ids = newIDs
+            table.reloadData()
+        }
+
+        @objc func boundsChanged() {
+            appState.searchState.noteResultsScrollActivity()
+        }
+
+        func numberOfRows(in tableView: NSTableView) -> Int { items.count }
+
+        func tableView(_ tableView: NSTableView, heightOfRow row: Int) -> CGFloat {
+            if case .groupEnd = items[row] { return SearchResultsHostedTableView.groupEndHeight }
+            return SearchResultsHostedTableView.rowHeight
+        }
+
+        func tableView(_ tableView: NSTableView, shouldSelectRow row: Int) -> Bool { false }
+
+        func tableView(_ tableView: NSTableView, viewFor tableColumn: NSTableColumn?, row: Int) -> NSView? {
+            let id = NSUserInterfaceItemIdentifier("hosted")
+            let cell = (tableView.makeView(withIdentifier: id, owner: nil) as? HostedRowCell) ?? {
+                let c = HostedRowCell()
+                c.identifier = id
+                return c
+            }()
+            cell.configure(AnyView(
+                SearchResultListItemView(item: items[row])
+                    .environment(\.appState, appState)
+            ))
+            return cell
+        }
+    }
+}
+
+final class HostedRowCell: NSTableCellView {
+    private var host: NSHostingView<AnyView>?
+
+    func configure(_ view: AnyView) {
+        if let host {
+            host.rootView = view
+            return
+        }
+        let h = NSHostingView(rootView: view)
+        h.sizingOptions = []
+        h.frame = bounds
+        h.autoresizingMask = [.width, .height]
+        addSubview(h)
+        host = h
+    }
+}

--- a/seeleseek/Features/Search/Views/SearchResultsHostedTableView.swift
+++ b/seeleseek/Features/Search/Views/SearchResultsHostedTableView.swift
@@ -5,9 +5,6 @@ import SeeleseekCore
 /// NSTableView we own (fixed row height, cell reuse, no SwiftUI delegate
 /// measurement) whose cells host the real SwiftUI rows. The table only
 /// scrolls and recycles; every row is still `SearchResultListItemView`.
-/// Hover suppression during scroll is not pushed into the hosted cells:
-/// re-setting ~20 root views on every scroll start costs more than the
-/// hover churn it would prevent with this few live rows.
 struct SearchResultsHostedTableView: NSViewRepresentable {
     @Environment(\.appState) private var appState
     let items: [SearchListItem]

--- a/seeleseek/Features/Search/Views/SearchView.swift
+++ b/seeleseek/Features/Search/Views/SearchView.swift
@@ -451,10 +451,8 @@ struct SearchView: View {
             }
             .background(SeeleColors.surface.opacity(0.3))
 
-            // An owned NSTableView hosting the SwiftUI rows. Measured under
-            // trackpad-style flicks at 120Hz (drops of >2 frames per 5s):
-            // LazyVStack ~33, List ~25 (its delegate measures every hosted
-            // cell), this ~9, AppKit cells ~1. See SearchResultsHostedTableView.
+            // Not LazyVStack/List: under 120Hz flicks those dropped ~33/~25
+            // frames per 5s, the hosted table ~9. See SearchResultsHostedTableView.
             ZStack(alignment: .bottom) {
                 SearchResultsHostedTableView(
                     items: searchState.displayItems,

--- a/seeleseek/Features/Search/Views/SearchView.swift
+++ b/seeleseek/Features/Search/Views/SearchView.swift
@@ -31,6 +31,9 @@ struct SearchView: View {
     }
 
     var body: some View {
+        #if DEBUG
+        let _ = { if SynthDiag.logChanges { Self._printChanges() } }()
+        #endif
         @Bindable var state = appState
         VStack(spacing: 0) {
             searchBar(binding: $state.searchState.searchQuery)
@@ -448,30 +451,15 @@ struct SearchView: View {
             }
             .background(SeeleColors.surface.opacity(0.3))
 
-            // Results list
+            // An owned NSTableView hosting the SwiftUI rows. Measured under
+            // trackpad-style flicks at 120Hz (drops of >2 frames per 5s):
+            // LazyVStack ~33, List ~25 (its delegate measures every hosted
+            // cell), this ~9, AppKit cells ~1. See SearchResultsHostedTableView.
             ZStack(alignment: .bottom) {
-                ScrollView {
-                    LazyVStack(spacing: SeeleSpacing.dividerSpacing) {
-                        if searchState.isGrouped {
-                            ForEach(searchState.displayItems) { item in
-                                SearchResultListItemView(item: item)
-                            }
-                        } else {
-                            ForEach(searchState.filteredResults) { result in
-                                SearchResultRow(
-                                    result: result,
-                                    isSelectionMode: searchState.isSelectionMode,
-                                    isSelected: searchState.selectedResults.contains(result.id),
-                                    onToggleSelection: {
-                                        searchState.toggleSelection(result.id)
-                                    }
-                                )
-                            }
-                        }
-                    }
-                    // Add bottom padding when action bar is visible
-                    .padding(.bottom, searchState.isSelectionMode ? 60 : 0)
-                }
+                SearchResultsHostedTableView(
+                    items: searchState.displayItems,
+                    bottomInset: searchState.isSelectionMode ? 60 : 0
+                )
 
                 // Floating action bar
                 if searchState.isSelectionMode {
@@ -528,7 +516,7 @@ struct SearchView: View {
 
         for result in results {
             if !appState.transferState.isFileQueued(filename: result.filename, username: result.username) {
-                appState.downloadManager.queueDownload(from: result)
+                Task { await appState.downloadManager.queueDownload(from: result) }
             }
         }
 

--- a/seeleseek/seeleseekApp.swift
+++ b/seeleseek/seeleseekApp.swift
@@ -55,6 +55,12 @@ struct SeeleSeekApp: App {
                             return
                         }
                         #endif
+                        #if DEBUG
+                        if SyntheticSearchDriver.isEnabled {
+                            SyntheticSearchDriver.start(appState: appState)
+                            return
+                        }
+                        #endif
                         appState.configure()
                         SeeleSeekShortcuts.updateAppShortcutParameters()
                     }

--- a/seeleseekTests/SearchResultDerivedFieldsTests.swift
+++ b/seeleseekTests/SearchResultDerivedFieldsTests.swift
@@ -1,0 +1,42 @@
+import Testing
+@testable import SeeleseekCore
+
+@Suite("SearchResult derived fields")
+struct SearchResultDerivedFieldsTests {
+
+    private func result(_ path: String) -> SearchResult {
+        SearchResult(username: "u", filename: path, size: 1)
+    }
+
+    @Test("Nested path splits into folder, display name, lowercased extension")
+    func nestedPath() {
+        let r = result("@@music\\Artist\\Album (FLAC)\\01 - Song.FLAC")
+        #expect(r.displayFilename == "01 - Song.FLAC")
+        #expect(r.folderPath == "@@music\\Artist\\Album (FLAC)")
+        #expect(r.fileExtension == "flac")
+        #expect(r.isLossless)
+    }
+
+    @Test("Bare filename has no folder")
+    func bareFilename() {
+        let r = result("song.mp3")
+        #expect(r.displayFilename == "song.mp3")
+        #expect(r.folderPath == "")
+        #expect(r.fileExtension == "mp3")
+    }
+
+    @Test("No extension yields empty string, dots in folders are ignored")
+    func noExtension() {
+        let r = result("v1.2\\README")
+        #expect(r.displayFilename == "README")
+        #expect(r.folderPath == "v1.2")
+        #expect(r.fileExtension == "")
+    }
+
+    @Test("formattedBytes keeps the file-style output")
+    func formattedBytes() {
+        #expect(Int64(0).formattedBytes == "0 KB")
+        #expect(Int64(45_300_000).formattedBytes == "45.3 MB")
+        #expect(Int64(1_234_567_890).formattedBytes == "1.23 GB")
+    }
+}

--- a/seeleseekTests/SearchResultGroupTests.swift
+++ b/seeleseekTests/SearchResultGroupTests.swift
@@ -268,14 +268,15 @@ struct SearchListItemTests {
         #expect(s.displayItems.count == 1)
     }
 
-    @Test("Ungrouping clears the flattened list so stale items cannot render")
-    func ungroupClears() {
+    @Test("Ungrouping flattens every result to a loose row")
+    func ungroupFlattens() {
         let s = state([
             r("alice", "m\\Album\\01.flac"),
             r("alice", "m\\Album\\02.flac")
         ])
-        #expect(!s.displayItems.isEmpty)
+        #expect(s.displayItems.count == 1)
         s.isGrouped = false
-        #expect(s.displayItems.isEmpty)
+        #expect(s.displayItems.count == 2)
+        #expect(s.displayItems.allSatisfy { $0.id.hasPrefix("loose-") })
     }
 }

--- a/seeleseekUITests/ScrollPerfTests.swift
+++ b/seeleseekUITests/ScrollPerfTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+
+/// Full-fidelity scroll-performance harness for the search results list.
+///
+/// Launches the app with `--synth-search` (the debug driver that streams
+/// synthetic results), parks the REAL cursor over the results list, and
+/// scrolls with REAL wheel events — so hover tracking, cursor rects, and
+/// the responsive-scrolling path are all exercised, unlike the in-process
+/// `--synth-scroll` clip-view driver. Frame pacing is measured inside the
+/// app (`PACE` lines, mirrored to `$SEELE_SYNTH_LOG`); this test only
+/// generates load and never asserts on timing, so it stays CI-safe.
+///
+/// Run with (`TEST_RUNNER_` prefix required — xcodebuild forwards only
+/// those env vars to the test runner, minus the prefix):
+///   TEST_RUNNER_SEELE_SYNTH_LOG=/tmp/scrollperf.log xcodebuild test \
+///     -scheme seeleseek \
+///     -only-testing:seeleseekUITests/ScrollPerfTests
+nonisolated final class ScrollPerfTests: XCTestCase {
+    func testScrollWhileSearchStreams() throws {
+        let app = XCUIApplication()
+        // `--synth-scroll` makes the app inject real 125Hz pixel wheel
+        // events itself (~7500 pt/s). XCUI's own scroll(byDeltaX:) can't
+        // scroll fast — each call is a ~hundreds-of-ms XPC round trip —
+        // so this test only supplies what the app cannot fake: the REAL
+        // cursor parked over the rows, exercising hover tracking while
+        // the list flicks underneath it.
+        app.launchArguments += ["--synth-search", "--synth-scroll"]
+        // XCUIApplication does not inherit the runner's environment; the
+        // log-path override must be forwarded explicitly or the app
+        // silently falls back to its temp-directory log.
+        if let logPath = ProcessInfo.processInfo.environment["SEELE_SYNTH_LOG"] {
+            app.launchEnvironment["SEELE_SYNTH_LOG"] = logPath
+        }
+        app.launch()
+
+        // Let the first results land so the list exists.
+        sleep(4)
+
+        let window = app.windows.firstMatch
+        XCTAssertTrue(window.waitForExistence(timeout: 10))
+
+        // Middle of the results area, clear of the header and filter bar.
+        let listPoint = window.coordinate(withNormalizedOffset: CGVector(dx: 0.55, dy: 0.6))
+
+        // ~2 minutes spanning several stream/hold cycles; re-hover
+        // periodically so the cursor stays parked over the moving rows.
+        for _ in 0..<60 {
+            listPoint.hover()
+            sleep(2)
+        }
+    }
+}

--- a/seeleseekUITests/ScrollPerfTests.swift
+++ b/seeleseekUITests/ScrollPerfTests.swift
@@ -18,12 +18,9 @@ import XCTest
 nonisolated final class ScrollPerfTests: XCTestCase {
     func testScrollWhileSearchStreams() throws {
         let app = XCUIApplication()
-        // `--synth-scroll` makes the app inject real 125Hz pixel wheel
-        // events itself (~7500 pt/s). XCUI's own scroll(byDeltaX:) can't
-        // scroll fast — each call is a ~hundreds-of-ms XPC round trip —
-        // so this test only supplies what the app cannot fake: the REAL
-        // cursor parked over the rows, exercising hover tracking while
-        // the list flicks underneath it.
+        // The app injects its own wheel events; XCUI's scroll(byDeltaX:) is
+        // one XPC round trip per call and cannot scroll fast. This test only
+        // supplies what the app cannot fake: the real cursor over the rows.
         app.launchArguments += ["--synth-search", "--synth-scroll"]
         // XCUIApplication does not inherit the runner's environment; the
         // log-path override must be forwarded explicitly or the app


### PR DESCRIPTION
### Description

This PR introduces several performance optimizations and UI improvements for search result handling and row rendering, with a focus on reducing UI lag and unnecessary computation. The most significant changes include batching incoming search results to minimize UI updates, optimizing how file information is stored and accessed, and introducing a custom tooltip system that only activates for hovered rows to reduce overhead. Additionally, there are improvements to the use of formatters and environment values for more efficient and maintainable code.

**Performance and UI Responsiveness Improvements:**

* Search results are now batched and staged before being appended to the main results list, reducing the frequency of UI updates and preventing dropped frames during rapid result inflow. Flushing of pending results is intelligently deferred if the user is scrolling, and forced when needed (e.g., on search completion or tab close). [[1]](diffhunk://#diff-c65e900923bc9575a5a8efac9b7544367eead1ccd183d416e45bb1030570c545L630-R630) [[2]](diffhunk://#diff-c65e900923bc9575a5a8efac9b7544367eead1ccd183d416e45bb1030570c545L659-R744) [[3]](diffhunk://#diff-c65e900923bc9575a5a8efac9b7544367eead1ccd183d416e45bb1030570c545R798-R799)
* The `RowIconButton` component no longer uses SwiftUI's `Button` to avoid excessive dropped frames; instead, it uses a tap gesture and accessibility modifiers, sacrificing keyboard focus for performance.

**Search Result Data Optimization:**

* The `SearchResult` struct now stores `displayFilename`, `folderPath`, and `fileExtension` as properties computed once at initialization, rather than as computed properties, to avoid redundant computation during row rendering. [[1]](diffhunk://#diff-c4a04fc88e9ac574c188715847431cb8150f6c56445fac0d4eb888b94d51ace1R18-R22) [[2]](diffhunk://#diff-c4a04fc88e9ac574c188715847431cb8150f6c56445fac0d4eb888b94d51ace1L46-R59) [[3]](diffhunk://#diff-c4a04fc88e9ac574c188715847431cb8150f6c56445fac0d4eb888b94d51ace1L106-L113)

**Tooltip and Hover Handling:**

* A new `rowHelp` view modifier is introduced, which only installs tooltips for the currently hovered row, reducing the number of AppKit tracking areas and improving performance in lists with many rows.
* The `isRowHovered` environment value is published by `StandardListRow` and consumed by child views for more granular and efficient hover state management. [[1]](diffhunk://#diff-4340dc60c4fa87882f584223d654a5021fe367996f172852571c65d1e0579053R30) [[2]](diffhunk://#diff-4340dc60c4fa87882f584223d654a5021fe367996f172852571c65d1e0579053R43-R47) [[3]](diffhunk://#diff-0c7563cb82c0a515e6f4c97e82b250314b358c0d62f7f84c9b019d5b33f2d49eL16-R16)

**Formatter and Miscellaneous Improvements:**

* A shared, locked `ByteCountFormatter` is used instead of `.formatted(.byteCount)` to avoid thread-safety issues and reduce overhead in formatting byte counts for search results.
* Minor documentation and code comments have been added or improved for clarity across several files. [[1]](diffhunk://#diff-4340dc60c4fa87882f584223d654a5021fe367996f172852571c65d1e0579053L4-R8) [[2]](diffhunk://#diff-c65e900923bc9575a5a8efac9b7544367eead1ccd183d416e45bb1030570c545R97-R98) [[3]](diffhunk://#diff-c65e900923bc9575a5a8efac9b7544367eead1ccd183d416e45bb1030570c545L187-R190) [[4]](diffhunk://#diff-9d0f24a1f4de264f70a5005dca64e76af62b9eb0cca9826a5b99697f5724c1b4R137-R141) [[5]](diffhunk://#diff-742d526115e52c9604576779e7a586e3e6da2521283e8a9a75843a3e6f03abc9L15-R22)

These changes collectively result in smoother UI performance, especially when displaying large numbers of search results, and make the codebase more maintainable and efficient.

<!--
### Future work
A place to describe changes that can or will be done in follow-up PRs
-->

### How to test

- Ensure all checks pass

### Author checklist

This PR:

- [x] Satisfies a goal that is specific & clearly motivated
- [x] Adds value in isolation (whether user-facing or sustainability-related)
- [x] Contains a concise & easy-to-understand title + description
- [x] Adheres to [SRP](https://en.wikipedia.org/wiki/Single-responsibility_principle) by default
- [x] Presents the best possible implementation to meet its goal, given constraints at hand
