### PR TITLE
accessibility fix: set labels on search result table

### DIFF
--- a/seeleseek/Features/Search/Views/SearchResultsHostedTableView.swift
+++ b/seeleseek/Features/Search/Views/SearchResultsHostedTableView.swift
@@ -32,6 +32,8 @@ struct SearchResultsHostedTableView: NSViewRepresentable {
         table.backgroundColor = .clear
         table.style = .plain
         table.gridStyleMask = []
+        table.setAccessibilityLabel("Search results")
+        table.setAccessibilityIdentifier("searchResultsTable")
         let column = NSTableColumn(identifier: .init("row"))
         column.resizingMask = .autoresizingMask
         table.addTableColumn(column)


### PR DESCRIPTION
### Description

This PR adds accessibility improvements to the `SearchResultsHostedTableView` in the search feature. The main change is the addition of accessibility labels and identifiers to the table, which will help users with assistive technologies and improve UI testing.

Accessibility improvements:

* [`seeleseek/Features/Search/Views/SearchResultsHostedTableView.swift`](diffhunk://#diff-48aef8697bc3b22a2e2a07a9df47b66778a1544c0ceaf8f92c75e0c7e1c71675R35-R36): Added an accessibility label (`"Search results"`) and an accessibility identifier (`"searchResultsTable"`) to the table for better support with assistive technologies and UI testing.

<!--
### Future work
A place to describe changes that can or will be done in follow-up PRs
-->

### How to test

- Ensure all checks pass

### Author checklist

This PR:

- [x] Satisfies a goal that is specific & clearly motivated
- [x] Adds value in isolation (whether user-facing or sustainability-related)
- [x] Contains a concise & easy-to-understand title + description
- [x] Adheres to [SRP](https://en.wikipedia.org/wiki/Single-responsibility_principle) by default
- [x] Presents the best possible implementation to meet its goal, given constraints at hand
