### PR TITLE
ui polish: login state + layout shift in search filters

### DIFF
--- a/seeleseek/Features/Search/Views/SearchView.swift
+++ b/seeleseek/Features/Search/Views/SearchView.swift
@@ -441,10 +441,13 @@ struct SearchView: View {
                             .buttonStyle(.plain)
                             .menuIndicator(.hidden)
 
-                            if search.isSearching {
-                                ProgressView()
-                                    .scaleEffect(0.6)
+                            ZStack {
+                                if search.isSearching {
+                                    ProgressView()
+                                        .scaleEffect(0.5)
+                                }
                             }
+                            .frame(width: SeeleSpacing.iconSizeSmall, height: SeeleSpacing.iconSizeSmall)
                         }
                     }
                 }

--- a/seeleseek/Navigation/MainView.swift
+++ b/seeleseek/Navigation/MainView.swift
@@ -127,12 +127,14 @@ struct MainView: View {
 
     @ViewBuilder
     private var detailView: some View {
-        // Show login when disconnected OR when there's a login error (so user can retry).
+        // Login stays up until the session is actually established:
+        // `.connecting` is only ever user-initiated (auto-reconnect
+        // publishes `.reconnecting`), so leaving for the app view on it
+        // meant a rejected password flashed the app and bounced back.
         // `isReapplyingSettings` suppresses the flash when something like a port
         // change is intentionally bouncing the connection — the user should keep
         // seeing whatever they were looking at, not the login screen.
-        if (appState.connection.connectionStatus == .disconnected ||
-            appState.connection.connectionStatus == .error) &&
+        if [.disconnected, .connecting, .error].contains(appState.connection.connectionStatus) &&
            !appState.connection.isReapplyingSettings {
             LoginView()
         } else {


### PR DESCRIPTION
### Description

This PR makes minor improvements to the user interface and login flow logic. The most notable changes are a visual adjustment to the search progress indicator and a refinement to the logic that determines when the login screen is displayed.

**Login flow improvements:**

* Updated the logic in `MainView` to keep the login screen visible until a session is fully established, including during the `.connecting` state. This prevents a rejected password from briefly flashing the main app view before returning to the login screen.

**UI adjustments:**

* Adjusted the `ProgressView` scale and wrapped it in a `ZStack` with a fixed frame in `SearchView` to ensure consistent sizing and alignment of the search progress indicator.

<!--
### Future work
A place to describe changes that can or will be done in follow-up PRs
-->

### How to test

- Ensure all checks pass

### Author checklist

This PR:

- [x] Satisfies a goal that is specific & clearly motivated
- [x] Adds value in isolation (whether user-facing or sustainability-related)
- [x] Contains a concise & easy-to-understand title + description
- [x] Adheres to [SRP](https://en.wikipedia.org/wiki/Single-responsibility_principle) by default
- [x] Presents the best possible implementation to meet its goal, given constraints at hand
